### PR TITLE
Derekdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# RVNKTools Minecraft Plugin
+
+RVNKTools is a comprehensive Minecraft server plugin that provides a wide array of features to enhance server administration. It includes tools for managing announcements, permissions, events, and much more, tailored for ease of use and scalability.
+
+## Features
+
+- **Announcements Management**: 
+  - Schedule, edit, and remove announcements using YAML or database integration.
+  - Flexible recurrence and type categorization for announcements.
+- **Permissions Handling**: 
+  - Advanced tools to manage player permissions.
+- **Integration Support**: 
+  - PlaceholderAPI integration for dynamic message handling.
+- **Extensible Commands**: 
+  - Rich subcommand system for plugin interaction.
+- **Custom Features**: 
+  - Includes features such as a hat manager, link maker, and more.
+
+## Installation
+
+1. Download the latest version of `rvnktools.jar` from the [Releases](#).
+2. Place the JAR file in your server's `plugins` directory.
+3. Restart your server.
+4. Configure the plugin using the `config.yml` and `announcements.yml` files generated in the `plugins/RVNKTools` directory.
+
+## Configuration
+
+### announcements.yml
+The `announcements.yml` file allows you to define and customize announcements in YAML format:
+
+```yaml
+announcements:
+  - id: "event_reminder"
+    text: "Don't forget to join the upcoming event!"
+    type: "news"
+    recurrence: "3h"
+    imported: false
+```
+Commands
+
+    /announce
+        /announce list - List all announcements.
+        /announce add <id> - Add a new announcement.
+        /announce delete <id> - Delete an announcement by ID.
+        /announce reload - Reload the announcements configuration.
+
+Permissions
+
+    rvnktools.announce.manage - Allows managing announcements.
+    rvnktools.announce.view - Allows viewing announcements.
+
+Development
+Building from Source
+
+    Clone the repository:
+
+    git clone https://github.com/fourz/rvnktools.git
+
+Navigate to the project directory:
+
+cd rvnktools
+
+Build the plugin using Maven:
+
+mvn clean package
+
+    The JAR file will be available in the target directory.
+
+Contributions
+
+Contributions are welcome! Please follow these steps:
+
+    Fork the repository.
+    Create a new branch for your feature/bugfix.
+    Commit your changes.
+    Submit a pull request with a clear description of the changes.
+
+Known Issues
+
+    YAML and database sync might result in discrepancies if not properly configured.
+    Ensure unique id values for announcements to avoid conflicts.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 RVNKTools is a comprehensive Minecraft server plugin that provides a wide array of features to enhance server administration. It includes tools for managing announcements, permissions, events, and much more, tailored for ease of use and scalability.
 
-## Features
-
-- **Announcements Management**: 
-  - Schedule, edit, and remove announcements using YAML or database integration.
-  - Flexible recurrence and type categorization for announcements.
-- **Permissions Handling**: 
-  - Advanced tools to manage player permissions.
-- **Integration Support**: 
-  - PlaceholderAPI integration for dynamic message handling.
-- **Extensible Commands**: 
-  - Rich subcommand system for plugin interaction.
-- **Custom Features**: 
-  - Includes features such as a hat manager, link maker, and more.
-
 ## Installation
 
 1. Download the latest version of `rvnktools.jar` from the [Releases](#).
@@ -23,59 +9,60 @@ RVNKTools is a comprehensive Minecraft server plugin that provides a wide array 
 3. Restart your server.
 4. Configure the plugin using the `config.yml` and `announcements.yml` files generated in the `plugins/RVNKTools` directory.
 
-## Configuration
+# RVNKTools Minecraft Plugin
 
-### announcements.yml
-The `announcements.yml` file allows you to define and customize announcements in YAML format:
+RVNKTools is a versatile Minecraft server plugin designed to streamline server administration and enhance player experience. This plugin offers a range of features, making it a valuable tool for server owners and administrators.
 
-```yaml
-announcements:
-  - id: "event_reminder"
-    text: "Don't forget to join the upcoming event!"
-    type: "news"
-    recurrence: "3h"
-    imported: false
-```
-Commands
+## Key Features
 
-    /announce
-        /announce list - List all announcements.
-        /announce add <id> - Add a new announcement.
-        /announce delete <id> - Delete an announcement by ID.
-        /announce reload - Reload the announcements configuration.
+- **Announcements Management**:
+  - Schedule, manage, and remove announcements with YAML or database integration.
+  - Support for recurring announcements and categorized types.
 
-Permissions
+- **Permissions Handling**:
+  - Tools to efficiently manage player permissions and access control.
 
-    rvnktools.announce.manage - Allows managing announcements.
-    rvnktools.announce.view - Allows viewing announcements.
+- **Integration Support**:
+  - Seamless integration with PlaceholderAPI for dynamic messages and content.
 
-Development
-Building from Source
+- **Custom Commands and Tools**:
+  - Extendable command system for managing announcements, preferences, and other features.
+  - Includes additional tools such as a hat manager and link maker.
 
-    Clone the repository:
+- **Database Compatibility**:
+  - Supports SQLite and MySQL for flexible data storage options.
 
-    git clone https://github.com/fourz/rvnktools.git
+## Suggested Use Cases
 
-Navigate to the project directory:
+- **Server Administration**:
+  - Simplify server management by automating announcements and schedules.
+  - Manage player permissions efficiently through built-in tools.
 
-cd rvnktools
+- **Event Management**:
+  - Use the announcement system to keep players informed about server events, updates, and important information.
 
-Build the plugin using Maven:
+- **Custom Player Experience**:
+  - Enhance interactivity by leveraging PlaceholderAPI integration for dynamic and personalized messages.
 
-mvn clean package
+- **Plugin Development**:
+  - Developers can extend RVNKTools to add custom features or integrate with other plugins.
 
-    The JAR file will be available in the target directory.
+## Getting Started
 
-Contributions
+1. Install the plugin by placing the `rvnktools.jar` file in your server's `plugins` directory.
+2. Restart the server to generate configuration files.
+3. Configure announcements and settings using the `announcements.yml` and `config.yml` files.
+4. Use the `/announce` commands to manage announcements directly in-game.
 
-Contributions are welcome! Please follow these steps:
+## Support and Contributions
 
-    Fork the repository.
-    Create a new branch for your feature/bugfix.
-    Commit your changes.
-    Submit a pull request with a clear description of the changes.
+- **Support**:
+  - For help and troubleshooting, join our [Discord](#) or open an issue on GitHub.
 
-Known Issues
+- **Contribute**:
+  - Contributions are welcome! Fork the repository, implement your changes, and submit a pull request.
 
-    YAML and database sync might result in discrepancies if not properly configured.
-    Ensure unique id values for announcements to avoid conflicts.
+## License
+
+RVNKTools is licensed under the MIT License. See the [LICENSE](LICENSE) file for more information.
+

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnktools</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-alpha</version>
 
     <name>RVNK Admin Toolkit</name>
     <description>A Minecraft toolkit plugin with basic commands</description>
@@ -92,6 +92,13 @@
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.36.0.3</version>
         </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/RVNKTools.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/RVNKTools.java
@@ -77,9 +77,10 @@ public class RVNKTools extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-        announceManager.shutdown();
-
-        // keep it cleaned up
+        if (announceManager != null) {
+            announceManager.shutdown(); // This will trigger AnnounceConfig.shutdown()
+        }
+        // ...rest of shutdown code...
         announceManager = null;
         cycleCommands = null;
         linkMaker = null;

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/RVNKTools.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/RVNKTools.java
@@ -77,24 +77,17 @@ public class RVNKTools extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-
-        announceManager.savePlayerDisabledTypes();
         announceManager.shutdown();
 
-        //garbage collection        
+        // keep it cleaned up
         announceManager = null;
         cycleCommands = null;
         linkMaker = null;
         
-        
-        // Code that runs when the plugin is disabled
         getLogger().info("RVNK Toolkit has been disabled.");
     }
 
     public Economy getEconomy() {
-
         return economy;
-
     }
-
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -209,18 +209,25 @@ public class AnnounceConfig {
     }
 
     private boolean dbMatchesYml() {
-            Integer ymlHash = generateConfigHash(ymlAnnouncements, ymlTypes);
-            Integer dbHash = generateConfigHash(dataStore.loadAnnouncements(), dataStore.loadAnnounceTypes());
+        Integer ymlHash = generateConfigHash(ymlAnnouncements, ymlTypes);
+        
+        if (dataStore instanceof MySQLDataConnector) {
+            MySQLDataConnector mysqlStore = (MySQLDataConnector) dataStore;
+            Integer dbHash = mysqlStore.calculateDatabaseHash();
             
-            if (ymlHash.equals(dbHash)) {
+            if (ymlHash != null && ymlHash.equals(dbHash)) {
                 debug.log("Database and YAML configurations match (Hash: " + ymlHash + ")");
                 dataStore.disconnect();
                 return true;
             }
-            return false;
+        }
+        return false;
     }
 
-    // Generates a hash of the configuration data for comparison
+    /**
+     * @deprecated Use MySQLDataConnector.calculateDatabaseHash() instead
+     */
+    @Deprecated
     private Integer generateConfigHash(List<Announcement> announcements, Collection<AnnounceType> types) {
         return generateConfigHash(
             announcements.stream()
@@ -229,7 +236,10 @@ public class AnnounceConfig {
         );
     }
 
-    // Overloaded method to generate hash of configuration data
+    /**
+     * @deprecated Use MySQLDataConnector.calculateDatabaseHash() instead
+     */
+    @Deprecated
     private Integer generateConfigHash(List<Announcement> announcements, Map<String, AnnounceType> types) {
         return generateConfigHash(
             announcements.stream()
@@ -241,36 +251,28 @@ public class AnnounceConfig {
     // Updated hash generation for Map structure
     private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
         StringBuilder hashBuilder = new StringBuilder();
-        debug.debug("Generating config hash for " + announcements.size() + " announcements and " + types.size() + " types");
+        debug.debug("\nJAVA CONFIG HASH SOURCE");
+        debug.debug("---------------------");
 
-        // Process announcements
+        // Process announcements only with essential fields, excluding recurrence
         announcements.values().stream()
             .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
             .forEach(a -> {
-                String announcementEntry = String.format("A|%s|%s|%s|%s\n",
+                String announcementEntry = String.format("A|%s|%s|%s",
                     a.getId().toLowerCase(),
                     a.getType().toLowerCase(),
-                    a.getText(),
-                    Optional.ofNullable(a.getPermission()).orElse(""));
-                hashBuilder.append(announcementEntry);
+                    a.getText());
+                hashBuilder.append(announcementEntry).append("\n");
             });
 
-        // Process types
-        types.stream()
-            .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
-            .forEach(t -> {
-                String typeEntry = String.format("T|%s|%s|%s|%s|%s\n",
-                    t.getId().toLowerCase(),
-                    Optional.ofNullable(t.getPrefix()).orElse(""),
-                    Optional.ofNullable(t.getSuffix()).orElse(""),
-                    Optional.ofNullable(t.getPermission()).orElse(""),
-                    Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""));
-                hashBuilder.append(typeEntry);
-            });
-
-        int finalHash = hashBuilder.toString().hashCode();
-        debug.debug("Generated hash value: " + finalHash);
-        return finalHash;
+        String hashStr = hashBuilder.toString();
+        int hash = hashStr.hashCode();
+        
+        debug.debug("String length: " + hashStr.length());
+        debug.debug("Hash value: " + hash);
+        debug.debug("---------------------\n");
+        
+        return hash;
     }
 
     // Loads or creates the YAML configuration file
@@ -342,10 +344,10 @@ public class AnnounceConfig {
         // Process announcements that need importing
         for (Announcement announcement : ymlAnnouncements) {
             boolean exists = existingAnnouncementIds.contains(announcement.getId().toLowerCase());
-            // Remove isImported() check since we want to import all announcements from YML
             if (!exists) {
                 try {
-                    announceManager.addAnnouncement(announcement);
+                    dataStore.saveAnnouncement(announcement); // Save to database
+                    announceManager.addAnnouncement(announcement); // Add to manager
                     successfulImports.add(announcement.getId().toLowerCase());              
                     debug.log("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
@@ -495,15 +497,20 @@ public class AnnounceConfig {
         String type = (String) map.get("type");
         Object recurrence = map.get("recurrence");
         Long recurrenceSeconds = null;
+        String originalRecurrence = null;
         
         if (recurrence != null) {
+            originalRecurrence = recurrence.toString();
             if (recurrence instanceof Long) {
                 recurrenceSeconds = (Long) recurrence;
             } else if (recurrence instanceof String) {
-                // Convert string format to seconds
                 String recStr = (String) recurrence;
                 try {
-                    if (recStr.endsWith("s")) {
+                    if (recStr.equalsIgnoreCase("none")) {
+                        recurrenceSeconds = null;
+                    } else if (recStr.equalsIgnoreCase("daily")) {
+                        recurrenceSeconds = 86400L;
+                    } else if (recStr.endsWith("s")) {
                         recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1));
                     } else if (recStr.endsWith("m")) {
                         recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1)) * 60;
@@ -553,6 +560,7 @@ public class AnnounceConfig {
         announcement.setText(text);
         announcement.setType(type);
         announcement.setRecurrence(recurrenceSeconds);
+        announcement.setRecurrenceString(originalRecurrence); // Store original string
         announcement.setOwner(owner);
         announcement.setPermission(permission);
         announcement.setDate(date);
@@ -615,8 +623,11 @@ public class AnnounceConfig {
                 map.put("text", announcement.getText());
                 map.put("type", announcement.getType());
 
-                // Optional fields
-                Optional.ofNullable(announcement.getRecurrence()).ifPresent(r -> map.put("recurrence", r));
+                // Only save recurrence if it exists
+                if (announcement.getRecurrenceString() != null) {
+                    map.put("recurrence", announcement.getRecurrenceString());
+                }
+
                 Optional.ofNullable(announcement.getOwner()).ifPresent(o -> map.put("owner", o));
                 Optional.ofNullable(announcement.getPermission()).ifPresent(p -> map.put("permission", p));
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -170,6 +170,7 @@ public class AnnounceConfig {
                 case FALLBACK_TO_YML:
                     announceManager.setAnnouncements(ymlAnnouncements);
                     announceTypes = ymlTypes;
+                    debug.log("Using existing announcements from local configuration");
                     break;
 
                 case IMPORT_YML_TO_NEW_DB:
@@ -195,10 +196,6 @@ public class AnnounceConfig {
                     break;
             }
 
-            if (isChanged) {
-                saveConfig();
-                debug.log("Saved announcements after import changes");
-            }
         } catch (Exception e) {
             debug.error("Failed to initialize database: " + e.getMessage(), e);
             e.printStackTrace();
@@ -209,70 +206,39 @@ public class AnnounceConfig {
     }
 
     private boolean dbMatchesYml() {
-        Integer ymlHash = generateConfigHash(ymlAnnouncements, ymlTypes);
+        String ymlHash = generateIdsHash(ymlAnnouncements.stream()
+            .map(a -> a.getId().toLowerCase())
+            .collect(Collectors.toSet()));
         
         if (dataStore instanceof MySQLDataConnector) {
             MySQLDataConnector mysqlStore = (MySQLDataConnector) dataStore;
-            Integer dbHash = mysqlStore.calculateDatabaseHash();
+            String dbHash = mysqlStore.calculateDatabaseHash();
             
-            if (ymlHash != null && ymlHash.equals(dbHash)) {
-                debug.log("Database and YAML configurations match (Hash: " + ymlHash + ")");
+            debug.log("Configuration hash comparison - YAML=" + ymlHash + " DB=" + dbHash);
+            
+            if (ymlHash != null && dbHash != null && ymlHash.equals(dbHash)) {
+                debug.log("Loading " + ymlAnnouncements.size() + " announcements from local configuration");
                 dataStore.disconnect();
                 return true;
+            } else {
+                debug.log("Configuration mismatch - will synchronize with database");
             }
         }
         return false;
     }
 
-    /**
-     * @deprecated Use MySQLDataConnector.calculateDatabaseHash() instead
-     */
-    @Deprecated
-    private Integer generateConfigHash(List<Announcement> announcements, Collection<AnnounceType> types) {
-        return generateConfigHash(
-            announcements.stream()
-                .collect(Collectors.toMap(Announcement::getId, a -> a)),
-            types
-        );
-    }
-
-    /**
-     * @deprecated Use MySQLDataConnector.calculateDatabaseHash() instead
-     */
-    @Deprecated
-    private Integer generateConfigHash(List<Announcement> announcements, Map<String, AnnounceType> types) {
-        return generateConfigHash(
-            announcements.stream()
-                .collect(Collectors.toMap(Announcement::getId, a -> a)),
-            types.values()
-        );
-    }
-
-    // Updated hash generation for Map structure
-    private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
+    private String generateIdsHash(Set<String> ids) {
+        if (ids.isEmpty()) return null;
+        
         StringBuilder hashBuilder = new StringBuilder();
-        debug.debug("\nJAVA CONFIG HASH SOURCE");
-        debug.debug("---------------------");
-
-        // Process announcements only with essential fields, excluding recurrence
-        announcements.values().stream()
-            .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
-            .forEach(a -> {
-                String announcementEntry = String.format("A|%s|%s|%s",
-                    a.getId().toLowerCase(),
-                    a.getType().toLowerCase(),
-                    a.getText());
-                hashBuilder.append(announcementEntry).append("\n");
-            });
-
+        debug.debug("Processing " + ids.size() + " announcements for hash generation");
+        
+        ids.stream()
+            .sorted()
+            .forEach(id -> hashBuilder.append(id).append("\n"));
+            
         String hashStr = hashBuilder.toString();
-        int hash = hashStr.hashCode();
-        
-        debug.debug("String length: " + hashStr.length());
-        debug.debug("Hash value: " + hash);
-        debug.debug("---------------------\n");
-        
-        return hash;
+        return org.apache.commons.codec.digest.DigestUtils.md5Hex(hashStr);
     }
 
     // Loads or creates the YAML configuration file
@@ -315,10 +281,9 @@ public class AnnounceConfig {
         List<Announcement> existingAnnouncements = dataStore.loadAnnouncements();
         List<AnnounceType> existingTypes = dataStore.loadAnnounceTypes();
 
-        Set<String> existingAnnouncementIds = new HashSet<>();
-        for (Announcement announcement : existingAnnouncements) {
-            existingAnnouncementIds.add(announcement.getId().toLowerCase());
-        }
+        Set<String> existingAnnouncementIds = existingAnnouncements.stream()
+            .map(a -> a.getId().toLowerCase())
+            .collect(Collectors.toSet());
 
         Set<String> existingTypeIds = new HashSet<>();
         for (AnnounceType type : existingTypes) {
@@ -343,11 +308,9 @@ public class AnnounceConfig {
         
         // Process announcements that need importing
         for (Announcement announcement : ymlAnnouncements) {
-            boolean exists = existingAnnouncementIds.contains(announcement.getId().toLowerCase());
-            if (!exists) {
+            if (!existingAnnouncementIds.contains(announcement.getId().toLowerCase())) {
                 try {
-                    dataStore.saveAnnouncement(announcement); // Save to database
-                    announceManager.addAnnouncement(announcement); // Add to manager
+                    dataStore.saveAnnouncement(announcement); // Save to database only
                     successfulImports.add(announcement.getId().toLowerCase());              
                     debug.log("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
@@ -623,9 +586,24 @@ public class AnnounceConfig {
                 map.put("text", announcement.getText());
                 map.put("type", announcement.getType());
 
-                // Only save recurrence if it exists
-                if (announcement.getRecurrenceString() != null) {
-                    map.put("recurrence", announcement.getRecurrenceString());
+                // Handle recurrence value
+                Long recurrence = announcement.getRecurrence();
+                if (recurrence != null) {
+                    // If we have the original string format, use that
+                    if (announcement.getRecurrenceString() != null) {
+                        map.put("recurrence", announcement.getRecurrenceString());
+                    } else {
+                        // Convert seconds back to a readable format
+                        if (recurrence % 86400 == 0) {
+                            map.put("recurrence", (recurrence / 86400) + "d");
+                        } else if (recurrence % 3600 == 0) {
+                            map.put("recurrence", (recurrence / 3600) + "h");
+                        } else if (recurrence % 60 == 0) {
+                            map.put("recurrence", (recurrence / 60) + "m");
+                        } else {
+                            map.put("recurrence", recurrence + "s");
+                        }
+                    }
                 }
 
                 Optional.ofNullable(announcement.getOwner()).ifPresent(o -> map.put("owner", o));
@@ -685,6 +663,7 @@ public class AnnounceConfig {
     // Add a shutdown method to disconnect the DataStore
     public void shutdown() {
         if (dataStore != null) {
+            saveConfig(); // Save any pending changes
             dataStore.disconnect();
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -39,46 +39,71 @@ public class AnnounceConfig {
 
     // initializes the configuration and data storage settings
     public AnnounceConfig(JavaPlugin plugin, AnnounceManager announceManager) {
+        // Store dependencies
         this.plugin = plugin;
         this.announceManager = announceManager;
-        this.usingPlaceholderAPI = (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null);
+        
+        // Initialize core components
         this.configFile = new File(plugin.getDataFolder(), "announcements.yml");
-
-        this.configOperation = loadConfig() 
-            ? detectConfigState()
-            : ConfigOperation.FALLBACK_TO_YML;
-
-            //log the config operation
-            plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
+        this.usingPlaceholderAPI = (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null);
+        
+        // Load configuration and determine operation mode
+        boolean configLoaded = loadConfig();
+        this.configOperation = configLoaded ? detectConfigState() : ConfigOperation.FALLBACK_TO_YML;
+        
+        // Log the determined configuration operation
+        plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
     }
 
     private ConfigOperation detectConfigState() {
-
+        plugin.getLogger().info("Detecting config state...");
+        
         initializeDataStoreConnection();
         
         if (dataStore == null) {
+            plugin.getLogger().warning("Database connection failed - dataStore is null");
             return ConfigOperation.FALLBACK_TO_YML;
         }
 
         // Connect to database and check if it is empty
-        dataStore.connect();
-        boolean dbEmpty = dataStore.isEmpty();
-        
-        // Check if database and YAML configurations match
-        if (!dbEmpty && dbMatchesYml()) return ConfigOperation.NO_UPDATE;        
-        dataStore.disconnect();
+        try {
+            plugin.getLogger().info("Attempting database connection...");
+            dataStore.connect();
+            plugin.getLogger().info("Database connection successful");
+            
+            boolean dbEmpty = dataStore.isEmpty();
+            plugin.getLogger().info("Database empty check result: " + dbEmpty);
+            
+            // Check if database and YAML configurations match
+            if (!dbEmpty && dbMatchesYml()) {
+                plugin.getLogger().info("Database matches YAML content");
+                return ConfigOperation.NO_UPDATE;
+            }
+            
+            dataStore.disconnect();
 
-        if (dbEmpty) {
-            return ConfigOperation.IMPORT_YML_TO_NEW_DB;
+            if (dbEmpty) {
+                plugin.getLogger().info("Empty database detected - will import YAML");
+                return ConfigOperation.IMPORT_YML_TO_NEW_DB;
 
-        } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
-            return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
+            } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
+                return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
 
-        } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
-            return ConfigOperation.MERGE_YML_INTO_DB;
+            } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
+                //output a warning message
+                plugin.getLogger().warning("Database and YAML configurations do not match. Merging YAML data into database.");
+
+                return ConfigOperation.MERGE_YML_INTO_DB;
+            }
+
+            //output a warning message
+            plugin.getLogger().warning("Unable to determine configuration state. Using YAML configurations.");
+            return ConfigOperation.FALLBACK_TO_YML;
+        } catch (Exception e) {
+            plugin.getLogger().severe("Database connection/check failed: " + e.getMessage());
+            e.printStackTrace();
+            return ConfigOperation.FALLBACK_TO_YML;
         }
-
-        return ConfigOperation.FALLBACK_TO_YML;
     }
     
     private boolean dbMatchesYml() {
@@ -313,19 +338,37 @@ public class AnnounceConfig {
 
     // Creates appropriate DataStore instance based on configuration settings
     private void initializeDataStoreConnection() {
+        plugin.getLogger().info("Initializing data store connection with type: " + storageType);
+        
         if (storageType.equalsIgnoreCase("mysql")) {
-            String host = config.getString("storage.mysql.host");
-            int port = config.getInt("storage.mysql.port");
-            String database = config.getString("storage.mysql.database");
-            String username = config.getString("storage.mysql.username");
-            String password = config.getString("storage.mysql.password");
+            String host = config.getString("storage.mysql.host", "");
+            int port = config.getInt("storage.mysql.port", 3306);
+            String database = config.getString("storage.mysql.database", "");
+            String username = config.getString("storage.mysql.username", "");
+            String password = config.getString("storage.mysql.password", "");
             boolean useSSL = config.getBoolean("storage.mysql.useSSL", false);
+            
+            plugin.getLogger().info("MySQL configuration - Host: " + host + ", Port: " + port + 
+                ", Database: " + database + ", Username: " + username + 
+                ", SSL: " + useSSL);
+            
+            if (host.isEmpty() || database.isEmpty() || username.isEmpty()) {
+                plugin.getLogger().severe("Invalid MySQL configuration - missing required fields");
+                dataStore = null;
+                return;
+            }
+            
             dataStore = new MySQLDataConnector(host, port, database, username, password, useSSL);
+            plugin.getLogger().info("MySQL connector created successfully");
         } else if (storageType.equalsIgnoreCase("sqlite")) {
             String databasePath = config.getString("storage.sqlite.database", "announcements.db");
             dataStore = new SQLiteDataConnector(plugin, databasePath);
         } else {
             dataStore = null;
+        }
+        
+        if (dataStore == null) {
+            plugin.getLogger().warning("Failed to initialize data store - unknown or invalid storage type");
         }
     }
 
@@ -368,7 +411,33 @@ public class AnnounceConfig {
         String id = (String) map.get("id");
         String text = (String) map.get("text");
         String type = (String) map.get("type");
-        String recurrence = (String) map.get("recurrence");
+        Object recurrence = map.get("recurrence");
+        Long recurrenceSeconds = null;
+        
+        if (recurrence != null) {
+            if (recurrence instanceof Long) {
+                recurrenceSeconds = (Long) recurrence;
+            } else if (recurrence instanceof String) {
+                // Convert string format to seconds
+                String recStr = (String) recurrence;
+                try {
+                    if (recStr.endsWith("s")) {
+                        recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1));
+                    } else if (recStr.endsWith("m")) {
+                        recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1)) * 60;
+                    } else if (recStr.endsWith("h")) {
+                        recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1)) * 3600;
+                    } else if (recStr.endsWith("d")) {
+                        recurrenceSeconds = Long.parseLong(recStr.substring(0, recStr.length() - 1)) * 86400;
+                    } else {
+                        recurrenceSeconds = Long.parseLong(recStr);
+                    }
+                } catch (NumberFormatException e) {
+                    plugin.getLogger().warning("Invalid recurrence format for announcement " + id + ": " + recStr);
+                }
+            }
+        }
+        
         String owner = (String) map.get("owner");
         String permission = (String) map.get("permission");
         String dateStr = (String) map.get("date");
@@ -401,7 +470,7 @@ public class AnnounceConfig {
         announcement.setId(id);
         announcement.setText(text);
         announcement.setType(type);
-        announcement.setRecurrence(recurrence);
+        announcement.setRecurrence(recurrenceSeconds);
         announcement.setOwner(owner);
         announcement.setPermission(permission);
         announcement.setDate(date);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -14,12 +14,17 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.logging.Level;
 import org.fourz.rvnktools.util.Debug;
-import org.fourz.rvnktools.util.Debug.LogLevel;
 import java.util.stream.Collectors;
 
 public class AnnounceConfig {
     private static final String CLASS_NAME = "AnnounceConfig";
+    private static Level logLevel = Level.INFO; // Default level
+    
+    public static Level getLogLevel() {
+        return logLevel;
+    }
     private enum ConfigOperation {
         IMPORT_YML_TO_NEW_DB,
         UPDATE_MISSING_YML_FROM_DB,
@@ -29,8 +34,8 @@ public class AnnounceConfig {
     }
 
     private class ConfigDebug extends Debug {
-        public ConfigDebug(JavaPlugin plugin, String className, LogLevel level) {
-            super(plugin, className, level);
+        public ConfigDebug(JavaPlugin plugin, String className) {
+            super(plugin, className, logLevel);
         }
     }
 
@@ -58,13 +63,17 @@ public class AnnounceConfig {
         this.configFile = new File(plugin.getDataFolder(), "announcements.yml");
         this.usingPlaceholderAPI = (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null);
         
-        // Initialize debug with default level
-        this.debug = new ConfigDebug(plugin, CLASS_NAME, Debug.LogLevel.INFO);
+        // Load config and set shared log level
+        config = YamlConfiguration.loadConfiguration(configFile);
+        String logLevelStr = config.getString("debug.level", "INFO");
+        logLevel = Debug.parseLevel(logLevelStr); // Use Debug.parseLevel instead of Level.parse
         
-        // Load config and update debug level
+        // Initialize debug with shared level
+        this.debug = new ConfigDebug(plugin, CLASS_NAME);
+        
+        // Now load rest of config
         if (loadConfig()) {
-            String logLevel = config.getString("debug.level", "INFO");
-            debug.setLogLevel(Debug.LogLevel.fromString(logLevel));
+            debug.log(Level.INFO, "Configuration loaded successfully");
         }
         
         // Rest of initialization
@@ -73,60 +82,58 @@ public class AnnounceConfig {
     }
 
     private ConfigOperation detectConfigState() {
-        debug.log(LogLevel.CONFIG, "Detecting config state...");
+        debug.log("Detecting config state...");
 
-        // Initialize database connection first 
+        // First check if storage type is explicitly set to yml
+        if (storageType.equalsIgnoreCase("yml")) {
+            debug.log("YAML storage explicitly configured");
+            return ConfigOperation.FALLBACK_TO_YML;
+        }
+
+        // Then check for database configurations
         if (storageType.equalsIgnoreCase("mysql") || storageType.equalsIgnoreCase("sqlite")) {
             initializeDataStoreConnection();
             
             if (dataStore != null) {
                 try {
-                    debug.log(LogLevel.CONFIG, "Testing database connectivity and state...");
+                    debug.log("Testing database connectivity");
                     dataStore.connect();
                     
                     // Wait briefly for connection to stabilize
                     Thread.sleep(100);
                     
-                    // Verify database access
-                    boolean dbEmpty;
                     try {
-                        dbEmpty = dataStore.isEmpty();
-                        debug.log(LogLevel.FINE, "Database empty check result: " + dbEmpty);
+                        boolean dbEmpty = dataStore.isEmpty();
+                        debug.debug("Database empty check result: " + dbEmpty);
                         
-                        // Test data access
-                        List<Announcement> testLoad = dataStore.loadAnnouncements();
-                        List<AnnounceType> testTypes = dataStore.loadAnnounceTypes();
-                        
-                        debug.log(LogLevel.FINE, "Database access test - Announcements: " + testLoad.size() + 
-                                              ", Types: " + testTypes.size());
-                        
-                        if (dbEmpty || testLoad.isEmpty() && testTypes.isEmpty()) {
-                            debug.log(LogLevel.CONFIG, "Empty database detected - will import from YAML");
+                        if (dbEmpty) {
+                            debug.log("Empty database detected - will import from YAML");
                             return ConfigOperation.IMPORT_YML_TO_NEW_DB;
                         }
                         
-                        if (!testLoad.isEmpty() || !testTypes.isEmpty()) {
-                            if (ymlAnnouncements.isEmpty() && ymlTypes.isEmpty()) {
-                                debug.log(LogLevel.CONFIG, "Using existing database content");
-                                return ConfigOperation.NO_UPDATE;
-                            }
-                            debug.log(LogLevel.CONFIG, "Will merge YAML content into database");
+                        if (dbMatchesYml()) {
+                            debug.log("Database matches YAML configuration");
+                            return ConfigOperation.NO_UPDATE;
+                        } else {
+                            debug.log("Database differs from YAML - will merge");
                             return ConfigOperation.MERGE_YML_INTO_DB;
                         }
+                        
                     } catch (Exception e) {
-                        debug.error("Database access test failed: " + e.getMessage(), e);
-                        throw e;
+                        debug.error("Database access test failed", e);
+                        debug.log("Falling back to YAML storage");
+                        return ConfigOperation.FALLBACK_TO_YML;
                     }
                     
                 } catch (Exception e) {
                     debug.error("Database connectivity test failed", e);
-                    e.printStackTrace();
+                    debug.log("Falling back to YAML storage");
                     return ConfigOperation.FALLBACK_TO_YML;
                 }
             }
         }
         
-        debug.log(LogLevel.CONFIG, "No valid database configuration - using YAML storage");
+        debug.log(Level.WARNING, "No database configuration found - falling back to YAML storage");
         return ConfigOperation.FALLBACK_TO_YML;
     }
 
@@ -234,27 +241,36 @@ public class AnnounceConfig {
     // Updated hash generation for Map structure
     private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
         StringBuilder hashBuilder = new StringBuilder();
+        debug.debug("Generating config hash for " + announcements.size() + " announcements and " + types.size() + " types");
 
         // Process announcements
         announcements.values().stream()
             .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
-            .forEach(a -> hashBuilder.append(String.format("A|%s|%s|%s|%s\n",
-                a.getId().toLowerCase(),
-                a.getType().toLowerCase(),
-                a.getText(),
-                Optional.ofNullable(a.getPermission()).orElse(""))));
+            .forEach(a -> {
+                String announcementEntry = String.format("A|%s|%s|%s|%s\n",
+                    a.getId().toLowerCase(),
+                    a.getType().toLowerCase(),
+                    a.getText(),
+                    Optional.ofNullable(a.getPermission()).orElse(""));
+                hashBuilder.append(announcementEntry);
+            });
 
         // Process types
         types.stream()
             .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
-            .forEach(t -> hashBuilder.append(String.format("T|%s|%s|%s|%s|%s\n",
-                t.getId().toLowerCase(),
-                Optional.ofNullable(t.getPrefix()).orElse(""),
-                Optional.ofNullable(t.getSuffix()).orElse(""),
-                Optional.ofNullable(t.getPermission()).orElse(""),
-                Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""))));
+            .forEach(t -> {
+                String typeEntry = String.format("T|%s|%s|%s|%s|%s\n",
+                    t.getId().toLowerCase(),
+                    Optional.ofNullable(t.getPrefix()).orElse(""),
+                    Optional.ofNullable(t.getSuffix()).orElse(""),
+                    Optional.ofNullable(t.getPermission()).orElse(""),
+                    Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""));
+                hashBuilder.append(typeEntry);
+            });
 
-        return hashBuilder.toString().hashCode();
+        int finalHash = hashBuilder.toString().hashCode();
+        debug.debug("Generated hash value: " + finalHash);
+        return finalHash;
     }
 
     // Loads or creates the YAML configuration file
@@ -264,18 +280,31 @@ public class AnnounceConfig {
             debug.log("Created default announcements.yml");
         }
 
-        config = YamlConfiguration.loadConfiguration(configFile);        
-        storageType = config.getString("storage.type", "yml");
+        config = YamlConfiguration.loadConfiguration(configFile);
+        storageType = config.getString("storage.type", "yml").toLowerCase();
+        debug.log("Storage type configured as: " + storageType);
 
         // Load data from YAML
         this.ymlAnnouncements = loadDataFromYAML();
-        debug.log(LogLevel.CONFIG, "Loaded " + ymlAnnouncements.size() + " announcements from file");
+        debug.log("Loaded " + ymlAnnouncements.size() + " announcements from file");
 
         this.ymlTypes = loadTypesFromYAML();
-        debug.log(LogLevel.CONFIG, "Loaded " + ymlTypes.size() + " announce types from file");
+        debug.log("Loaded " + ymlTypes.size() + " announce types from file");
 
-        // return success if data is loaded
-        return !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty();
+        // Validate YAML data when using YAML storage
+        if (storageType.equals("yml")) {
+            if (ymlAnnouncements.isEmpty()) {
+                debug.log(Level.WARNING, "No announcements found in YAML configuration");
+            }
+            if (ymlTypes.isEmpty()) {
+                debug.log(Level.WARNING, "No announcement types found in YAML configuration");
+            }
+        }
+
+        // Consider config loaded if either announcements or types exist
+        boolean hasData = !ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty();
+        debug.log("Configuration loaded " + (hasData ? "successfully" : "with no data"));
+        return hasData;
     }
 
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
@@ -301,7 +330,7 @@ public class AnnounceConfig {
                     dataStore.saveAnnounceType(type);                    
                     debug.log("Imported announce type: " + type.getId());                    
                 } catch (Exception e) {
-                    debug.log(LogLevel.WARNING, "Error saving announce type: " + type.getId());
+                    debug.log(Level.WARNING, "Error saving announce type: " + type.getId());
                     e.printStackTrace();
                 }
             }
@@ -320,7 +349,7 @@ public class AnnounceConfig {
                     successfulImports.add(announcement.getId().toLowerCase());              
                     debug.log("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
-                    debug.log(LogLevel.WARNING, "Error importing announcement " + announcement.getId() + ": " + e.getMessage());
+                    debug.log(Level.WARNING, "Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
                 }
             }            
@@ -339,59 +368,11 @@ public class AnnounceConfig {
         return needsSaving;
     }
 
-    // Updated import method for Map structure
-    private boolean importYML(Map<String, Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
-        boolean needsSaving = false;
-        Set<String> importedIds = new HashSet<>();
-
-        // Import types first with validation
-        for (AnnounceType type : ymlTypes.values()) {
-            try {
-                if (type.getId() == null) {
-                    debug.log(LogLevel.WARNING, "Skipping announce type with null ID");
-                    continue;
-                }
-                
-                if (!dataStore.loadAnnounceTypes().stream()
-                        .anyMatch(t -> t.getId().equalsIgnoreCase(type.getId()))) {
-                    dataStore.saveAnnounceType(type);
-                    debug.log("Imported announce type: " + type.getId());
-                }
-            } catch (Exception e) {
-                debug.log(LogLevel.WARNING, "Failed to import announce type " + type.getId() + ": " + e.getMessage());
-            }
-        }
-
-        // Import announcements with validation
-        for (Announcement announcement : ymlAnnouncements.values()) {
-            try {
-                if (validateAnnouncement(announcement) && 
-                    !dataStore.announcementExists(announcement.getId())) {
-                    
-                    announceManager.addAnnouncement(announcement);
-                    importedIds.add(announcement.getId().toLowerCase());
-                    needsSaving = true;
-                }
-            } catch (Exception e) {
-                debug.log(LogLevel.WARNING, "Failed to import announcement " + announcement.getId() + ": " + e.getMessage());
-            }
-        }
-
-        // Mark successful imports
-        if (!importedIds.isEmpty()) {
-            ymlAnnouncements.values().stream()
-                .filter(a -> importedIds.contains(a.getId().toLowerCase()))
-                .forEach(Announcement::setImported);
-        }
-
-        return needsSaving;
-    }
-
     // Updated YAML loading with better error handling
     private List<Announcement> loadDataFromYAML() {
         List<Announcement> announcements = new ArrayList<>();
         if (!configFile.exists()) {
-            debug.log(LogLevel.WARNING, "Config file does not exist: " + configFile.getName());
+            debug.log(Level.WARNING, "Config file does not exist: " + configFile.getName());
             return announcements;
         }
 
@@ -403,14 +384,14 @@ public class AnnounceConfig {
                 Announcement announcement = parseAnnouncement(map);
                 if (announcement != null && announcement.getId() != null) {
                     if (usedIds.contains(announcement.getId().toLowerCase())) {
-                        debug.log(LogLevel.WARNING, "Duplicate announcement ID found: " + announcement.getId());
+                        debug.log(Level.WARNING, "Duplicate announcement ID found: " + announcement.getId());
                         continue;
                     }
                     usedIds.add(announcement.getId().toLowerCase());
                     announcements.add(announcement);
                 }
             } catch (Exception e) {
-                debug.log(LogLevel.WARNING, "Error parsing announcement: " + e.getMessage());
+                debug.log(Level.WARNING, "Error parsing announcement: " + e.getMessage());
             }
         }
         return announcements;
@@ -428,7 +409,7 @@ public class AnnounceConfig {
                 }
             }
         } else {
-            debug.log(LogLevel.WARNING, "Config file not found: " + configFile.getName());
+            debug.log(Level.WARNING, "Config file not found: " + configFile.getName());
         }
         return types;
     }
@@ -450,7 +431,7 @@ public class AnnounceConfig {
                 ", SSL: " + useSSL);
             
             if (host.isEmpty() || database.isEmpty() || username.isEmpty()) {
-                debug.log(LogLevel.SEVERE, "Invalid MySQL configuration - missing required fields");
+                debug.log(Level.SEVERE, "Invalid MySQL configuration - missing required fields");
                 dataStore = null;
                 return;
             }
@@ -465,7 +446,7 @@ public class AnnounceConfig {
         }
         
         if (dataStore == null) {
-            debug.log(LogLevel.WARNING, "Failed to initialize data store - unknown or invalid storage type");
+            debug.log(Level.WARNING, "Using YAML storage - no valid database configuration");
         }
     }
 
@@ -534,7 +515,7 @@ public class AnnounceConfig {
                         recurrenceSeconds = Long.parseLong(recStr);
                     }
                 } catch (NumberFormatException e) {
-                    debug.log(LogLevel.WARNING, "Invalid recurrence format for announcement " + id + ": " + recStr);
+                    debug.log(Level.WARNING, "Invalid recurrence format for announcement " + id + ": " + recStr);
                 }
             }
         }
@@ -548,7 +529,7 @@ public class AnnounceConfig {
 
         // Check if PlaceholderAPI is used and available
         if (text.contains("%") && !usingPlaceholderAPI) {
-            debug.log(LogLevel.WARNING, "PlaceholderAPI not found, unable to parse placeholders in announcement: " + id);
+            debug.log(Level.WARNING, "PlaceholderAPI not found, unable to parse placeholders in announcement: " + id);
             return null;
         }
 
@@ -600,30 +581,7 @@ public class AnnounceConfig {
         return announceType;
     }
 
-    // New validation method
-    private boolean validateAnnouncement(Announcement announcement) {
-        if (announcement == null) {
-            debug.log(LogLevel.WARNING, "Null announcement found during validation");
-            return false;
-        }
 
-        if (announcement.getId() == null || announcement.getId().trim().isEmpty()) {
-            debug.log(LogLevel.WARNING, "Invalid announcement: missing ID");
-            return false;
-        }
-
-        if (announcement.getText() == null || announcement.getText().trim().isEmpty()) {
-            debug.log(LogLevel.WARNING, "Invalid announcement: missing text for ID " + announcement.getId());
-            return false;
-        }
-
-        if (announcement.getType() == null || announcement.getType().trim().isEmpty()) {
-            debug.log(LogLevel.WARNING, "Invalid announcement: missing type for ID " + announcement.getId());
-            return false;
-        }
-
-        return true;
-    }
 
     // Persists player preferences for disabled announcement types
     public void savePlayerDisabledTypes() {
@@ -648,7 +606,7 @@ public class AnnounceConfig {
             try {
                 // Validate required fields
                 if (announcement.getId() == null || announcement.getType() == null || announcement.getText() == null) {
-                    debug.log(LogLevel.WARNING, "Skipping invalid announcement: " + announcement.getId());
+                    debug.log(Level.WARNING, "Skipping invalid announcement: " + announcement.getId());
                     continue;
                 }
 
@@ -677,7 +635,7 @@ public class AnnounceConfig {
         }
 
         if (announcementMaps.isEmpty()) {
-            debug.log(LogLevel.WARNING, "No valid announcements to save");
+            debug.log(Level.WARNING, "No valid announcements to save");
             return;
         }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -16,6 +16,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class AnnounceConfig {
+    private enum ConfigOperation {
+        IMPORT_YML_TO_NEW_DB,
+        UPDATE_MISSING_YML_FROM_DB,
+        MERGE_YML_INTO_DB,
+        FALLBACK_TO_YML
+    }
+
     private final JavaPlugin plugin;
     private final File configFile;
     private FileConfiguration config;
@@ -25,8 +32,11 @@ public class AnnounceConfig {
     private final AnnounceManager announceManager;
     private DataStore dataStore;
     private String storageType;
+    private ConfigOperation configOperation;
+    private List<Announcement> ymlAnnouncements;
+    private Map<String, AnnounceType> ymlTypes;
 
-    // Constructor to initialize the announcement configuration and load data
+    // initializes the configuration and data storage settings
     public AnnounceConfig(JavaPlugin plugin, AnnounceManager announceManager) {
         this.plugin = plugin;
         this.announceManager = announceManager;
@@ -34,87 +44,147 @@ public class AnnounceConfig {
         this.configFile = new File(plugin.getDataFolder(), "announcements.yml");
         this.playerDisabledTypes = new HashMap<>();
 
-        loadConfig();        
+        this.configOperation = loadConfig() 
+            ? detectConfigState()
+            : ConfigOperation.FALLBACK_TO_YML;
+
+            //log the config operation
+            plugin.getLogger().info("Config Operation: " + configOperation);
+        
         loadPlayerDisabledTypes();
+    }
+
+    private ConfigOperation detectConfigState() {
+
+        initializeDataStoreConnection();
+        
+        if (dataStore == null) {
+            //log to console
+            plugin.getLogger().info("DataStore is null, falling back to YAML");
+            return ConfigOperation.FALLBACK_TO_YML;
+        }
+
+        dataStore.connect();
+        boolean dbEmpty = dataStore.isEmpty();
+        dataStore.disconnect();
+
+        //plugin.getLogger().info("dbEmpty: " + dbEmpty);
+        //plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.isEmpty());
+        //plugin.getLogger().info("YAML Types: " + ymlTypes.isEmpty());
+
+        // if db is empty, mark for import
+        if (dbEmpty) {
+            plugin.getLogger().info("Database is empty, importing YAML data");
+            return ConfigOperation.IMPORT_YML_TO_NEW_DB;
+
+        // if db is not empty and yml is empty, mark for config update
+        } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
+            plugin.getLogger().info("YAML data is empty, loading from database");
+            return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
+
+        // if db is not empty and yml is not empty, mark for merge
+        } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
+            plugin.getLogger().info("Merging YAML data into database");
+            return ConfigOperation.MERGE_YML_INTO_DB;
+        }
+
+        return ConfigOperation.FALLBACK_TO_YML;
+    }
+
+    // Loads or creates the YAML configuration file
+    public boolean loadConfig() {
+        if (!configFile.exists()) {
+            plugin.saveResource("announcements.yml", false);
+            plugin.getLogger().info("Created default announcements.yml");
+        }
+
+        config = YamlConfiguration.loadConfiguration(configFile);        
+        storageType = config.getString("storage.type", "yml");
+
+        // Load data from YAML
+        this.ymlAnnouncements = loadDataFromYAML();
+        this.ymlTypes = loadTypesFromYAML();
+
+        //log ymlAnnouncements.isEmpty() to console
+        plugin.getLogger().info("YAML Announcements: " + ymlTypes.isEmpty());
+        plugin.getLogger().info("YAML Types: " + ymlTypes.isEmpty());
+
+        // return success if data is loaded
+        return !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty();
     }
 
     // Sets up data storage and handles initial data migration from YAML to database if needed
     public void initializeDataStore() {
         plugin.getLogger().info("Using " + storageType + " storage");
 
-        // Load data from YAML files
-        List<Announcement> ymlAnnouncements = loadDataFromYAML();
-        Map<String, AnnounceType> ymlTypes = loadTypesFromYAML();
-        announceTypes = new HashMap<>();
+        // Initialize DataStore if not already done
+        if (dataStore == null) {
+            initializeDataStoreConnection();
+        }
 
-        // Initialize DataStore based on storage type
-        initializeDataStoreConnection();
-
-        boolean isChanged = false;
-
-        if (dataStore != null) {
-            dataStore.connect();
-            try {
-                if (dataStore.isEmpty()) {
-                    // if database is empty, populate it with YAML data
-                    plugin.getLogger().info("Database is empty");                    
-                    announceManager.setAnnouncements(ymlAnnouncements);
-                    plugin.getLogger().info("Loading " + ymlAnnouncements.size() + " announcements from file");
-                    announceTypes = ymlTypes;
-                    isChanged = importYML(ymlAnnouncements, ymlTypes);
-                } else {
-                    plugin.getLogger().info("Database is not empty");
-
-                    //if YAML data is empty, load data from the database into memory first
-                    if (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty()) {                        
-                        
-                        plugin.getLogger().warning("YAML data is empty. Skipping import");
-                        // Load data from the database into memory first                        
-                        List<Announcement> announcements = loadDataFromDatabase();
-                        announceManager.setAnnouncements(announcements);
-                        isChanged = true;
-
-                    //if YML data is not empty, perform import
-                    } else {                        
-                        List<Announcement> announcements = loadDataFromDatabase();                    
-                        // Load data from the database into memory first
-                        announceManager.setAnnouncements(announcements);
-                        announceManager.setAnnouncementsImported();
-
-                        // Perform YML imports after database data is loaded
-                        isChanged = importYML(ymlAnnouncements, ymlTypes);
-                    }                    
-
-                }
-                if (isChanged) {
-                    saveConfig();
-                    plugin.getLogger().info("Saved announcements after import changes");
-                }
-            } catch (Exception e) {
-                plugin.getLogger().severe("Failed to initialize database: " + e.getMessage());
-                e.printStackTrace();
-
-                // Fallback to YAML data if database fails
-                announceManager.setAnnouncements(ymlAnnouncements);
-                announceTypes = ymlTypes;
-            } finally {
-                dataStore.disconnect();
-            }
-        } else {
-            // If using YAML storage, set the data directly
+        // If not using database storage, use YAML data directly
+        if (dataStore == null) {
             announceManager.setAnnouncements(ymlAnnouncements);
             announceTypes = ymlTypes;
+            return;
+        }
+
+        boolean isChanged = false;
+        dataStore.connect();
+
+        try {
+            switch (configOperation) {
+                case IMPORT_YML_TO_NEW_DB:
+                    announceTypes = ymlTypes;
+                    isChanged = importYML(ymlAnnouncements, ymlTypes);
+                    if (isChanged) {
+                        announceManager.setAnnouncements(dataStore.loadAnnouncements());
+                    }
+                    break;
+
+                case UPDATE_MISSING_YML_FROM_DB:
+                    List<Announcement> announcements = loadDataFromDatabase();
+                    announceManager.setAnnouncements(announcements);
+                    isChanged = true;
+                    break;
+
+                case MERGE_YML_INTO_DB:
+                    List<Announcement> announcements_ = loadDataFromDatabase();
+                    announceManager.setAnnouncements(announcements_);
+                    announceManager.setAnnouncementsImported();
+                    isChanged = importYML(ymlAnnouncements, ymlTypes);
+                    break;
+
+                case FALLBACK_TO_YML:
+                    announceManager.setAnnouncements(ymlAnnouncements);
+                    announceTypes = ymlTypes;
+                    break;
+            }
+
+            if (isChanged) {
+                saveConfig();
+                plugin.getLogger().info("Saved announcements after import changes");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("Failed to initialize database: " + e.getMessage());
+            e.printStackTrace();
+            // Fallback to YAML data on database error
+            announceManager.setAnnouncements(ymlAnnouncements);
+            announceTypes = ymlTypes;
+        } finally {
+            dataStore.disconnect();
         }
     }
 
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
         boolean needsSaving = false;
         
-        // Load existing data for comparison
+        plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.size());
+        plugin.getLogger().info("YAML Types: " + ymlTypes.size());
+
         List<Announcement> existingAnnouncements = dataStore.loadAnnouncements();
         List<AnnounceType> existingTypes = dataStore.loadAnnounceTypes();
 
-        // Create lookup sets
         Set<String> existingAnnouncementIds = new HashSet<>();
         for (Announcement announcement : existingAnnouncements) {
             existingAnnouncementIds.add(announcement.getId().toLowerCase());
@@ -125,7 +195,7 @@ public class AnnounceConfig {
             existingTypeIds.add(type.getId().toLowerCase());
         }
 
-        // Import announce types
+        // Import types first
         for (AnnounceType type : ymlTypes.values()) {
             if (!existingTypeIds.contains(type.getId().toLowerCase())) {
                 try {                    
@@ -138,29 +208,32 @@ public class AnnounceConfig {
             }
         }
 
-        // Import announcements
-        for (Announcement ymlAnnouncement : ymlAnnouncements) {
-            boolean exists = existingAnnouncementIds.contains(ymlAnnouncement.getId().toLowerCase());
-            
-            // Only try to import if not already imported
-            if (!exists && !ymlAnnouncement.isImported()) {                
-                // output message to console
+        // Track successfully imported announcements
+        Set<String> successfulImports = new HashSet<>();
+        
+        // Process announcements that need importing
+        for (Announcement announcement : ymlAnnouncements) {
+            boolean exists = existingAnnouncementIds.contains(announcement.getId().toLowerCase());
+            if (!exists && !announcement.isImported()) {
                 try {
-                    //dataStore.saveAnnouncement(ymlAnnouncement);    
-                    announceManager.addAnnouncement(ymlAnnouncement);            
-                    announceManager.setAnnouncementImported(ymlAnnouncement.getId());
-                    needsSaving = true;                    
-                    plugin.getLogger().info("Imported announcement: " + ymlAnnouncement.getId() + announceManager.isAnnouncementImported(ymlAnnouncement.getId()));
+                    announceManager.addAnnouncement(announcement);
+                    successfulImports.add(announcement.getId().toLowerCase());              
+                    plugin.getLogger().info("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
-                    plugin.getLogger().warning("Error importing announcement " + ymlAnnouncement.getId() + ": " + e.getMessage());
+                    plugin.getLogger().warning("Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
                 }
-            } 
-            // Mark as imported if exists but not already marked
-            else if (exists && !ymlAnnouncement.isImported()) {
-                announceManager.setAnnouncementImported(ymlAnnouncement.getId());
-                needsSaving = true;
-                plugin.getLogger().info("Marked existing announcement as imported: " + ymlAnnouncement.getId());
+            }
+        }
+
+        // Only mark announcements that were successfully imported
+        if (!successfulImports.isEmpty()) {
+            for (Announcement announcement : ymlAnnouncements) {
+                if (successfulImports.contains(announcement.getId().toLowerCase())) {                   
+                    announcement.setImported(); // Set the imported flag on ymlAnnouncements
+                    plugin.getLogger().info("Marked imported announcement: " + announcement.getId());
+                    needsSaving = true;
+                }
             }
         }
 
@@ -193,6 +266,8 @@ public class AnnounceConfig {
                     types.put(announceType.getId(), announceType);
                 }
             }
+        } else {
+            plugin.getLogger().warning("Config file not found: " + configFile.getName());
         }
         return types;
     }
@@ -227,22 +302,6 @@ public class AnnounceConfig {
         // Load announcements from database
         return dataStore.loadAnnouncements();
         //announceManager.setAnnouncements(dbAnnouncements);
-    }
-
-    // Loads or creates the YAML configuration file
-    public void loadConfig() {
-        if (!configFile.exists()) {
-            plugin.saveResource("announcements.yml", false);
-            plugin.getLogger().info("Created default announcements.yml");
-        }
-
-        config = YamlConfiguration.loadConfiguration(configFile);        
-        storageType = config.getString("storage.type", "yml");
-    }
-
-    // Parses an announcement object, adding to local memory and data store
-    public boolean parseAnnouncement(Announcement announcement) {        
-        return announceManager.addAnnouncement(announcement);
     }
 
     // Creates a new announcement from player input with owner information

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -52,7 +52,7 @@ public class AnnounceConfig {
             //log the config operation
             plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
         
-        loadPlayerDisabledTypes();
+
     }
 
     private ConfigOperation detectConfigState() {
@@ -73,19 +73,13 @@ public class AnnounceConfig {
         
         dataStore.disconnect();
 
-        // if db is empty, mark for import
         if (dbEmpty) {
-            //plugin.getLogger().info("Database is empty, importing YAML data");
             return ConfigOperation.IMPORT_YML_TO_NEW_DB;
 
-        // if db is not empty and yml is empty, mark for config update
         } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
-            //plugin.getLogger().info("YAML data is empty, loading from database");
             return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
 
-        // if db is not empty and yml is not empty, mark for merge
         } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
-            //plugin.getLogger().info("Merging YAML data into database");
             return ConfigOperation.MERGE_YML_INTO_DB;
         }
 
@@ -170,11 +164,13 @@ public class AnnounceConfig {
         if (dataStore == null) {
             announceManager.setAnnouncements(ymlAnnouncements);
             announceTypes = ymlTypes;
+            loadPlayerDisabledTypes();
             return;
         }
 
         boolean isChanged = false;
         dataStore.connect();
+        loadPlayerDisabledTypes();
 
         try {
             switch (configOperation) {
@@ -275,7 +271,6 @@ public class AnnounceConfig {
             for (Announcement announcement : ymlAnnouncements) {
                 if (successfulImports.contains(announcement.getId().toLowerCase())) {                   
                     announcement.setImported(); // Set the imported flag on ymlAnnouncements
-                    plugin.getLogger().info("Marked imported announcement: " + announcement.getId());
                     needsSaving = true;
                 }
             }
@@ -435,12 +430,18 @@ public class AnnounceConfig {
 
     // Loads player preferences for disabled announcement types
     public boolean loadPlayerDisabledTypes() {
+        if (dataStore != null) {
+            playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
+            return true;
+        }
+        
+        // Fallback to YML if no datastore
         File dataFolder = plugin.getDataFolder();
         if (!dataFolder.exists()) {
             dataFolder.mkdirs();
         }
 
-        File configFile = new File(dataFolder, "playerDisabledTypes.yml");
+        File configFile = new File(dataFolder, "announceDisabledTypes.yml");
         if (!configFile.exists()) {
             return false;
         }
@@ -459,6 +460,16 @@ public class AnnounceConfig {
 
     // Persists player preferences for disabled announcement types
     public void savePlayerDisabledTypes() {
+        if (dataStore != null) {
+            for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
+                for (String type : entry.getValue()) {
+                    dataStore.savePlayerDisabledType(entry.getKey(), type);
+                }
+            }
+            return;
+        }
+        
+        // Fallback to YML if no datastore
         File dataFolder = plugin.getDataFolder();
         if (!dataFolder.exists()) {
             dataFolder.mkdirs();
@@ -476,17 +487,17 @@ public class AnnounceConfig {
         try {
             // Save the config to file
             config.save(configFile);
-            plugin.getLogger().info("Saved playerDisabledTypes to file");
+            plugin.getLogger().info("Saved announceDisabledTypes to file");
 
         } catch (IOException e) {
-            plugin.getLogger().warning("Failed to save playerDisabledTypes to file: " + e.getMessage());
+            plugin.getLogger().warning("Failed to save announceDisabledTypes to file: " + e.getMessage());
         }
     }
 
     // Refreshes configuration and player preferences from disk
     public void reloadConfig() {
         loadConfig();
-        loadPlayerDisabledTypes();
+        //loadPlayerDisabledTypes();
     }
 
     // Persists announcements and announcement types to YAML configuration
@@ -577,5 +588,21 @@ public class AnnounceConfig {
     // Returns the current data storage implementation
     public DataStore getDataStore() {
         return dataStore;
+    }
+
+    public void addPlayerDisabledType(UUID playerId, String type) {
+        if (dataStore != null) {
+            dataStore.connect();
+            dataStore.savePlayerDisabledType(playerId, type);
+            dataStore.disconnect();
+        }
+    }
+
+    public void removePlayerDisabledType(UUID playerId, String type) {
+        if (dataStore != null) {
+            dataStore.connect();
+            dataStore.removePlayerDisabledType(playerId, type);
+            dataStore.disconnect();
+        }
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -144,6 +144,11 @@ public class AnnounceConfig {
         if (dataStore == null) {
             initializeDataStoreConnection();
         }
+        
+        // Add memory check
+        debug.debug("Memory state before initialization - YML: " + 
+                   (ymlAnnouncements != null ? ymlAnnouncements.size() : 0) + 
+                   " announcements");
 
         // Connect to the database once during initialization
         if (dataStore != null) {
@@ -259,19 +264,13 @@ public class AnnounceConfig {
         this.ymlTypes = loadTypesFromYAML();
         debug.log("Loaded " + ymlTypes.size() + " announce types from file");
 
-        // Validate YAML data when using YAML storage
-        if (storageType.equals("yml")) {
-            if (ymlAnnouncements.isEmpty()) {
-                debug.log(Level.WARNING, "No announcements found in YAML configuration");
-            }
-            if (ymlTypes.isEmpty()) {
-                debug.log(Level.WARNING, "No announcement types found in YAML configuration");
-            }
-        }
-
         // Consider config loaded if either announcements or types exist
         boolean hasData = !ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty();
-        debug.log("Configuration loaded " + (hasData ? "successfully" : "with no data"));
+        if (hasData) {
+            debug.log(Level.INFO, "Configuration loaded successfully"); // Only log once
+        } else {
+            debug.log(Level.WARNING, "Configuration loaded but no data found");
+        }
         return hasData;
     }
 
@@ -311,6 +310,7 @@ public class AnnounceConfig {
             if (!existingAnnouncementIds.contains(announcement.getId().toLowerCase())) {
                 try {
                     dataStore.saveAnnouncement(announcement); 
+                    announcement.setImported(); // Mark as imported immediately
                     successfulImports.add(announcement.getId().toLowerCase());
                     announceManager.getAnnouncements().add(announcement); // Add to memory
                     debug.log("Imported announcement: " + announcement.getId());
@@ -398,9 +398,7 @@ public class AnnounceConfig {
             String password = config.getString("storage.mysql.password", "");
             boolean useSSL = config.getBoolean("storage.mysql.useSSL", false);
             
-            debug.log("MySQL configuration - Host: " + host + ", Port: " + port + 
-                ", Database: " + database + ", Username: " + username + 
-                ", SSL: " + useSSL);
+            debug.log("MySQL configured for " + host + ": " + port);
             
             if (host.isEmpty() || database.isEmpty() || username.isEmpty()) {
                 debug.log(Level.SEVERE, "Invalid MySQL configuration - missing required fields");
@@ -409,7 +407,6 @@ public class AnnounceConfig {
             }
             
             dataStore = new MySQLDataConnector(plugin, host, port, database, username, password, useSSL);
-            debug.log("MySQL connector created successfully");
         } else if (storageType.equalsIgnoreCase("sqlite")) {
             String databasePath = config.getString("storage.sqlite.database", "announcements.db");
             dataStore = new SQLiteDataConnector(plugin, databasePath);
@@ -436,6 +433,7 @@ public class AnnounceConfig {
         List<Announcement> announcementList = new ArrayList<>();
         List<Announcement> dbAnnouncements = dataStore.loadAnnouncements();
         for (Announcement announcement : dbAnnouncements) {
+            announcement.setImported(); // Mark as imported when loading from DB
             announcementList.add(announcement);
         }
         return announcementList;
@@ -579,6 +577,7 @@ public class AnnounceConfig {
         // Get a snapshot of announcements to avoid concurrent modification
         Collection<Announcement> currentAnnouncements = new ArrayList<>(announceManager.getAnnouncements());
         debug.log("Saving " + currentAnnouncements.size() + " announcements to file");
+        int importedCount = 0;
 
         for (Announcement announcement : currentAnnouncements) {
             try {
@@ -623,21 +622,23 @@ public class AnnounceConfig {
                     map.put("time", announcement.getTime().format(DateTimeFormatter.ofPattern("HHmm")));
                 }
                 
-                map.put("imported", announcement.isImported());
+                // Ensure imported status is correctly tracked
+                boolean isImported = announcement.isImported();
+                map.put("imported", isImported);
+                if (isImported) importedCount++;
+                
                 announcementMaps.add(map);
             } catch (Exception e) {
                 debug.error("Error saving announcement " + announcement.getId() + ": " + e.getMessage(), e);
             }
         }
 
-        if (announcementMaps.isEmpty()) {
-            debug.log(Level.WARNING, "No valid announcements to save");
-            return;
-        }
+        debug.log("Saving " + announcementMaps.size() + " announcements (" + importedCount + " imported)");
 
         try {
             config.set("announcements", announcementMaps);
             config.save(configFile);
+            debug.log("Configuration saved successfully");
         } catch (IOException e) {
             debug.error("Failed to save announcements: " + e.getMessage(), e);
             e.printStackTrace();

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -382,9 +382,13 @@ public class AnnounceConfig {
             announceTypes.put(type.getId(), type);
         }
 
-        // Load announcements from database
-        return dataStore.loadAnnouncements();
-        //announceManager.setAnnouncements(dbAnnouncements);
+        // Convert list to map
+        List<Announcement> announcementList = new ArrayList<>();
+        List<Announcement> dbAnnouncements = dataStore.loadAnnouncements();
+        for (Announcement announcement : dbAnnouncements) {
+            announcementList.add(announcement);
+        }
+        return announcementList;
     }
 
     // Creates a new announcement from player input with owner information

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -27,7 +27,6 @@ public class AnnounceConfig {
     private final JavaPlugin plugin;
     private final File configFile;
     private FileConfiguration config;
-    private Map<UUID, Set<String>> playerDisabledTypes;
     private Map<String, AnnounceType> announceTypes;
     boolean usingPlaceholderAPI;
     private final AnnounceManager announceManager;
@@ -36,6 +35,7 @@ public class AnnounceConfig {
     private ConfigOperation configOperation;
     private List<Announcement> ymlAnnouncements;
     private Map<String, AnnounceType> ymlTypes;
+    private AnnouncePreferences preferences;
 
     // initializes the configuration and data storage settings
     public AnnounceConfig(JavaPlugin plugin, AnnounceManager announceManager) {
@@ -43,7 +43,6 @@ public class AnnounceConfig {
         this.announceManager = announceManager;
         this.usingPlaceholderAPI = (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null);
         this.configFile = new File(plugin.getDataFolder(), "announcements.yml");
-        this.playerDisabledTypes = new HashMap<>();
 
         this.configOperation = loadConfig() 
             ? detectConfigState()
@@ -51,8 +50,6 @@ public class AnnounceConfig {
 
             //log the config operation
             plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
-        
-
     }
 
     private ConfigOperation detectConfigState() {
@@ -60,17 +57,15 @@ public class AnnounceConfig {
         initializeDataStoreConnection();
         
         if (dataStore == null) {
-            //log to console
-            plugin.getLogger().info("DataStore is null, falling back to YAML");
             return ConfigOperation.FALLBACK_TO_YML;
         }
 
+        // Connect to database and check if it is empty
         dataStore.connect();
-
         boolean dbEmpty = dataStore.isEmpty();
         
-        if (!dbEmpty && dbMatchesYml()) return ConfigOperation.NO_UPDATE;
-        
+        // Check if database and YAML configurations match
+        if (!dbEmpty && dbMatchesYml()) return ConfigOperation.NO_UPDATE;        
         dataStore.disconnect();
 
         if (dbEmpty) {
@@ -153,24 +148,30 @@ public class AnnounceConfig {
 
     // Sets up data storage and handles initial data migration from YAML to database if needed
     public void initializeDataStore() {
-        plugin.getLogger().info("Using " + storageType + " storage");
+        plugin.getLogger().info("AnnounceConfig using " + storageType + " storage");
 
         // Initialize DataStore if not already done
         if (dataStore == null) {
             initializeDataStoreConnection();
         }
 
+        // Connect to the database once during initialization
+        if (dataStore != null) {
+            dataStore.connect();
+        }
+
+        // Initialize preferences after dataStore is initialized
+        this.preferences = new AnnouncePreferences(plugin, dataStore);
+        preferences.loadPreferences();
+
         // If not using database storage, use YAML data directly
         if (dataStore == null) {
             announceManager.setAnnouncements(ymlAnnouncements);
             announceTypes = ymlTypes;
-            loadPlayerDisabledTypes();
             return;
         }
 
         boolean isChanged = false;
-        dataStore.connect();
-        loadPlayerDisabledTypes();
 
         try {
             switch (configOperation) {
@@ -214,8 +215,6 @@ public class AnnounceConfig {
             // Fallback to YAML data on database error
             announceManager.setAnnouncements(ymlAnnouncements);
             announceTypes = ymlTypes;
-        } finally {
-            dataStore.disconnect();
         }
     }
 
@@ -239,7 +238,7 @@ public class AnnounceConfig {
         for (AnnounceType type : ymlTypes.values()) {
             if (!existingTypeIds.contains(type.getId().toLowerCase())) {
                 try {                    
-                    dataStore.saveAnnounceType(type);
+                    dataStore.saveAnnounceType(type);                    
                     plugin.getLogger().info("Imported announce type: " + type.getId());                    
                 } catch (Exception e) {
                     plugin.getLogger().warning("Error saving announce type: " + type.getId());
@@ -263,7 +262,7 @@ public class AnnounceConfig {
                     plugin.getLogger().warning("Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
                 }
-            }
+            }            
         }
 
         // Only mark announcements that were successfully imported
@@ -332,6 +331,7 @@ public class AnnounceConfig {
     // Retrieves announcement data from database and stores it in memory
     private List<Announcement> loadDataFromDatabase() {
         // Load announce types from database
+
         List<AnnounceType> dbTypes = dataStore.loadAnnounceTypes();
         announceTypes = new HashMap<>();
         for (AnnounceType type : dbTypes) {
@@ -428,70 +428,9 @@ public class AnnounceConfig {
         return announceType;
     }
 
-    // Loads player preferences for disabled announcement types
-    public boolean loadPlayerDisabledTypes() {
-        if (dataStore != null) {
-            playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
-            return true;
-        }
-        
-        // Fallback to YML if no datastore
-        File dataFolder = plugin.getDataFolder();
-        if (!dataFolder.exists()) {
-            dataFolder.mkdirs();
-        }
-
-        File configFile = new File(dataFolder, "announceDisabledTypes.yml");
-        if (!configFile.exists()) {
-            return false;
-        }
-
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
-
-        for (String key : config.getKeys(false)) {
-            UUID playerId = UUID.fromString(key);
-            List<String> disabledTypesList = config.getStringList(key);
-            Set<String> disabledTypesSet = new HashSet<>(disabledTypesList);
-            playerDisabledTypes.put(playerId, disabledTypesSet);
-        }
-
-        return true;
-    }
-
     // Persists player preferences for disabled announcement types
     public void savePlayerDisabledTypes() {
-        if (dataStore != null) {
-            for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
-                for (String type : entry.getValue()) {
-                    dataStore.savePlayerDisabledType(entry.getKey(), type);
-                }
-            }
-            return;
-        }
-        
-        // Fallback to YML if no datastore
-        File dataFolder = plugin.getDataFolder();
-        if (!dataFolder.exists()) {
-            dataFolder.mkdirs();
-        }
-
-        File configFile = new File(dataFolder, "playerDisabledTypes.yml");
-        YamlConfiguration config = new YamlConfiguration();
-
-        for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
-            String key = entry.getKey().toString();
-            List<String> disabledTypesList = new ArrayList<>(entry.getValue());
-            config.set(key, disabledTypesList);
-        }
-
-        try {
-            // Save the config to file
-            config.save(configFile);
-            plugin.getLogger().info("Saved announceDisabledTypes to file");
-
-        } catch (IOException e) {
-            plugin.getLogger().warning("Failed to save announceDisabledTypes to file: " + e.getMessage());
-        }
+        preferences.savePreferences();
     }
 
     // Refreshes configuration and player preferences from disk
@@ -577,7 +516,7 @@ public class AnnounceConfig {
 
     // Returns the map of player-disabled announcement types
     public Map<UUID, Set<String>> getPlayerDisabledTypes() {
-        return playerDisabledTypes;
+        return preferences.getAllDisabledTypes();
     }
 
     // Returns the map of available announcement types
@@ -591,17 +530,16 @@ public class AnnounceConfig {
     }
 
     public void addPlayerDisabledType(UUID playerId, String type) {
-        if (dataStore != null) {
-            dataStore.connect();
-            dataStore.savePlayerDisabledType(playerId, type);
-            dataStore.disconnect();
-        }
+        preferences.addDisabledType(playerId, type);
     }
 
     public void removePlayerDisabledType(UUID playerId, String type) {
+        preferences.removeDisabledType(playerId, type);
+    }
+
+    // Add a shutdown method to disconnect the DataStore
+    public void shutdown() {
         if (dataStore != null) {
-            dataStore.connect();
-            dataStore.removePlayerDisabledType(playerId, type);
             dataStore.disconnect();
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -65,7 +65,6 @@ public class AnnounceConfig {
             return ConfigOperation.FALLBACK_TO_YML;
         }
 
-        // Connect to database and check if it is empty
         try {
             plugin.getLogger().info("Attempting database connection...");
             dataStore.connect();
@@ -73,39 +72,109 @@ public class AnnounceConfig {
             
             boolean dbEmpty = dataStore.isEmpty();
             plugin.getLogger().info("Database empty check result: " + dbEmpty);
-            
-            // Check if database and YAML configurations match
-            if (!dbEmpty && dbMatchesYml()) {
-                plugin.getLogger().info("Database matches YAML content");
-                return ConfigOperation.NO_UPDATE;
-            }
-            
-            dataStore.disconnect();
 
             if (dbEmpty) {
                 plugin.getLogger().info("Empty database detected - will import YAML");
                 return ConfigOperation.IMPORT_YML_TO_NEW_DB;
-
-            } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
-                return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
-
-            } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
-                //output a warning message
-                plugin.getLogger().warning("Database and YAML configurations do not match. Merging YAML data into database.");
-
+            }
+            
+            // Load data from both sources for comparison
+            List<Announcement> dbAnnouncements = dataStore.loadAnnouncements();
+            List<AnnounceType> dbTypes = dataStore.loadAnnounceTypes();
+            
+            if ((dbAnnouncements.isEmpty() || dbTypes.isEmpty()) && 
+                (!ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty())) {
+                plugin.getLogger().info("Database partially empty - will import YAML");
+                return ConfigOperation.IMPORT_YML_TO_NEW_DB;
+            }
+            
+            if (!dbAnnouncements.isEmpty() && !dbTypes.isEmpty()) {
+                if (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty()) {
+                    return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
+                }
                 return ConfigOperation.MERGE_YML_INTO_DB;
             }
 
-            //output a warning message
-            plugin.getLogger().warning("Unable to determine configuration state. Using YAML configurations.");
             return ConfigOperation.FALLBACK_TO_YML;
+            
         } catch (Exception e) {
             plugin.getLogger().severe("Database connection/check failed: " + e.getMessage());
             e.printStackTrace();
             return ConfigOperation.FALLBACK_TO_YML;
         }
     }
-    
+
+    public void initializeDataStore() {
+        plugin.getLogger().info("AnnounceConfig using " + storageType + " storage");
+
+        // Initialize DataStore if not already done
+        if (dataStore == null) {
+            initializeDataStoreConnection();
+        }
+
+        // Connect to the database once during initialization
+        if (dataStore != null) {
+            dataStore.connect();
+        }
+
+        // Initialize preferences after dataStore is initialized
+        this.preferences = new AnnouncePreferences(plugin, dataStore);
+        preferences.loadPreferences();
+
+        // If not using database storage, use YAML data directly
+        if (dataStore == null) {
+            announceManager.setAnnouncements(ymlAnnouncements);
+            announceTypes = ymlTypes;
+            return;
+        }
+
+        boolean isChanged = false;
+
+        try {
+            switch (configOperation) {
+
+                case NO_UPDATE:
+                case FALLBACK_TO_YML:
+                    announceManager.setAnnouncements(ymlAnnouncements);
+                    announceTypes = ymlTypes;
+                    break;
+
+                case IMPORT_YML_TO_NEW_DB:
+                    announceTypes = ymlTypes;
+                    isChanged = importYML(ymlAnnouncements, ymlTypes);
+                    if (isChanged) {
+                        announceManager.setAnnouncements(dataStore.loadAnnouncements());
+                        announceManager.setAnnouncementsImported();
+                    }
+                    break;
+
+                case UPDATE_MISSING_YML_FROM_DB:
+                    List<Announcement> announcements = loadDataFromDatabase();
+                    announceManager.setAnnouncements(announcements);
+                    isChanged = true;
+                    break;
+
+                case MERGE_YML_INTO_DB:
+                    List<Announcement> announcements_ = loadDataFromDatabase();
+                    announceManager.setAnnouncements(announcements_);
+                    announceManager.setAnnouncementsImported();
+                    isChanged = importYML(ymlAnnouncements, ymlTypes);
+                    break;
+            }
+
+            if (isChanged) {
+                saveConfig();
+                plugin.getLogger().info("Saved announcements after import changes");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("Failed to initialize database: " + e.getMessage());
+            e.printStackTrace();
+            // Fallback to YAML data on database error
+            announceManager.setAnnouncements(ymlAnnouncements);
+            announceTypes = ymlTypes;
+        }
+    }
+
     private boolean dbMatchesYml() {
             Integer ymlHash = generateConfigHash(ymlAnnouncements, ymlTypes);
             Integer dbHash = generateConfigHash(dataStore.loadAnnouncements(), dataStore.loadAnnounceTypes());
@@ -195,78 +264,6 @@ public class AnnounceConfig {
 
         // return success if data is loaded
         return !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty();
-    }
-
-    // Sets up data storage and handles initial data migration from YAML to database if needed
-    public void initializeDataStore() {
-        plugin.getLogger().info("AnnounceConfig using " + storageType + " storage");
-
-        // Initialize DataStore if not already done
-        if (dataStore == null) {
-            initializeDataStoreConnection();
-        }
-
-        // Connect to the database once during initialization
-        if (dataStore != null) {
-            dataStore.connect();
-        }
-
-        // Initialize preferences after dataStore is initialized
-        this.preferences = new AnnouncePreferences(plugin, dataStore);
-        preferences.loadPreferences();
-
-        // If not using database storage, use YAML data directly
-        if (dataStore == null) {
-            announceManager.setAnnouncements(ymlAnnouncements);
-            announceTypes = ymlTypes;
-            return;
-        }
-
-        boolean isChanged = false;
-
-        try {
-            switch (configOperation) {
-
-                case NO_UPDATE:
-                case FALLBACK_TO_YML:
-                    announceManager.setAnnouncements(ymlAnnouncements);
-                    announceTypes = ymlTypes;
-                    break;
-
-                case IMPORT_YML_TO_NEW_DB:
-                    announceTypes = ymlTypes;
-                    isChanged = importYML(ymlAnnouncements, ymlTypes);
-                    if (isChanged) {
-                        announceManager.setAnnouncements(dataStore.loadAnnouncements());
-                        announceManager.setAnnouncementsImported();
-                    }
-                    break;
-
-                case UPDATE_MISSING_YML_FROM_DB:
-                    List<Announcement> announcements = loadDataFromDatabase();
-                    announceManager.setAnnouncements(announcements);
-                    isChanged = true;
-                    break;
-
-                case MERGE_YML_INTO_DB:
-                    List<Announcement> announcements_ = loadDataFromDatabase();
-                    announceManager.setAnnouncements(announcements_);
-                    announceManager.setAnnouncementsImported();
-                    isChanged = importYML(ymlAnnouncements, ymlTypes);
-                    break;
-            }
-
-            if (isChanged) {
-                saveConfig();
-                plugin.getLogger().info("Saved announcements after import changes");
-            }
-        } catch (Exception e) {
-            plugin.getLogger().severe("Failed to initialize database: " + e.getMessage());
-            e.printStackTrace();
-            // Fallback to YAML data on database error
-            announceManager.setAnnouncements(ymlAnnouncements);
-            announceTypes = ymlTypes;
-        }
     }
 
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -68,23 +68,19 @@ public class AnnounceConfig {
         boolean dbEmpty = dataStore.isEmpty();
         dataStore.disconnect();
 
-        //plugin.getLogger().info("dbEmpty: " + dbEmpty);
-        //plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.isEmpty());
-        //plugin.getLogger().info("YAML Types: " + ymlTypes.isEmpty());
-
         // if db is empty, mark for import
         if (dbEmpty) {
-            plugin.getLogger().info("Database is empty, importing YAML data");
+            //plugin.getLogger().info("Database is empty, importing YAML data");
             return ConfigOperation.IMPORT_YML_TO_NEW_DB;
 
         // if db is not empty and yml is empty, mark for config update
         } else if (!dbEmpty && (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty())) {
-            plugin.getLogger().info("YAML data is empty, loading from database");
+            //plugin.getLogger().info("YAML data is empty, loading from database");
             return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
 
         // if db is not empty and yml is not empty, mark for merge
         } else if (!dbEmpty && !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty()) {
-            plugin.getLogger().info("Merging YAML data into database");
+            //plugin.getLogger().info("Merging YAML data into database");
             return ConfigOperation.MERGE_YML_INTO_DB;
         }
 
@@ -104,10 +100,6 @@ public class AnnounceConfig {
         // Load data from YAML
         this.ymlAnnouncements = loadDataFromYAML();
         this.ymlTypes = loadTypesFromYAML();
-
-        //log ymlAnnouncements.isEmpty() to console
-        plugin.getLogger().info("YAML Announcements: " + ymlTypes.isEmpty());
-        plugin.getLogger().info("YAML Types: " + ymlTypes.isEmpty());
 
         // return success if data is loaded
         return !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty();
@@ -137,8 +129,13 @@ public class AnnounceConfig {
                 case IMPORT_YML_TO_NEW_DB:
                     announceTypes = ymlTypes;
                     isChanged = importYML(ymlAnnouncements, ymlTypes);
+                    
+                    //log to console
+                    plugin.getLogger().info("isChanged: " + isChanged);
+
                     if (isChanged) {
                         announceManager.setAnnouncements(dataStore.loadAnnouncements());
+                        announceManager.setAnnouncementsImported();
                     }
                     break;
 
@@ -179,8 +176,8 @@ public class AnnounceConfig {
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
         boolean needsSaving = false;
         
-        plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.size());
-        plugin.getLogger().info("YAML Types: " + ymlTypes.size());
+        //plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.size());
+        //plugin.getLogger().info("YAML Types: " + ymlTypes.size());
 
         List<Announcement> existingAnnouncements = dataStore.loadAnnouncements();
         List<AnnounceType> existingTypes = dataStore.loadAnnounceTypes();

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -20,7 +20,8 @@ public class AnnounceConfig {
         IMPORT_YML_TO_NEW_DB,
         UPDATE_MISSING_YML_FROM_DB,
         MERGE_YML_INTO_DB,
-        FALLBACK_TO_YML
+        FALLBACK_TO_YML,
+        NO_UPDATE
     }
 
     private final JavaPlugin plugin;
@@ -49,7 +50,7 @@ public class AnnounceConfig {
             : ConfigOperation.FALLBACK_TO_YML;
 
             //log the config operation
-            plugin.getLogger().info("Config Operation: " + configOperation);
+            plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
         
         loadPlayerDisabledTypes();
     }
@@ -65,7 +66,11 @@ public class AnnounceConfig {
         }
 
         dataStore.connect();
+
         boolean dbEmpty = dataStore.isEmpty();
+        
+        if (!dbEmpty && dbMatchesYml()) return ConfigOperation.NO_UPDATE;
+        
         dataStore.disconnect();
 
         // if db is empty, mark for import
@@ -85,6 +90,53 @@ public class AnnounceConfig {
         }
 
         return ConfigOperation.FALLBACK_TO_YML;
+    }
+    
+    private boolean dbMatchesYml() {
+            Integer ymlHash = generateConfigHash(ymlAnnouncements, ymlTypes);
+            Integer dbHash = generateConfigHash(dataStore.loadAnnouncements(), dataStore.loadAnnounceTypes());
+            
+            if (ymlHash.equals(dbHash)) {
+                plugin.getLogger().info("Database and YAML configurations match (Hash: " + ymlHash + ")");
+                dataStore.disconnect();
+                return true;
+            }
+            return false;
+    }
+
+    // Generates a hash of the configuration data for comparison
+    private Integer generateConfigHash(List<Announcement> announcements, Collection<AnnounceType> types) {
+        List<String> elements = new ArrayList<>();
+        
+        // Add sorted announcement entries
+        for (Announcement a : announcements) {
+            elements.add(String.format("%s:%s:%s:%s",
+                a.getId().toLowerCase(),
+                a.getType().toLowerCase(),
+                a.getText(),
+                a.getPermission() != null ? a.getPermission() : ""));
+        }
+        
+        // Add sorted type entries
+        for (AnnounceType t : types) {
+            elements.add(String.format("%s:%s:%s:%s:%s",
+                t.getId().toLowerCase(),
+                t.getPrefix() != null ? t.getPrefix() : "",
+                t.getSuffix() != null ? t.getSuffix() : "",
+                t.getPermission() != null ? t.getPermission() : "",
+                t.getListingFee() != null ? t.getListingFee().toString() : ""));
+        }
+        
+        // Sort elements for consistent ordering
+        Collections.sort(elements);
+
+        //generate hash of concatenated elements into a string
+        return String.join("|", elements).hashCode();
+    }
+
+    // Overloaded method to generate hash of configuration data
+    private Integer generateConfigHash(List<Announcement> announcements, Map<String, AnnounceType> types) {
+        return generateConfigHash(announcements, types.values());
     }
 
     // Loads or creates the YAML configuration file
@@ -126,13 +178,16 @@ public class AnnounceConfig {
 
         try {
             switch (configOperation) {
+
+                case NO_UPDATE:
+                case FALLBACK_TO_YML:
+                    announceManager.setAnnouncements(ymlAnnouncements);
+                    announceTypes = ymlTypes;
+                    break;
+
                 case IMPORT_YML_TO_NEW_DB:
                     announceTypes = ymlTypes;
                     isChanged = importYML(ymlAnnouncements, ymlTypes);
-                    
-                    //log to console
-                    plugin.getLogger().info("isChanged: " + isChanged);
-
                     if (isChanged) {
                         announceManager.setAnnouncements(dataStore.loadAnnouncements());
                         announceManager.setAnnouncementsImported();
@@ -150,11 +205,6 @@ public class AnnounceConfig {
                     announceManager.setAnnouncements(announcements_);
                     announceManager.setAnnouncementsImported();
                     isChanged = importYML(ymlAnnouncements, ymlTypes);
-                    break;
-
-                case FALLBACK_TO_YML:
-                    announceManager.setAnnouncements(ymlAnnouncements);
-                    announceTypes = ymlTypes;
                     break;
             }
 
@@ -175,9 +225,6 @@ public class AnnounceConfig {
 
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
         boolean needsSaving = false;
-        
-        //plugin.getLogger().info("YAML Announcements: " + ymlAnnouncements.size());
-        //plugin.getLogger().info("YAML Types: " + ymlTypes.size());
 
         List<Announcement> existingAnnouncements = dataStore.loadAnnouncements();
         List<AnnounceType> existingTypes = dataStore.loadAnnounceTypes();
@@ -373,8 +420,7 @@ public class AnnounceConfig {
         String prefix = (String) map.get("prefix");
         String suffix = (String) map.get("suffix");
         Double listingFee = map.get("list_fee") == null ? null : (map.get("list_fee") instanceof Integer ? ((Integer) map.get("list_fee")).doubleValue() : (Double) map.get("list_fee"));
-        String permission = (String) map.get("permission");
-        boolean imported = map.containsKey("imported") ? (Boolean) map.get("imported") : false;
+        String permission = (String) map.get("permission");        
 
         AnnounceType announceType = new AnnounceType();
         announceType.setId(id);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -131,7 +131,7 @@ public class AnnounceConfig {
     }
 
     public void initializeDataStore() {
-        debug.log(LogLevel.INFO, "AnnounceConfig using " + storageType + " storage");
+        debug.log("AnnounceConfig using " + storageType + " storage");
 
         // Initialize DataStore if not already done
         if (dataStore == null) {
@@ -190,7 +190,7 @@ public class AnnounceConfig {
 
             if (isChanged) {
                 saveConfig();
-                debug.log(LogLevel.INFO, "Saved announcements after import changes");
+                debug.log("Saved announcements after import changes");
             }
         } catch (Exception e) {
             debug.error("Failed to initialize database: " + e.getMessage(), e);
@@ -206,7 +206,7 @@ public class AnnounceConfig {
             Integer dbHash = generateConfigHash(dataStore.loadAnnouncements(), dataStore.loadAnnounceTypes());
             
             if (ymlHash.equals(dbHash)) {
-                debug.log(LogLevel.INFO, "Database and YAML configurations match (Hash: " + ymlHash + ")");
+                debug.log("Database and YAML configurations match (Hash: " + ymlHash + ")");
                 dataStore.disconnect();
                 return true;
             }
@@ -261,7 +261,7 @@ public class AnnounceConfig {
     public boolean loadConfig() {
         if (!configFile.exists()) {
             plugin.saveResource("announcements.yml", false);
-            debug.log(LogLevel.INFO, "Created default announcements.yml");
+            debug.log("Created default announcements.yml");
         }
 
         config = YamlConfiguration.loadConfiguration(configFile);        
@@ -269,7 +269,10 @@ public class AnnounceConfig {
 
         // Load data from YAML
         this.ymlAnnouncements = loadDataFromYAML();
+        debug.log(LogLevel.CONFIG, "Loaded " + ymlAnnouncements.size() + " announcements from file");
+
         this.ymlTypes = loadTypesFromYAML();
+        debug.log(LogLevel.CONFIG, "Loaded " + ymlTypes.size() + " announce types from file");
 
         // return success if data is loaded
         return !ymlAnnouncements.isEmpty() && !ymlTypes.isEmpty();
@@ -296,7 +299,7 @@ public class AnnounceConfig {
             if (!existingTypeIds.contains(type.getId().toLowerCase())) {
                 try {                    
                     dataStore.saveAnnounceType(type);                    
-                    debug.log(LogLevel.INFO, "Imported announce type: " + type.getId());                    
+                    debug.log("Imported announce type: " + type.getId());                    
                 } catch (Exception e) {
                     debug.log(LogLevel.WARNING, "Error saving announce type: " + type.getId());
                     e.printStackTrace();
@@ -315,7 +318,7 @@ public class AnnounceConfig {
                 try {
                     announceManager.addAnnouncement(announcement);
                     successfulImports.add(announcement.getId().toLowerCase());              
-                    debug.log(LogLevel.INFO, "Imported announcement: " + announcement.getId());
+                    debug.log("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
                     debug.log(LogLevel.WARNING, "Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
@@ -352,7 +355,7 @@ public class AnnounceConfig {
                 if (!dataStore.loadAnnounceTypes().stream()
                         .anyMatch(t -> t.getId().equalsIgnoreCase(type.getId()))) {
                     dataStore.saveAnnounceType(type);
-                    debug.log(LogLevel.INFO, "Imported announce type: " + type.getId());
+                    debug.log("Imported announce type: " + type.getId());
                 }
             } catch (Exception e) {
                 debug.log(LogLevel.WARNING, "Failed to import announce type " + type.getId() + ": " + e.getMessage());
@@ -432,7 +435,7 @@ public class AnnounceConfig {
 
     // Creates appropriate DataStore instance based on configuration settings
     private void initializeDataStoreConnection() {
-        debug.log(LogLevel.INFO, "Initializing data store connection with type: " + storageType);
+        debug.log("Initializing data store connection with type: " + storageType);
         
         if (storageType.equalsIgnoreCase("mysql")) {
             String host = config.getString("storage.mysql.host", "");
@@ -442,7 +445,7 @@ public class AnnounceConfig {
             String password = config.getString("storage.mysql.password", "");
             boolean useSSL = config.getBoolean("storage.mysql.useSSL", false);
             
-            debug.log(LogLevel.INFO, "MySQL configuration - Host: " + host + ", Port: " + port + 
+            debug.log("MySQL configuration - Host: " + host + ", Port: " + port + 
                 ", Database: " + database + ", Username: " + username + 
                 ", SSL: " + useSSL);
             
@@ -453,7 +456,7 @@ public class AnnounceConfig {
             }
             
             dataStore = new MySQLDataConnector(plugin, host, port, database, username, password, useSSL);
-            debug.log(LogLevel.INFO, "MySQL connector created successfully");
+            debug.log("MySQL connector created successfully");
         } else if (storageType.equalsIgnoreCase("sqlite")) {
             String databasePath = config.getString("storage.sqlite.database", "announcements.db");
             dataStore = new SQLiteDataConnector(plugin, databasePath);
@@ -639,7 +642,7 @@ public class AnnounceConfig {
 
         // Get a snapshot of announcements to avoid concurrent modification
         Collection<Announcement> currentAnnouncements = new ArrayList<>(announceManager.getAnnouncements());
-        debug.log(LogLevel.INFO, "Saving " + currentAnnouncements.size() + " announcements to file");
+        debug.log("Saving " + currentAnnouncements.size() + " announcements to file");
 
         for (Announcement announcement : currentAnnouncements) {
             try {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -253,7 +253,8 @@ public class AnnounceConfig {
         // Process announcements that need importing
         for (Announcement announcement : ymlAnnouncements) {
             boolean exists = existingAnnouncementIds.contains(announcement.getId().toLowerCase());
-            if (!exists && !announcement.isImported()) {
+            // Remove isImported() check since we want to import all announcements from YML
+            if (!exists) {
                 try {
                     announceManager.addAnnouncement(announcement);
                     successfulImports.add(announcement.getId().toLowerCase());              
@@ -372,7 +373,8 @@ public class AnnounceConfig {
         String permission = (String) map.get("permission");
         String dateStr = (String) map.get("date");
         String timeStr = (String) map.get("time");
-        boolean imported = map.containsKey("imported") ? (Boolean) map.get("imported") : false;
+        // Default imported to false if not present in YAML
+        boolean imported = map.containsKey("imported") && (Boolean) map.get("imported");
 
         // Check if PlaceholderAPI is used and available
         if (text.contains("%") && !usingPlaceholderAPI) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -96,7 +96,7 @@ public class AnnounceConfig {
             
             if (dataStore != null) {
                 try {
-                    debug.log("Testing database connectivity");
+                    debug.debug("Testing database connectivity"); // Moved to debug level
                     dataStore.connect();
                     
                     // Wait briefly for connection to stabilize
@@ -112,7 +112,7 @@ public class AnnounceConfig {
                         }
                         
                         if (dbMatchesYml()) {
-                            debug.log("Database matches YAML configuration");
+                            debug.debug("Database matches YAML configuration"); // Moved to debug level
                             return ConfigOperation.NO_UPDATE;
                         } else {
                             debug.log("Database differs from YAML - will merge");
@@ -219,10 +219,10 @@ public class AnnounceConfig {
             MySQLDataConnector mysqlStore = (MySQLDataConnector) dataStore;
             String dbHash = mysqlStore.calculateDatabaseHash();
             
-            debug.log("Configuration hash comparison - YAML=" + ymlHash + " DB=" + dbHash);
+            debug.debug("Configuration hash comparison - YAML=" + ymlHash + " DB=" + dbHash); // Moved to debug level
             
             if (ymlHash != null && dbHash != null && ymlHash.equals(dbHash)) {
-                debug.log("Loading " + ymlAnnouncements.size() + " announcements from local configuration");
+                debug.debug("Loading announcements from local configuration"); // Moved to debug level
                 dataStore.disconnect();
                 return true;
             } else {
@@ -255,23 +255,15 @@ public class AnnounceConfig {
 
         config = YamlConfiguration.loadConfiguration(configFile);
         storageType = config.getString("storage.type", "yml").toLowerCase();
-        debug.log("Storage type configured as: " + storageType);
-
-        // Load data from YAML
+        
+        // Consolidate loading messages into a single INFO message
         this.ymlAnnouncements = loadDataFromYAML();
-        debug.log("Loaded " + ymlAnnouncements.size() + " announcements from file");
-
         this.ymlTypes = loadTypesFromYAML();
-        debug.log("Loaded " + ymlTypes.size() + " announce types from file");
+        
+        debug.log(String.format("Loaded configuration: %d announcements, %d types, storage: %s", 
+            ymlAnnouncements.size(), ymlTypes.size(), storageType));
 
-        // Consider config loaded if either announcements or types exist
-        boolean hasData = !ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty();
-        if (hasData) {
-            debug.log(Level.INFO, "Configuration loaded successfully"); // Only log once
-        } else {
-            debug.log(Level.WARNING, "Configuration loaded but no data found");
-        }
-        return hasData;
+        return !ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty();
     }
 
     private boolean importYML(List<Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
@@ -398,14 +390,13 @@ public class AnnounceConfig {
             String password = config.getString("storage.mysql.password", "");
             boolean useSSL = config.getBoolean("storage.mysql.useSSL", false);
             
-            debug.log("MySQL configured for " + host + ": " + port);
-            
             if (host.isEmpty() || database.isEmpty() || username.isEmpty()) {
                 debug.log(Level.SEVERE, "Invalid MySQL configuration - missing required fields");
                 dataStore = null;
                 return;
             }
             
+            debug.debug("Configuring MySQL connection for " + host + ":" + port); // Moved to debug level
             dataStore = new MySQLDataConnector(plugin, host, port, database, username, password, useSSL);
         } else if (storageType.equalsIgnoreCase("sqlite")) {
             String databasePath = config.getString("storage.sqlite.database", "announcements.db");

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -310,14 +310,21 @@ public class AnnounceConfig {
         for (Announcement announcement : ymlAnnouncements) {
             if (!existingAnnouncementIds.contains(announcement.getId().toLowerCase())) {
                 try {
-                    dataStore.saveAnnouncement(announcement); // Save to database only
-                    successfulImports.add(announcement.getId().toLowerCase());              
+                    dataStore.saveAnnouncement(announcement); 
+                    successfulImports.add(announcement.getId().toLowerCase());
+                    announceManager.getAnnouncements().add(announcement); // Add to memory
                     debug.log("Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
                     debug.log(Level.WARNING, "Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
                 }
             }            
+        }
+
+        // Update the local announcements list after import
+        if (!successfulImports.isEmpty()) {
+            announceManager.setAnnouncements(dataStore.loadAnnouncements());
+            debug.log("Updated in-memory announcements after import");
         }
 
         // Only mark announcements that were successfully imported

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -14,8 +14,12 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import org.fourz.rvnktools.util.Debug;
+import org.fourz.rvnktools.util.Debug.LogLevel;
+import java.util.stream.Collectors;
 
 public class AnnounceConfig {
+    private static final String CLASS_NAME = "AnnounceConfig";
     private enum ConfigOperation {
         IMPORT_YML_TO_NEW_DB,
         UPDATE_MISSING_YML_FROM_DB,
@@ -24,6 +28,13 @@ public class AnnounceConfig {
         NO_UPDATE
     }
 
+    private class ConfigDebug extends Debug {
+        public ConfigDebug(JavaPlugin plugin, String className, LogLevel level) {
+            super(plugin, className, level);
+        }
+    }
+
+    private final ConfigDebug debug;
     private final JavaPlugin plugin;
     private final File configFile;
     private FileConfiguration config;
@@ -47,65 +58,80 @@ public class AnnounceConfig {
         this.configFile = new File(plugin.getDataFolder(), "announcements.yml");
         this.usingPlaceholderAPI = (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null);
         
-        // Load configuration and determine operation mode
-        boolean configLoaded = loadConfig();
-        this.configOperation = configLoaded ? detectConfigState() : ConfigOperation.FALLBACK_TO_YML;
+        // Initialize debug with default level
+        this.debug = new ConfigDebug(plugin, CLASS_NAME, Debug.LogLevel.INFO);
         
-        // Log the determined configuration operation
-        plugin.getLogger().info("AnnounceConfig Operation: " + configOperation);
+        // Load config and update debug level
+        if (loadConfig()) {
+            String logLevel = config.getString("debug.level", "INFO");
+            debug.setLogLevel(Debug.LogLevel.fromString(logLevel));
+        }
+        
+        // Rest of initialization
+        this.configOperation = detectConfigState();
+        debug.log("AnnounceConfig Operation: " + configOperation);
     }
 
     private ConfigOperation detectConfigState() {
-        plugin.getLogger().info("Detecting config state...");
-        
-        initializeDataStoreConnection();
-        
-        if (dataStore == null) {
-            plugin.getLogger().warning("Database connection failed - dataStore is null");
-            return ConfigOperation.FALLBACK_TO_YML;
-        }
+        debug.log(LogLevel.CONFIG, "Detecting config state...");
 
-        try {
-            plugin.getLogger().info("Attempting database connection...");
-            dataStore.connect();
-            plugin.getLogger().info("Database connection successful");
+        // Initialize database connection first 
+        if (storageType.equalsIgnoreCase("mysql") || storageType.equalsIgnoreCase("sqlite")) {
+            initializeDataStoreConnection();
             
-            boolean dbEmpty = dataStore.isEmpty();
-            plugin.getLogger().info("Database empty check result: " + dbEmpty);
-
-            if (dbEmpty) {
-                plugin.getLogger().info("Empty database detected - will import YAML");
-                return ConfigOperation.IMPORT_YML_TO_NEW_DB;
-            }
-            
-            // Load data from both sources for comparison
-            List<Announcement> dbAnnouncements = dataStore.loadAnnouncements();
-            List<AnnounceType> dbTypes = dataStore.loadAnnounceTypes();
-            
-            if ((dbAnnouncements.isEmpty() || dbTypes.isEmpty()) && 
-                (!ymlAnnouncements.isEmpty() || !ymlTypes.isEmpty())) {
-                plugin.getLogger().info("Database partially empty - will import YAML");
-                return ConfigOperation.IMPORT_YML_TO_NEW_DB;
-            }
-            
-            if (!dbAnnouncements.isEmpty() && !dbTypes.isEmpty()) {
-                if (ymlAnnouncements.isEmpty() || ymlTypes.isEmpty()) {
-                    return ConfigOperation.UPDATE_MISSING_YML_FROM_DB;
+            if (dataStore != null) {
+                try {
+                    debug.log(LogLevel.CONFIG, "Testing database connectivity and state...");
+                    dataStore.connect();
+                    
+                    // Wait briefly for connection to stabilize
+                    Thread.sleep(100);
+                    
+                    // Verify database access
+                    boolean dbEmpty;
+                    try {
+                        dbEmpty = dataStore.isEmpty();
+                        debug.log(LogLevel.FINE, "Database empty check result: " + dbEmpty);
+                        
+                        // Test data access
+                        List<Announcement> testLoad = dataStore.loadAnnouncements();
+                        List<AnnounceType> testTypes = dataStore.loadAnnounceTypes();
+                        
+                        debug.log(LogLevel.FINE, "Database access test - Announcements: " + testLoad.size() + 
+                                              ", Types: " + testTypes.size());
+                        
+                        if (dbEmpty || testLoad.isEmpty() && testTypes.isEmpty()) {
+                            debug.log(LogLevel.CONFIG, "Empty database detected - will import from YAML");
+                            return ConfigOperation.IMPORT_YML_TO_NEW_DB;
+                        }
+                        
+                        if (!testLoad.isEmpty() || !testTypes.isEmpty()) {
+                            if (ymlAnnouncements.isEmpty() && ymlTypes.isEmpty()) {
+                                debug.log(LogLevel.CONFIG, "Using existing database content");
+                                return ConfigOperation.NO_UPDATE;
+                            }
+                            debug.log(LogLevel.CONFIG, "Will merge YAML content into database");
+                            return ConfigOperation.MERGE_YML_INTO_DB;
+                        }
+                    } catch (Exception e) {
+                        debug.error("Database access test failed: " + e.getMessage(), e);
+                        throw e;
+                    }
+                    
+                } catch (Exception e) {
+                    debug.error("Database connectivity test failed", e);
+                    e.printStackTrace();
+                    return ConfigOperation.FALLBACK_TO_YML;
                 }
-                return ConfigOperation.MERGE_YML_INTO_DB;
             }
-
-            return ConfigOperation.FALLBACK_TO_YML;
-            
-        } catch (Exception e) {
-            plugin.getLogger().severe("Database connection/check failed: " + e.getMessage());
-            e.printStackTrace();
-            return ConfigOperation.FALLBACK_TO_YML;
         }
+        
+        debug.log(LogLevel.CONFIG, "No valid database configuration - using YAML storage");
+        return ConfigOperation.FALLBACK_TO_YML;
     }
 
     public void initializeDataStore() {
-        plugin.getLogger().info("AnnounceConfig using " + storageType + " storage");
+        debug.log(LogLevel.INFO, "AnnounceConfig using " + storageType + " storage");
 
         // Initialize DataStore if not already done
         if (dataStore == null) {
@@ -164,10 +190,10 @@ public class AnnounceConfig {
 
             if (isChanged) {
                 saveConfig();
-                plugin.getLogger().info("Saved announcements after import changes");
+                debug.log(LogLevel.INFO, "Saved announcements after import changes");
             }
         } catch (Exception e) {
-            plugin.getLogger().severe("Failed to initialize database: " + e.getMessage());
+            debug.error("Failed to initialize database: " + e.getMessage(), e);
             e.printStackTrace();
             // Fallback to YAML data on database error
             announceManager.setAnnouncements(ymlAnnouncements);
@@ -180,7 +206,7 @@ public class AnnounceConfig {
             Integer dbHash = generateConfigHash(dataStore.loadAnnouncements(), dataStore.loadAnnounceTypes());
             
             if (ymlHash.equals(dbHash)) {
-                plugin.getLogger().info("Database and YAML configurations match (Hash: " + ymlHash + ")");
+                debug.log(LogLevel.INFO, "Database and YAML configurations match (Hash: " + ymlHash + ")");
                 dataStore.disconnect();
                 return true;
             }
@@ -189,70 +215,53 @@ public class AnnounceConfig {
 
     // Generates a hash of the configuration data for comparison
     private Integer generateConfigHash(List<Announcement> announcements, Collection<AnnounceType> types) {
-        List<String> elements = new ArrayList<>();
-        
-        // Add sorted announcement entries
-        for (Announcement a : announcements) {
-            elements.add(String.format("%s:%s:%s:%s",
-                a.getId().toLowerCase(),
-                a.getType().toLowerCase(),
-                a.getText(),
-                a.getPermission() != null ? a.getPermission() : ""));
-        }
-        
-        // Add sorted type entries
-        for (AnnounceType t : types) {
-            elements.add(String.format("%s:%s:%s:%s:%s",
-                t.getId().toLowerCase(),
-                t.getPrefix() != null ? t.getPrefix() : "",
-                t.getSuffix() != null ? t.getSuffix() : "",
-                t.getPermission() != null ? t.getPermission() : "",
-                t.getListingFee() != null ? t.getListingFee().toString() : ""));
-        }
-        
-        // Sort elements for consistent ordering
-        Collections.sort(elements);
-
-        //generate hash of concatenated elements into a string
-        return String.join("|", elements).hashCode();
+        return generateConfigHash(
+            announcements.stream()
+                .collect(Collectors.toMap(Announcement::getId, a -> a)),
+            types
+        );
     }
 
     // Overloaded method to generate hash of configuration data
     private Integer generateConfigHash(List<Announcement> announcements, Map<String, AnnounceType> types) {
-        return generateConfigHash(announcements, types.values());
+        return generateConfigHash(
+            announcements.stream()
+                .collect(Collectors.toMap(Announcement::getId, a -> a)),
+            types.values()
+        );
     }
 
     // Updated hash generation for Map structure
     private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
-        List<String> elements = new ArrayList<>();
-        
-        // Add sorted announcement entries from map
+        StringBuilder hashBuilder = new StringBuilder();
+
+        // Process announcements
         announcements.values().stream()
             .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
-            .forEach(a -> elements.add(String.format("%s:%s:%s:%s",
+            .forEach(a -> hashBuilder.append(String.format("A|%s|%s|%s|%s\n",
                 a.getId().toLowerCase(),
                 a.getType().toLowerCase(),
                 a.getText(),
                 Optional.ofNullable(a.getPermission()).orElse(""))));
-        
-        // Add sorted type entries
+
+        // Process types
         types.stream()
             .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
-            .forEach(t -> elements.add(String.format("%s:%s:%s:%s:%s",
+            .forEach(t -> hashBuilder.append(String.format("T|%s|%s|%s|%s|%s\n",
                 t.getId().toLowerCase(),
                 Optional.ofNullable(t.getPrefix()).orElse(""),
                 Optional.ofNullable(t.getSuffix()).orElse(""),
                 Optional.ofNullable(t.getPermission()).orElse(""),
                 Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""))));
 
-        return String.join("|", elements).hashCode();
+        return hashBuilder.toString().hashCode();
     }
 
     // Loads or creates the YAML configuration file
     public boolean loadConfig() {
         if (!configFile.exists()) {
             plugin.saveResource("announcements.yml", false);
-            plugin.getLogger().info("Created default announcements.yml");
+            debug.log(LogLevel.INFO, "Created default announcements.yml");
         }
 
         config = YamlConfiguration.loadConfiguration(configFile);        
@@ -287,9 +296,9 @@ public class AnnounceConfig {
             if (!existingTypeIds.contains(type.getId().toLowerCase())) {
                 try {                    
                     dataStore.saveAnnounceType(type);                    
-                    plugin.getLogger().info("Imported announce type: " + type.getId());                    
+                    debug.log(LogLevel.INFO, "Imported announce type: " + type.getId());                    
                 } catch (Exception e) {
-                    plugin.getLogger().warning("Error saving announce type: " + type.getId());
+                    debug.log(LogLevel.WARNING, "Error saving announce type: " + type.getId());
                     e.printStackTrace();
                 }
             }
@@ -306,9 +315,9 @@ public class AnnounceConfig {
                 try {
                     announceManager.addAnnouncement(announcement);
                     successfulImports.add(announcement.getId().toLowerCase());              
-                    plugin.getLogger().info("Imported announcement: " + announcement.getId());
+                    debug.log(LogLevel.INFO, "Imported announcement: " + announcement.getId());
                 } catch (Exception e) {
-                    plugin.getLogger().warning("Error importing announcement " + announcement.getId() + ": " + e.getMessage());
+                    debug.log(LogLevel.WARNING, "Error importing announcement " + announcement.getId() + ": " + e.getMessage());
                     e.printStackTrace();
                 }
             }            
@@ -336,17 +345,17 @@ public class AnnounceConfig {
         for (AnnounceType type : ymlTypes.values()) {
             try {
                 if (type.getId() == null) {
-                    plugin.getLogger().warning("Skipping announce type with null ID");
+                    debug.log(LogLevel.WARNING, "Skipping announce type with null ID");
                     continue;
                 }
                 
                 if (!dataStore.loadAnnounceTypes().stream()
                         .anyMatch(t -> t.getId().equalsIgnoreCase(type.getId()))) {
                     dataStore.saveAnnounceType(type);
-                    plugin.getLogger().info("Imported announce type: " + type.getId());
+                    debug.log(LogLevel.INFO, "Imported announce type: " + type.getId());
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Failed to import announce type " + type.getId() + ": " + e.getMessage());
+                debug.log(LogLevel.WARNING, "Failed to import announce type " + type.getId() + ": " + e.getMessage());
             }
         }
 
@@ -361,7 +370,7 @@ public class AnnounceConfig {
                     needsSaving = true;
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Failed to import announcement " + announcement.getId() + ": " + e.getMessage());
+                debug.log(LogLevel.WARNING, "Failed to import announcement " + announcement.getId() + ": " + e.getMessage());
             }
         }
 
@@ -379,7 +388,7 @@ public class AnnounceConfig {
     private List<Announcement> loadDataFromYAML() {
         List<Announcement> announcements = new ArrayList<>();
         if (!configFile.exists()) {
-            plugin.getLogger().warning("Config file does not exist: " + configFile.getName());
+            debug.log(LogLevel.WARNING, "Config file does not exist: " + configFile.getName());
             return announcements;
         }
 
@@ -391,14 +400,14 @@ public class AnnounceConfig {
                 Announcement announcement = parseAnnouncement(map);
                 if (announcement != null && announcement.getId() != null) {
                     if (usedIds.contains(announcement.getId().toLowerCase())) {
-                        plugin.getLogger().warning("Duplicate announcement ID found: " + announcement.getId());
+                        debug.log(LogLevel.WARNING, "Duplicate announcement ID found: " + announcement.getId());
                         continue;
                     }
                     usedIds.add(announcement.getId().toLowerCase());
                     announcements.add(announcement);
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Error parsing announcement: " + e.getMessage());
+                debug.log(LogLevel.WARNING, "Error parsing announcement: " + e.getMessage());
             }
         }
         return announcements;
@@ -416,14 +425,14 @@ public class AnnounceConfig {
                 }
             }
         } else {
-            plugin.getLogger().warning("Config file not found: " + configFile.getName());
+            debug.log(LogLevel.WARNING, "Config file not found: " + configFile.getName());
         }
         return types;
     }
 
     // Creates appropriate DataStore instance based on configuration settings
     private void initializeDataStoreConnection() {
-        plugin.getLogger().info("Initializing data store connection with type: " + storageType);
+        debug.log(LogLevel.INFO, "Initializing data store connection with type: " + storageType);
         
         if (storageType.equalsIgnoreCase("mysql")) {
             String host = config.getString("storage.mysql.host", "");
@@ -433,18 +442,18 @@ public class AnnounceConfig {
             String password = config.getString("storage.mysql.password", "");
             boolean useSSL = config.getBoolean("storage.mysql.useSSL", false);
             
-            plugin.getLogger().info("MySQL configuration - Host: " + host + ", Port: " + port + 
+            debug.log(LogLevel.INFO, "MySQL configuration - Host: " + host + ", Port: " + port + 
                 ", Database: " + database + ", Username: " + username + 
                 ", SSL: " + useSSL);
             
             if (host.isEmpty() || database.isEmpty() || username.isEmpty()) {
-                plugin.getLogger().severe("Invalid MySQL configuration - missing required fields");
+                debug.log(LogLevel.SEVERE, "Invalid MySQL configuration - missing required fields");
                 dataStore = null;
                 return;
             }
             
-            dataStore = new MySQLDataConnector(host, port, database, username, password, useSSL);
-            plugin.getLogger().info("MySQL connector created successfully");
+            dataStore = new MySQLDataConnector(plugin, host, port, database, username, password, useSSL);
+            debug.log(LogLevel.INFO, "MySQL connector created successfully");
         } else if (storageType.equalsIgnoreCase("sqlite")) {
             String databasePath = config.getString("storage.sqlite.database", "announcements.db");
             dataStore = new SQLiteDataConnector(plugin, databasePath);
@@ -453,7 +462,7 @@ public class AnnounceConfig {
         }
         
         if (dataStore == null) {
-            plugin.getLogger().warning("Failed to initialize data store - unknown or invalid storage type");
+            debug.log(LogLevel.WARNING, "Failed to initialize data store - unknown or invalid storage type");
         }
     }
 
@@ -522,7 +531,7 @@ public class AnnounceConfig {
                         recurrenceSeconds = Long.parseLong(recStr);
                     }
                 } catch (NumberFormatException e) {
-                    plugin.getLogger().warning("Invalid recurrence format for announcement " + id + ": " + recStr);
+                    debug.log(LogLevel.WARNING, "Invalid recurrence format for announcement " + id + ": " + recStr);
                 }
             }
         }
@@ -536,7 +545,7 @@ public class AnnounceConfig {
 
         // Check if PlaceholderAPI is used and available
         if (text.contains("%") && !usingPlaceholderAPI) {
-            plugin.getLogger().warning("PlaceholderAPI not found, unable to parse placeholders in announcement: " + id);
+            debug.log(LogLevel.WARNING, "PlaceholderAPI not found, unable to parse placeholders in announcement: " + id);
             return null;
         }
 
@@ -591,22 +600,22 @@ public class AnnounceConfig {
     // New validation method
     private boolean validateAnnouncement(Announcement announcement) {
         if (announcement == null) {
-            plugin.getLogger().warning("Null announcement found during validation");
+            debug.log(LogLevel.WARNING, "Null announcement found during validation");
             return false;
         }
 
         if (announcement.getId() == null || announcement.getId().trim().isEmpty()) {
-            plugin.getLogger().warning("Invalid announcement: missing ID");
+            debug.log(LogLevel.WARNING, "Invalid announcement: missing ID");
             return false;
         }
 
         if (announcement.getText() == null || announcement.getText().trim().isEmpty()) {
-            plugin.getLogger().warning("Invalid announcement: missing text for ID " + announcement.getId());
+            debug.log(LogLevel.WARNING, "Invalid announcement: missing text for ID " + announcement.getId());
             return false;
         }
 
         if (announcement.getType() == null || announcement.getType().trim().isEmpty()) {
-            plugin.getLogger().warning("Invalid announcement: missing type for ID " + announcement.getId());
+            debug.log(LogLevel.WARNING, "Invalid announcement: missing type for ID " + announcement.getId());
             return false;
         }
 
@@ -630,13 +639,13 @@ public class AnnounceConfig {
 
         // Get a snapshot of announcements to avoid concurrent modification
         Collection<Announcement> currentAnnouncements = new ArrayList<>(announceManager.getAnnouncements());
-        plugin.getLogger().info("Saving " + currentAnnouncements.size() + " announcements to file");
+        debug.log(LogLevel.INFO, "Saving " + currentAnnouncements.size() + " announcements to file");
 
         for (Announcement announcement : currentAnnouncements) {
             try {
                 // Validate required fields
                 if (announcement.getId() == null || announcement.getType() == null || announcement.getText() == null) {
-                    plugin.getLogger().warning("Skipping invalid announcement: " + announcement.getId());
+                    debug.log(LogLevel.WARNING, "Skipping invalid announcement: " + announcement.getId());
                     continue;
                 }
 
@@ -660,12 +669,12 @@ public class AnnounceConfig {
                 map.put("imported", announcement.isImported());
                 announcementMaps.add(map);
             } catch (Exception e) {
-                plugin.getLogger().severe("Error saving announcement " + announcement.getId() + ": " + e.getMessage());
+                debug.error("Error saving announcement " + announcement.getId() + ": " + e.getMessage(), e);
             }
         }
 
         if (announcementMaps.isEmpty()) {
-            plugin.getLogger().warning("No valid announcements to save");
+            debug.log(LogLevel.WARNING, "No valid announcements to save");
             return;
         }
 
@@ -673,7 +682,7 @@ public class AnnounceConfig {
             config.set("announcements", announcementMaps);
             config.save(configFile);
         } catch (IOException e) {
-            plugin.getLogger().severe("Failed to save announcements: " + e.getMessage());
+            debug.error("Failed to save announcements: " + e.getMessage(), e);
             e.printStackTrace();
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -153,6 +153,32 @@ public class AnnounceConfig {
         return generateConfigHash(announcements, types.values());
     }
 
+    // Updated hash generation for Map structure
+    private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
+        List<String> elements = new ArrayList<>();
+        
+        // Add sorted announcement entries from map
+        announcements.values().stream()
+            .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
+            .forEach(a -> elements.add(String.format("%s:%s:%s:%s",
+                a.getId().toLowerCase(),
+                a.getType().toLowerCase(),
+                a.getText(),
+                Optional.ofNullable(a.getPermission()).orElse(""))));
+        
+        // Add sorted type entries
+        types.stream()
+            .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
+            .forEach(t -> elements.add(String.format("%s:%s:%s:%s:%s",
+                t.getId().toLowerCase(),
+                Optional.ofNullable(t.getPrefix()).orElse(""),
+                Optional.ofNullable(t.getSuffix()).orElse(""),
+                Optional.ofNullable(t.getPermission()).orElse(""),
+                Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""))));
+
+        return String.join("|", elements).hashCode();
+    }
+
     // Loads or creates the YAML configuration file
     public boolean loadConfig() {
         if (!configFile.exists()) {
@@ -304,16 +330,78 @@ public class AnnounceConfig {
         return needsSaving;
     }
 
-    // Reads and parses announcement data from YAML configuration
+    // Updated import method for Map structure
+    private boolean importYML(Map<String, Announcement> ymlAnnouncements, Map<String, AnnounceType> ymlTypes) {
+        boolean needsSaving = false;
+        Set<String> importedIds = new HashSet<>();
+
+        // Import types first with validation
+        for (AnnounceType type : ymlTypes.values()) {
+            try {
+                if (type.getId() == null) {
+                    plugin.getLogger().warning("Skipping announce type with null ID");
+                    continue;
+                }
+                
+                if (!dataStore.loadAnnounceTypes().stream()
+                        .anyMatch(t -> t.getId().equalsIgnoreCase(type.getId()))) {
+                    dataStore.saveAnnounceType(type);
+                    plugin.getLogger().info("Imported announce type: " + type.getId());
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to import announce type " + type.getId() + ": " + e.getMessage());
+            }
+        }
+
+        // Import announcements with validation
+        for (Announcement announcement : ymlAnnouncements.values()) {
+            try {
+                if (validateAnnouncement(announcement) && 
+                    !dataStore.announcementExists(announcement.getId())) {
+                    
+                    announceManager.addAnnouncement(announcement);
+                    importedIds.add(announcement.getId().toLowerCase());
+                    needsSaving = true;
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to import announcement " + announcement.getId() + ": " + e.getMessage());
+            }
+        }
+
+        // Mark successful imports
+        if (!importedIds.isEmpty()) {
+            ymlAnnouncements.values().stream()
+                .filter(a -> importedIds.contains(a.getId().toLowerCase()))
+                .forEach(Announcement::setImported);
+        }
+
+        return needsSaving;
+    }
+
+    // Updated YAML loading with better error handling
     private List<Announcement> loadDataFromYAML() {
         List<Announcement> announcements = new ArrayList<>();
-        if (configFile.exists()) {
-            List<Map<?, ?>> announcementMaps = config.getMapList("announcements");
-            for (Map<?, ?> map : announcementMaps) {
+        if (!configFile.exists()) {
+            plugin.getLogger().warning("Config file does not exist: " + configFile.getName());
+            return announcements;
+        }
+
+        List<Map<?, ?>> announcementMaps = config.getMapList("announcements");
+        Set<String> usedIds = new HashSet<>();
+        
+        for (Map<?, ?> map : announcementMaps) {
+            try {
                 Announcement announcement = parseAnnouncement(map);
-                if (announcement != null) {
+                if (announcement != null && announcement.getId() != null) {
+                    if (usedIds.contains(announcement.getId().toLowerCase())) {
+                        plugin.getLogger().warning("Duplicate announcement ID found: " + announcement.getId());
+                        continue;
+                    }
+                    usedIds.add(announcement.getId().toLowerCase());
                     announcements.add(announcement);
                 }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Error parsing announcement: " + e.getMessage());
             }
         }
         return announcements;
@@ -503,6 +591,31 @@ public class AnnounceConfig {
         return announceType;
     }
 
+    // New validation method
+    private boolean validateAnnouncement(Announcement announcement) {
+        if (announcement == null) {
+            plugin.getLogger().warning("Null announcement found during validation");
+            return false;
+        }
+
+        if (announcement.getId() == null || announcement.getId().trim().isEmpty()) {
+            plugin.getLogger().warning("Invalid announcement: missing ID");
+            return false;
+        }
+
+        if (announcement.getText() == null || announcement.getText().trim().isEmpty()) {
+            plugin.getLogger().warning("Invalid announcement: missing text for ID " + announcement.getId());
+            return false;
+        }
+
+        if (announcement.getType() == null || announcement.getType().trim().isEmpty()) {
+            plugin.getLogger().warning("Invalid announcement: missing type for ID " + announcement.getId());
+            return false;
+        }
+
+        return true;
+    }
+
     // Persists player preferences for disabled announcement types
     public void savePlayerDisabledTypes() {
         preferences.savePreferences();
@@ -516,76 +629,55 @@ public class AnnounceConfig {
 
     // Persists announcements and announcement types to YAML configuration
     public void saveConfig() {
-        // Create a list to hold the announcements data
         List<Map<String, Object>> announcementMaps = new ArrayList<>();
 
-        plugin.getLogger().info("Saving " + announceManager.getAnnouncements().size() + " announcements to file");
+        // Get a snapshot of announcements to avoid concurrent modification
+        Collection<Announcement> currentAnnouncements = new ArrayList<>(announceManager.getAnnouncements());
+        plugin.getLogger().info("Saving " + currentAnnouncements.size() + " announcements to file");
 
-        for (Announcement announcement : announceManager.getAnnouncements()) {
-            // Ensure required fields are not null
-            if (announcement.getId() == null || announcement.getType() == null || announcement.getText() == null) {
-                plugin.getLogger().warning("Skipping announcement due to missing required fields: " + announcement.getId());
-                continue;
-            }
+        for (Announcement announcement : currentAnnouncements) {
+            try {
+                // Validate required fields
+                if (announcement.getId() == null || announcement.getType() == null || announcement.getText() == null) {
+                    plugin.getLogger().warning("Skipping invalid announcement: " + announcement.getId());
+                    continue;
+                }
 
-            Map<String, Object> map = new LinkedHashMap<>();
-            map.put("id", announcement.getId());
-            map.put("text", announcement.getText());
-            map.put("type", announcement.getType());
+                Map<String, Object> map = new LinkedHashMap<>();
+                map.put("id", announcement.getId());
+                map.put("text", announcement.getText());
+                map.put("type", announcement.getType());
 
-            // Add optional fields only if they are not null
-            if (announcement.getRecurrence() != null) {
-                map.put("recurrence", announcement.getRecurrence());
-            }
-            if (announcement.getOwner() != null) {
-                map.put("owner", announcement.getOwner());
-            }
-            if (announcement.getPermission() != null) {
-                map.put("permission", announcement.getPermission());
-            }
-            if (announcement.getDate() != null) {
-                map.put("date", announcement.getDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-            }
-            if (announcement.getTime() != null) {
-                map.put("time", announcement.getTime().format(DateTimeFormatter.ofPattern("HHmm")));
-            }
-            
-            // Add the imported flag
-            map.put("imported", announcement.isImported());
+                // Optional fields
+                Optional.ofNullable(announcement.getRecurrence()).ifPresent(r -> map.put("recurrence", r));
+                Optional.ofNullable(announcement.getOwner()).ifPresent(o -> map.put("owner", o));
+                Optional.ofNullable(announcement.getPermission()).ifPresent(p -> map.put("permission", p));
 
-            announcementMaps.add(map);
+                if (announcement.getDate() != null) {
+                    map.put("date", announcement.getDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                }
+                if (announcement.getTime() != null) {
+                    map.put("time", announcement.getTime().format(DateTimeFormatter.ofPattern("HHmm")));
+                }
+                
+                map.put("imported", announcement.isImported());
+                announcementMaps.add(map);
+            } catch (Exception e) {
+                plugin.getLogger().severe("Error saving announcement " + announcement.getId() + ": " + e.getMessage());
+            }
         }
 
-        // Check if announcementMaps is empty
         if (announcementMaps.isEmpty()) {
-            plugin.getLogger().warning("Announcements list is empty. Not saving announcements to config file.");
-            return; // Do not save empty announcements
+            plugin.getLogger().warning("No valid announcements to save");
+            return;
         }
-
-        // Set the 'announcements' section in the config
-        config.set("announcements", announcementMaps);
-        
-        // Create a list to hold the announce types data
-        List<Map<String, Object>> announceTypeMaps = new ArrayList<>();
-        
-        for (AnnounceType type : announceTypes.values()) {
-            Map<String, Object> map = new LinkedHashMap<>();
-            map.put("id", type.getId());
-            map.put("prefix", type.getPrefix());
-            map.put("suffix", type.getSuffix());
-            if (type.getListingFee() != null) {
-                map.put("list_fee", type.getListingFee());
-            }
-            map.put("permission", type.getPermission());            
-            announceTypeMaps.add(map);
-        }
-
-        config.set("announce_types", announceTypeMaps);
 
         try {
-            config.save(configFile);            
+            config.set("announcements", announcementMaps);
+            config.save(configFile);
         } catch (IOException e) {
-            plugin.getLogger().warning("Failed to save announcements to file: " + e.getMessage());
+            plugin.getLogger().severe("Failed to save announcements: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -20,14 +20,14 @@ public class AnnounceManager {
     private final AnnounceScheduler announceScheduler;
     private final ChatServiceInterface chatService;    
     boolean usingPlaceholderAPI;    
-    private List<Announcement> announcements;
+    private Map<String, Announcement> announcements;
 
     public AnnounceManager(RVNKTools plugin) {
         plugin.getLogger().info("Enabling AnnounceManager.");
         this.plugin = plugin;
         this.chatService = new ChatService();
         this.usingPlaceholderAPI = plugin.getServer().getPluginManager().getPlugin("PlaceholderAPI") != null;
-        this.announcements = new ArrayList<>();
+        this.announcements = new HashMap<>();
         this.announceConfig = new AnnounceConfig(plugin, this);
         this.announceConfig.initializeDataStore();
         this.announceScheduler = new AnnounceScheduler(plugin, this);
@@ -63,7 +63,7 @@ public class AnnounceManager {
                 setImported(announcement.getId());
                 // fall through
             case ADD_ANNOUNCEMENT:
-                announcements.add(announcement);
+                announcements.put(announcement.getId(), announcement);
                 return true;
             default:
                 return false;
@@ -72,11 +72,9 @@ public class AnnounceManager {
 
     // private setImported method
     private void setImported(String id) {
-        for (Announcement a : announcements) {
-            if (a.getId().equalsIgnoreCase(id)) {
-                a.setImported();
-                break;
-            }
+        Announcement announcement = announcements.get(id);
+        if (announcement != null) {
+            announcement.setImported();
         }
     }
 
@@ -195,8 +193,8 @@ public class AnnounceManager {
             announceConfig.getDataStore().deleteAnnouncement(id);
         }
 
-        boolean removed = announcements.removeIf(announcement -> announcement.getId().equalsIgnoreCase(id));
-        if (removed) {
+        Announcement removed = announcements.remove(id);
+        if (removed != null) {
             plugin.getLogger().info("Deleted announcement: " + id);
             announceConfig.saveConfig();
             return true;
@@ -291,19 +289,18 @@ public class AnnounceManager {
     }
 
     public Set<String> getAnnouncementIds() {
-        Set<String> ids = new HashSet<>();
-        for (Announcement announcement : this.announcements) {
-            ids.add(announcement.getId());
-        }
-        return ids;
+        return announcements.keySet();
     }
 
     public List<Announcement> getAnnouncements() {
-        return announcements;
+        return new ArrayList<>(announcements.values());
     }
 
     public void setAnnouncements(List<Announcement> announcements) {
-        this.announcements = announcements;
+        this.announcements = new HashMap<>();
+        for (Announcement announcement : announcements) {
+            this.announcements.put(announcement.getId(), announcement);
+        }
     }
 
     public void savePlayerDisabledTypes() {
@@ -311,11 +308,10 @@ public class AnnounceManager {
     }
 
     public boolean sendAnnouncementNow(Player player, String id) {
-        for (Announcement announcement : this.announcements) {
-            if (announcement.getId().equalsIgnoreCase(id)) {
-                broadcastAnnouncement(announcement);
-                return true;
-            }
+        Announcement announcement = announcements.get(id);
+        if (announcement != null) {
+            broadcastAnnouncement(announcement);
+            return true;
         }
         return false;
     }
@@ -326,11 +322,9 @@ public class AnnounceManager {
 
     public boolean announcementExists(String id) {
         // First check in memory
-        for (Announcement announcement : announcements) {
-            if (announcement.getId().equalsIgnoreCase(id)) {
-                plugin.getLogger().info("Announcement with ID '" + id + "' found in memory");
-                return true;
-            }
+        if (announcements.containsKey(id)) {
+            plugin.getLogger().info("Announcement with ID '" + id + "' found in memory");
+            return true;
         }
 
         // Then check in database if available
@@ -346,26 +340,20 @@ public class AnnounceManager {
     }
 
     public void setAnnouncementImported(String id) {
-        for (Announcement announcement : announcements) {
-            if (announcement.getId().equalsIgnoreCase(id)) {
-                announcement.setImported();         
-                break;
-            }
+        Announcement announcement = announcements.get(id);
+        if (announcement != null) {
+            announcement.setImported();
         }
     }
 
     public void setAnnouncementsImported() {
-        for (Announcement announcement : announcements) {
+        for (Announcement announcement : announcements.values()) {
             announcement.setImported();
         }
     }
 
     public boolean isAnnouncementImported(String id) {
-        for (Announcement announcement : announcements) {
-            if (announcement.getId().equalsIgnoreCase(id)) {
-                return announcement.isImported();
-            }
-        }
-        return false;
+        Announcement announcement = announcements.get(id);
+        return announcement != null && announcement.isImported();
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -73,14 +73,6 @@ public class AnnounceManager {
         }
     }
 
-    // private setImported method
-    private void setImported(String id) {
-        Announcement announcement = announcements.get(id);
-        if (announcement != null) {
-            announcement.setImported();
-        }
-    }
-
     // Add an announcement to the announcements list, used by AnnounceCommand
     public boolean addAnnouncement(Player player, String input) {
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -41,27 +41,31 @@ public class AnnounceManager {
 
     // Add an announcement to the announcements list, used by AnnounceConfig and AnnounceManager.parseAnnouncement()
     public boolean addAnnouncement(Announcement announcement) {
-        if (announcement == null) {
-            plugin.getLogger().warning("Cannot add null announcement");
-            return false;
-        }
-        if (announcement.getId() == null) {
-            plugin.getLogger().warning("Cannot add announcement with null ID");
+        if (announcement == null || announcement.getId() == null) {
+            plugin.getLogger().warning("Cannot add invalid announcement");
             return false;
         }
 
-        // Check for existing announcement
-        if (announcements.containsKey(announcement.getId())) {
-            plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
+        String id = announcement.getId().toLowerCase();
+        // Check for existing announcement in memory first
+        if (announcements.containsKey(id)) {
+            plugin.getLogger().warning("Announcement with ID '" + id + "' already exists in memory");
             return false;
         }
 
         try {
+            // Only save to database if not imported and database exists
             if (announceConfig.getDataStore() != null && !announcement.isImported()) {
+                // Check database before saving
+                if (announceConfig.getDataStore().announcementExists(id)) {
+                    plugin.getLogger().warning("Announcement with ID '" + id + "' already exists in database");
+                    return false;
+                }
                 announceConfig.getDataStore().saveAnnouncement(announcement);
                 announcement.setImported();
             }
-            announcements.put(announcement.getId(), announcement);
+            
+            announcements.put(id, announcement);
             return true;
         } catch (Exception e) {
             plugin.getLogger().warning("Failed to add announcement: " + e.getMessage());

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import org.fourz.rvnktools.RVNKTools;
 import org.fourz.rvnktools.util.ChatServiceInterface;
 import org.fourz.rvnktools.util.ChatService;
@@ -20,14 +21,13 @@ public class AnnounceManager {
     private final AnnounceScheduler announceScheduler;
     private final ChatServiceInterface chatService;    
     boolean usingPlaceholderAPI;    
-    private Map<String, Announcement> announcements;
+    private final Map<String, Announcement> announcements = new ConcurrentHashMap<>();
 
     public AnnounceManager(RVNKTools plugin) {
         plugin.getLogger().info("Enabling AnnounceManager.");
         this.plugin = plugin;
         this.chatService = new ChatService();
         this.usingPlaceholderAPI = plugin.getServer().getPluginManager().getPlugin("PlaceholderAPI") != null;
-        this.announcements = new HashMap<>();
         this.announceConfig = new AnnounceConfig(plugin, this);
         this.announceConfig.initializeDataStore();
         this.announceScheduler = new AnnounceScheduler(plugin, this);
@@ -41,32 +41,31 @@ public class AnnounceManager {
 
     // Add an announcement to the announcements list, used by AnnounceConfig and AnnounceManager.parseAnnouncement()
     public boolean addAnnouncement(Announcement announcement) {
-        CheckCondition condition;
-
         if (announcement == null) {
             plugin.getLogger().warning("Cannot add null announcement");
             return false;
-        } else if (announceConfig.getDataStore() != null && !announcement.isImported()) {
-            condition = checkAnnounceExist(announcement.getId()) ? 
-            CheckCondition.ANNOUNCEMENT_EXISTS : 
-            CheckCondition.SAVE_ANNOUNCEMENT;
-        } else {
-            condition = CheckCondition.ADD_ANNOUNCEMENT;
+        }
+        if (announcement.getId() == null) {
+            plugin.getLogger().warning("Cannot add announcement with null ID");
+            return false;
         }
 
-        switch (condition) {
-            case ANNOUNCEMENT_EXISTS:
-                plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
-                return false;
-            case SAVE_ANNOUNCEMENT:
+        // Check for existing announcement
+        if (announcements.containsKey(announcement.getId())) {
+            plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
+            return false;
+        }
+
+        try {
+            if (announceConfig.getDataStore() != null && !announcement.isImported()) {
                 announceConfig.getDataStore().saveAnnouncement(announcement);
-                setImported(announcement.getId());
-                // fall through
-            case ADD_ANNOUNCEMENT:
-                announcements.put(announcement.getId(), announcement);
-                return true;
-            default:
-                return false;
+                announcement.setImported();
+            }
+            announcements.put(announcement.getId(), announcement);
+            return true;
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to add announcement: " + e.getMessage());
+            return false;
         }
     }
 
@@ -180,28 +179,33 @@ public class AnnounceManager {
     }
 
     public boolean deleteAnnouncement(String id) {
-        if (id == null || id.isEmpty()) {
-            plugin.getLogger().warning("Cannot delete announcement with null or empty id");
+        if (id == null) {
+            plugin.getLogger().warning("Cannot delete announcement with null ID");
             return false;
         }
 
-        if (announceConfig.getDataStore() != null) {
-            if (!announceConfig.getDataStore().announcementExists(id)) {
-                plugin.getLogger().warning("Announcement with ID '" + id + "' does not exist");
-                return false;
+        try {
+            if (announceConfig.getDataStore() != null) {
+                if (!announceConfig.getDataStore().announcementExists(id)) {
+                    plugin.getLogger().warning("Announcement with ID '" + id + "' does not exist");
+                    return false;
+                }
+                announceConfig.getDataStore().deleteAnnouncement(id);
             }
-            announceConfig.getDataStore().deleteAnnouncement(id);
-        }
 
-        Announcement removed = announcements.remove(id);
-        if (removed != null) {
-            plugin.getLogger().info("Deleted announcement: " + id);
-            announceConfig.saveConfig();
-            return true;
-        }
+            Announcement removed = announcements.remove(id);
+            if (removed != null) {
+                plugin.getLogger().info("Deleted announcement: " + id);
+                announceConfig.saveConfig();
+                return true;
+            }
 
-        plugin.getLogger().warning("Could not find announcement with id: " + id);
-        return false;
+            plugin.getLogger().warning("Could not find announcement with ID: " + id);
+            return false;
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to delete announcement: " + e.getMessage());
+            return false;
+        }
     }
 
     public void toggleAnnouncementType(Player player, String type) {
@@ -296,10 +300,18 @@ public class AnnounceManager {
         return new ArrayList<>(announcements.values());
     }
 
-    public void setAnnouncements(List<Announcement> announcements) {
-        this.announcements = new HashMap<>();
-        for (Announcement announcement : announcements) {
-            this.announcements.put(announcement.getId(), announcement);
+    public void setAnnouncements(List<Announcement> announcementList) {
+        if (announcementList == null) {
+            plugin.getLogger().warning("Skipping null announcement list");
+            return;
+        }
+        announcements.clear();
+        for (Announcement announcement : announcementList) {
+            if (announcement.getId() == null) {
+                plugin.getLogger().warning("Skipping announcement with null ID");
+                continue;
+            }
+            announcements.put(announcement.getId(), announcement);
         }
     }
 
@@ -309,11 +321,12 @@ public class AnnounceManager {
 
     public boolean sendAnnouncementNow(Player player, String id) {
         Announcement announcement = announcements.get(id);
-        if (announcement != null) {
-            broadcastAnnouncement(announcement);
-            return true;
+        if (announcement == null) {
+            plugin.getLogger().warning("Cannot send announcement: No announcement found with ID " + id);
+            return false;
         }
-        return false;
+        broadcastAnnouncement(announcement);
+        return true;
     }
 
     public AnnounceType getAnnounceType(String type) {
@@ -355,5 +368,13 @@ public class AnnounceManager {
     public boolean isAnnouncementImported(String id) {
         Announcement announcement = announcements.get(id);
         return announcement != null && announcement.isImported();
+    }
+
+    public Announcement getAnnouncement(String id) {
+        if (id == null) {
+            plugin.getLogger().warning("Cannot get announcement with null ID");
+            return null;
+        }
+        return announcements.get(id);
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -245,10 +245,16 @@ public class AnnounceManager {
     }    
 
     public void shutdown() {    
+        plugin.getLogger().info("Saving announcements before shutdown...");
+        // Ensure we have all announcements in memory
+        if (announceConfig.getDataStore() != null) {
+            setAnnouncements(announceConfig.getDataStore().loadAnnouncements());
+        }
         saveConfig();    
         announceScheduler.shutdown();
         savePlayerDisabledTypes();
-        announceConfig.shutdown(); // Disconnect the DataStore during shutdown
+        announceConfig.shutdown();
+        plugin.getLogger().info("AnnounceManager shutdown complete");
     }
 
     public boolean validateAnnounceType(String type) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -36,37 +36,59 @@ public class AnnounceManager {
     }
 
     // Add an announcement to the announcements list, used by AnnounceConfig
-    public boolean addAnnouncement(Announcement announcement) {        
+    public boolean addAnnouncement(Announcement announcement) {
+        // Determine the condition code based on the announcement state
+        String conditionCode;
 
         if (announcement == null) {
-            plugin.getLogger().warning("Cannot add null announcement");
-            return false;
-        }
-
-        //log to console        
-        plugin.getLogger().info("Adding announcement: " + announcement.getId() + " (" + announcement.getType() + ")");        
-
-        if (announceConfig.getDataStore() != null && !announcement.isImported()) {
-            ////announceConfig.getDataStore().connect();
+            // Condition when the announcement is null
+            conditionCode = "NULL_ANNOUNCEMENT";
+        } else if (announceConfig.getDataStore() != null && !announcement.isImported()) {
+            // Condition when there's a data store and the announcement is not imported
             if (announceConfig.getDataStore().announcementExists(announcement.getId())) {
-                plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
-                ////announceConfig.getDataStore().disconnect();
-                return false;
+                // Condition when the announcement already exists in the data store
+                conditionCode = "ANNOUNCEMENT_EXISTS";
+            } else {
+                // Condition when the announcement needs to be saved to the data store
+                conditionCode = "SAVE_ANNOUNCEMENT";
             }
-            announceConfig.getDataStore().saveAnnouncement(announcement);
-                        
-            //set as imported in the announcements list
-            setImported(announcement.getId());
-            plugin.getLogger().info("Marked announcement as imported: " + announcement.getId());
-
-            ////announceConfig.getDataStore().disconnect();
+        } else {
+            // Default condition to add the announcement
+            conditionCode = "ADD_ANNOUNCEMENT";
         }
 
-        announcements.add(announcement);
-        plugin.getLogger().info("Added announcement: " + announcement.getId() + " (" + announcement.getType() + ")");
-        return true;
-    }
+        // Handle each condition using a switch statement
+        switch (conditionCode) {
+            case "NULL_ANNOUNCEMENT":
+                // Cannot add a null announcement
+                plugin.getLogger().warning("Cannot add null announcement");
+                return false;
 
+            case "ANNOUNCEMENT_EXISTS":
+                // Announcement with this ID already exists in the data store
+                plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
+                return false;
+
+            case "SAVE_ANNOUNCEMENT":
+                // Save the announcement to the data store and mark as imported
+                announceConfig.getDataStore().saveAnnouncement(announcement);
+                setImported(announcement.getId());
+                plugin.getLogger().info("Marked announcement as imported: " + announcement.getId());
+                // Proceed to add the announcement
+                // (No break to continue to ADD_ANNOUNCEMENT case)
+
+            case "ADD_ANNOUNCEMENT":
+                // Add the announcement to the list and log the addition
+                announcements.add(announcement);
+                plugin.getLogger().info("Added announcement: " + announcement.getId() + " (" + announcement.getType() + ")");
+                return true;
+
+            default:
+                // Unexpected condition
+                plugin.getLogger().warning("Unexpected condition in addAnnouncement");
+                return false;
+        }
+    }
 
     // private setImported method
     private void setImported(String id) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -65,14 +65,11 @@ public class AnnounceManager {
                 plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
                 return false;
             case SAVE_ANNOUNCEMENT:
-                announceConfig.getDataStore().connect();
                 announceConfig.getDataStore().saveAnnouncement(announcement);
-                    announceConfig.getDataStore().disconnect();
                 setImported(announcement.getId());
                 // Fall through to ADD_ANNOUNCEMENT
             case ADD_ANNOUNCEMENT:
                 announcements.add(announcement);
-                plugin.getLogger().info("Added announcement: " + announcement.getId() + " (" + announcement.getType() + ")");
                 return true;
             default:
                 return false;
@@ -147,10 +144,7 @@ public class AnnounceManager {
     }
 
     private boolean checkAnnounceExist(String id) {
-        announceConfig.getDataStore().connect();
-        boolean exists = announceConfig.getDataStore().announcementExists(id);
-        announceConfig.getDataStore().disconnect();
-        return exists;
+        return announceConfig.getDataStore().announcementExists(id);
     }
 
     public void broadcastAnnouncement(Announcement announcement) {      
@@ -200,14 +194,11 @@ public class AnnounceManager {
         }
 
         if (announceConfig.getDataStore() != null) {
-            announceConfig.getDataStore().connect();
             if (!announceConfig.getDataStore().announcementExists(id)) {
                 plugin.getLogger().warning("Announcement with ID '" + id + "' does not exist");
-                announceConfig.getDataStore().disconnect();
                 return false;
             }
             announceConfig.getDataStore().deleteAnnouncement(id);
-            announceConfig.getDataStore().disconnect();
         }
 
         boolean removed = announcements.removeIf(announcement -> announcement.getId().equalsIgnoreCase(id));
@@ -256,6 +247,8 @@ public class AnnounceManager {
     public void shutdown() {    
         saveConfig();    
         announceScheduler.shutdown();
+        savePlayerDisabledTypes();
+        announceConfig.shutdown(); // Disconnect the DataStore during shutdown
     }
 
     public boolean validateAnnounceType(String type) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -10,7 +10,6 @@ import org.fourz.rvnktools.util.ChatService;
 
 public class AnnounceManager {
     private enum CheckCondition {
-        NULL_ANNOUNCEMENT,
         ANNOUNCEMENT_EXISTS,
         SAVE_ANNOUNCEMENT,
         ADD_ANNOUNCEMENT
@@ -37,17 +36,15 @@ public class AnnounceManager {
         plugin.getCommand("announce").setExecutor(new AnnounceCommand(this, plugin));
         plugin.getCommand("announce").setTabCompleter(new AnnounceTabCompleter(this));
 
-        // Schedule announcements
-        //plugin.getLogger().info("Scheduling announcements...");
         announceScheduler.scheduleAnnouncements();
     }
 
-    // Add an announcement to the announcements list, used by AnnounceConfig
+    // Add an announcement to the announcements list, used by AnnounceConfig and AnnounceManager.parseAnnouncement()
     public boolean addAnnouncement(Announcement announcement) {
         CheckCondition condition;
 
         if (announcement == null) {
-            condition = CheckCondition.NULL_ANNOUNCEMENT;
+            plugin.getLogger().warning("Cannot add null announcement");
             return false;
         } else if (announceConfig.getDataStore() != null && !announcement.isImported()) {
             condition = checkAnnounceExist(announcement.getId()) ? 
@@ -58,16 +55,13 @@ public class AnnounceManager {
         }
 
         switch (condition) {
-            case NULL_ANNOUNCEMENT:
-                plugin.getLogger().warning("Cannot add null announcement");
-                return false;
             case ANNOUNCEMENT_EXISTS:
                 plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
                 return false;
             case SAVE_ANNOUNCEMENT:
                 announceConfig.getDataStore().saveAnnouncement(announcement);
                 setImported(announcement.getId());
-                // Fall through to ADD_ANNOUNCEMENT
+                // fall through
             case ADD_ANNOUNCEMENT:
                 announcements.add(announcement);
                 return true;

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -9,6 +9,13 @@ import org.fourz.rvnktools.util.ChatServiceInterface;
 import org.fourz.rvnktools.util.ChatService;
 
 public class AnnounceManager {
+    private enum CheckCondition {
+        NULL_ANNOUNCEMENT,
+        ANNOUNCEMENT_EXISTS,
+        SAVE_ANNOUNCEMENT,
+        ADD_ANNOUNCEMENT
+    }
+
     private final RVNKTools plugin;
     private final AnnounceConfig announceConfig;
     private final AnnounceScheduler announceScheduler;
@@ -37,55 +44,37 @@ public class AnnounceManager {
 
     // Add an announcement to the announcements list, used by AnnounceConfig
     public boolean addAnnouncement(Announcement announcement) {
-        // Determine the condition code based on the announcement state
-        String conditionCode;
+        CheckCondition condition;
 
         if (announcement == null) {
-            // Condition when the announcement is null
-            conditionCode = "NULL_ANNOUNCEMENT";
+            condition = CheckCondition.NULL_ANNOUNCEMENT;
+            return false;
         } else if (announceConfig.getDataStore() != null && !announcement.isImported()) {
-            // Condition when there's a data store and the announcement is not imported
-            if (announceConfig.getDataStore().announcementExists(announcement.getId())) {
-                // Condition when the announcement already exists in the data store
-                conditionCode = "ANNOUNCEMENT_EXISTS";
-            } else {
-                // Condition when the announcement needs to be saved to the data store
-                conditionCode = "SAVE_ANNOUNCEMENT";
-            }
+            condition = checkAnnounceExist(announcement.getId()) ? 
+            CheckCondition.ANNOUNCEMENT_EXISTS : 
+            CheckCondition.SAVE_ANNOUNCEMENT;
         } else {
-            // Default condition to add the announcement
-            conditionCode = "ADD_ANNOUNCEMENT";
+            condition = CheckCondition.ADD_ANNOUNCEMENT;
         }
 
-        // Handle each condition using a switch statement
-        switch (conditionCode) {
-            case "NULL_ANNOUNCEMENT":
-                // Cannot add a null announcement
+        switch (condition) {
+            case NULL_ANNOUNCEMENT:
                 plugin.getLogger().warning("Cannot add null announcement");
                 return false;
-
-            case "ANNOUNCEMENT_EXISTS":
-                // Announcement with this ID already exists in the data store
+            case ANNOUNCEMENT_EXISTS:
                 plugin.getLogger().warning("Announcement with ID '" + announcement.getId() + "' already exists");
                 return false;
-
-            case "SAVE_ANNOUNCEMENT":
-                // Save the announcement to the data store and mark as imported
+            case SAVE_ANNOUNCEMENT:
+                announceConfig.getDataStore().connect();
                 announceConfig.getDataStore().saveAnnouncement(announcement);
+                    announceConfig.getDataStore().disconnect();
                 setImported(announcement.getId());
-                plugin.getLogger().info("Marked announcement as imported: " + announcement.getId());
-                // Proceed to add the announcement
-                // (No break to continue to ADD_ANNOUNCEMENT case)
-
-            case "ADD_ANNOUNCEMENT":
-                // Add the announcement to the list and log the addition
+                // Fall through to ADD_ANNOUNCEMENT
+            case ADD_ANNOUNCEMENT:
                 announcements.add(announcement);
                 plugin.getLogger().info("Added announcement: " + announcement.getId() + " (" + announcement.getType() + ")");
                 return true;
-
             default:
-                // Unexpected condition
-                plugin.getLogger().warning("Unexpected condition in addAnnouncement");
                 return false;
         }
     }
@@ -121,17 +110,14 @@ public class AnnounceManager {
 
         // Check if announcement already exists
         if (announceConfig.getDataStore() != null) {
-            announceConfig.getDataStore().connect();
-            if (announceConfig.getDataStore().announcementExists(id)) {
+            if (checkAnnounceExist(id)) {
                 if (player != null) {
                     chatService.sendMessage(player, "An announcement with ID '" + id + "' already exists");
                 } else {
                     plugin.getLogger().warning("An announcement with ID '" + id + "' already exists");
                 }
-                announceConfig.getDataStore().disconnect();
                 return false;
             }
-            announceConfig.getDataStore().disconnect();
         }
 
         if (!validateAnnounceType(type)) {
@@ -150,7 +136,21 @@ public class AnnounceManager {
             }
         }        
         // Parse announcement as console        
-        return announceConfig.parseAnnouncement(id, type, text);
+
+        if (announceConfig.getDataStore() != null) {
+            announceConfig.getDataStore().connect();            
+            Boolean result = announceConfig.parseAnnouncement(id, type, text);
+            announceConfig.getDataStore().disconnect();
+            return result;
+        } 
+        return announceConfig.parseAnnouncement(id, type, text);       
+    }
+
+    private boolean checkAnnounceExist(String id) {
+        announceConfig.getDataStore().connect();
+        boolean exists = announceConfig.getDataStore().announcementExists(id);
+        announceConfig.getDataStore().disconnect();
+        return exists;
     }
 
     public void broadcastAnnouncement(Announcement announcement) {      
@@ -229,9 +229,11 @@ public class AnnounceManager {
 
             if (disabledTypes.contains(type)) {
                 disabledTypes.remove(type);
+                announceConfig.removePlayerDisabledType(playerId, type);
                 chatService.sendMessage(player, "Announcements of type '" + type + "' enabled.");
             } else {
                 disabledTypes.add(type);
+                announceConfig.addPlayerDisabledType(playerId, type);
                 chatService.sendMessage(player, "Announcements of type '" + type + "' disabled.");
             }
             announceConfig.getPlayerDisabledTypes().put(playerId, disabledTypes);
@@ -330,8 +332,6 @@ public class AnnounceManager {
         }
         return false;
     }
-
-
 
     public AnnounceType getAnnounceType(String type) {
         return announceConfig.getAnnounceTypes().get(type);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncePreferences.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncePreferences.java
@@ -1,0 +1,123 @@
+package org.fourz.rvnktools.announceManager;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.fourz.rvnktools.announceManager.data.DataStore;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class AnnouncePreferences {
+    private final JavaPlugin plugin;
+    private final DataStore dataStore;
+    private Map<UUID, Set<String>> playerDisabledTypes;
+
+    public AnnouncePreferences(JavaPlugin plugin, DataStore dataStore) {
+        this.plugin = plugin;
+        this.dataStore = dataStore;
+        this.playerDisabledTypes = new HashMap<>();
+        loadPreferences();
+    }
+
+    public void loadPreferences() {
+        if (dataStore != null) {
+            dataStore.connect();
+            playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
+            dataStore.disconnect();
+            
+            // Sync to YML backup
+            saveToYml();
+            return;
+        }
+
+        // Fallback to YML if no datastore
+        loadFromYml();
+    }
+
+    private void loadFromYml() {
+        File configFile = new File(plugin.getDataFolder(), "announceDisabledTypes.yml");
+        if (!configFile.exists()) {
+            return;
+        }
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+        for (String key : config.getKeys(false)) {
+            UUID playerId = UUID.fromString(key);
+            List<String> disabledTypesList = config.getStringList(key);
+            Set<String> disabledTypesSet = new HashSet<>(disabledTypesList);
+            playerDisabledTypes.put(playerId, disabledTypesSet);
+        }
+    }
+
+    public void savePreferences() {
+        // Always maintain YML backup
+        saveToYml();
+
+        // Save to database if available
+        if (dataStore != null) {
+            dataStore.connect();
+            // Get fresh data first
+            playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
+            
+            // Save all preferences
+            for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
+                for (String type : entry.getValue()) {
+                    dataStore.savePlayerDisabledType(entry.getKey(), type);
+                }
+            }
+            dataStore.disconnect();
+        }
+    }
+
+    private void saveToYml() {
+        File dataFolder = plugin.getDataFolder();
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+
+        File configFile = new File(dataFolder, "announceDisabledTypes.yml");
+        YamlConfiguration config = new YamlConfiguration();
+
+        for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
+            String key = entry.getKey().toString();
+            List<String> disabledTypesList = new ArrayList<>(entry.getValue());
+            config.set(key, disabledTypesList);
+        }
+
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to sync announceDisabledTypes to YML: " + e.getMessage());
+        }
+    }
+
+    public void addDisabledType(UUID playerId, String type) {
+        if (dataStore != null) {
+            dataStore.connect();
+            dataStore.savePlayerDisabledType(playerId, type);
+            dataStore.disconnect();
+        }
+        playerDisabledTypes.computeIfAbsent(playerId, k -> new HashSet<>()).add(type);
+    }
+
+    public void removeDisabledType(UUID playerId, String type) {
+        if (dataStore != null) {
+            dataStore.connect();
+            dataStore.removePlayerDisabledType(playerId, type);
+            dataStore.disconnect();
+        }
+        Set<String> types = playerDisabledTypes.get(playerId);
+        if (types != null) {
+            types.remove(type);
+        }
+    }
+
+    public Set<String> getDisabledTypes(UUID playerId) {
+        return playerDisabledTypes.getOrDefault(playerId, new HashSet<>());
+    }
+
+    public Map<UUID, Set<String>> getAllDisabledTypes() {
+        return playerDisabledTypes;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncePreferences.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncePreferences.java
@@ -12,18 +12,29 @@ public class AnnouncePreferences {
     private final JavaPlugin plugin;
     private final DataStore dataStore;
     private Map<UUID, Set<String>> playerDisabledTypes;
+    private Map<UUID, String> playerPreferences;
 
     public AnnouncePreferences(JavaPlugin plugin, DataStore dataStore) {
         this.plugin = plugin;
         this.dataStore = dataStore;
         this.playerDisabledTypes = new HashMap<>();
+        this.playerPreferences = new HashMap<>();
         loadPreferences();
     }
 
     public void loadPreferences() {
         if (dataStore != null) {
             dataStore.connect();
+            // Load disabled types
             playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
+            
+            // Load preferences for each player
+            for (UUID playerId : playerDisabledTypes.keySet()) {
+                String prefs = dataStore.getPlayerPreferences(playerId);
+                if (prefs != null) {
+                    playerPreferences.put(playerId, prefs);
+                }
+            }
             dataStore.disconnect();
             
             // Sync to YML backup
@@ -48,6 +59,18 @@ public class AnnouncePreferences {
             Set<String> disabledTypesSet = new HashSet<>(disabledTypesList);
             playerDisabledTypes.put(playerId, disabledTypesSet);
         }
+        
+        // Load preferences
+        configFile = new File(plugin.getDataFolder(), "announcePreferences.yml");
+        if (configFile.exists()) {
+            config = YamlConfiguration.loadConfiguration(configFile);
+            for (String key : config.getKeys(false)) {
+                UUID playerId = UUID.fromString(key);
+                if (config.contains(key + ".preferences")) {
+                    playerPreferences.put(playerId, config.getString(key + ".preferences"));
+                }
+            }
+        }
     }
 
     public void savePreferences() {
@@ -57,15 +80,19 @@ public class AnnouncePreferences {
         // Save to database if available
         if (dataStore != null) {
             dataStore.connect();
-            // Get fresh data first
-            playerDisabledTypes = dataStore.getAllPlayerDisabledTypes();
             
-            // Save all preferences
+            // Save preferences
+            for (Map.Entry<UUID, String> entry : playerPreferences.entrySet()) {
+                dataStore.savePlayerPreferences(entry.getKey(), entry.getValue());
+            }
+            
+            // Save disabled types
             for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
                 for (String type : entry.getValue()) {
                     dataStore.savePlayerDisabledType(entry.getKey(), type);
                 }
             }
+            
             dataStore.disconnect();
         }
     }
@@ -89,6 +116,27 @@ public class AnnouncePreferences {
             config.save(configFile);
         } catch (IOException e) {
             plugin.getLogger().warning("Failed to sync announceDisabledTypes to YML: " + e.getMessage());
+        }
+        
+        configFile = new File(dataFolder, "announcePreferences.yml");
+        config = new YamlConfiguration();
+        
+        // Save both disabled types and preferences
+        for (Map.Entry<UUID, Set<String>> entry : playerDisabledTypes.entrySet()) {
+            String key = entry.getKey().toString();
+            config.set(key + ".disabled_types", new ArrayList<>(entry.getValue()));
+            
+            // Save preferences if they exist
+            String prefs = playerPreferences.get(entry.getKey());
+            if (prefs != null) {
+                config.set(key + ".preferences", prefs);
+            }
+        }
+
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to save preferences to YML: " + e.getMessage());
         }
     }
 
@@ -119,5 +167,18 @@ public class AnnouncePreferences {
 
     public Map<UUID, Set<String>> getAllDisabledTypes() {
         return playerDisabledTypes;
+    }
+
+    public void setPlayerPreferences(UUID playerId, String preferences) {
+        if (dataStore != null) {
+            dataStore.connect();
+            dataStore.savePlayerPreferences(playerId, preferences);
+            dataStore.disconnect();
+        }
+        playerPreferences.put(playerId, preferences);
+    }
+
+    public String getPlayerPreferences(UUID playerId) {
+        return playerPreferences.getOrDefault(playerId, null);
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
@@ -51,12 +51,7 @@ public class AnnounceScheduler {
     // schedules all announcements
     public void scheduleAnnouncements() {
         // Cancel existing tasks if any
-        if (scheduledTasks != null) {
-            for (BukkitTask task : scheduledTasks.values()) {
-                task.cancel();
-            }
-        }
-        scheduledTasks = new ConcurrentHashMap<>();
+        cleanup();
 
         // Schedule each announcement
         for (Announcement announcement : announceManager.getAnnouncements()) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
@@ -74,9 +74,9 @@ public class AnnounceScheduler {
             }
         }
 
-        //calculate the ticks based on the recurrence
-        long ticks = announcement.getRecurrence() * 20L;
-
+        // Safely handle null recurrence by defaulting to RECURRENCE_UNSET (-1)
+        Long recurrence = announcement.getRecurrence();
+        long ticks = recurrence != null ? recurrence * 20L : RECURRENCE_UNSET;
 
         if (ticks > 0) {
             ticks = applyRandomTicks(ticks);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
@@ -17,6 +17,7 @@ public class AnnounceScheduler {
     private static final double RANDOM_TICK_MULTIPLIER_MAX = 1.1;
     private static final long DEFAULT_RANDOM_RANGE = 144000 * 2;
     private static final long DEFAULT_DELAY = 72000;
+    private static final long DEFAULT_RECURRENCE_TICKS = 3 * 60 * 60 * 20L; // 3 hours in ticks
 
     private final RVNKTools plugin;
     private final AnnounceManager announceManager;
@@ -36,16 +37,6 @@ public class AnnounceScheduler {
         this.plugin = plugin;
         this.announceManager = announceManager;
         this.usingPlaceholderAPI = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
-        // Comment out the scheduleSaveConfig() method to prevent periodic saving
-        // private void scheduleSaveConfig() {
-        //     // Schedule saveConfig to run every 20 minutes (24000 ticks)
-        //     // new BukkitRunnable() {
-        //     //     @Override
-        //     //     public void run() {
-        //     //         saveConfig();
-        //     //     }
-        //     // }.runTaskTimer(plugin, 24000L, 24000L);
-        // }
     }
 
     // schedules all announcements
@@ -136,15 +127,9 @@ public class AnnounceScheduler {
 
     // handle scheduling of periodic announcements
     private void handlePeriodicAnnouncement(Announcement announcement, long ticks) {
-
-        // if ticks is set to RECURRENCE_UNSET (-1), the recurrence was not set, calculate an interval that will only run once before midnight
-        // using factor of 0.7, if the server starts at midnight, the announcement will run at 4:48 PM
-        // using factor of 0.7, if the server starts at 5am, the announcement will run at 6:18 PM
+        // if ticks is set to RECURRENCE_UNSET (-1), use the default recurrence of 3 hours
         if (ticks == RECURRENCE_UNSET) {
-            LocalDateTime now = LocalDateTime.now();
-            LocalDateTime midnight = now.toLocalDate().atStartOfDay().plusDays(1);
-            long ticks_until_midnight = Duration.between(now, midnight).toMillis() / 50L;
-            ticks = (long) (ticks_until_midnight * 0.7);
+            ticks = DEFAULT_RECURRENCE_TICKS;
         }
 
         BukkitTask task = new BukkitRunnable() {
@@ -156,7 +141,6 @@ public class AnnounceScheduler {
         }.runTaskTimer(plugin, ticks, ticks);
 
         scheduledTasks.put(announcement, task);
-        //logInfo("Scheduled announcement '" + announcement.getId() + "' with delay " + ticks + " ticks.");
     }
 
     // applies a random multiplier to the ticks value

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
@@ -62,7 +62,11 @@ public class AnnounceScheduler {
         for (Announcement announcement : announceManager.getAnnouncements()) {
             scheduleAnnouncement(announcement);
         }
-        logInfo("Scheduled " + scheduledTasks.size() + " announcements.");
+        
+        // Only log the final count
+        if (scheduledTasks.size() > 0) {
+            logInfo("Scheduled " + scheduledTasks.size() + " announcements.");
+        }
     }
 
     // schedule a single announcement given an announcement object
@@ -76,7 +80,7 @@ public class AnnounceScheduler {
         }
 
         //calculate the ticks based on the recurrence
-        long ticks = convertRecurrenceToTicks(announcement.getRecurrence());
+        long ticks = announcement.getRecurrence() * 20L;
 
 
         if (ticks > 0) {
@@ -85,7 +89,7 @@ public class AnnounceScheduler {
 
         // if the type is 'scheduled' and the date is set, handle it as a scheduled announcement
         if ("scheduled".equalsIgnoreCase(announcement.getType()) && announcement.getDate() != null) {
-            handleScheduledAnnouncement(announcement, ticks);
+            handleScheduledAnnouncement(announcement);
             return;
         }
 
@@ -93,34 +97,37 @@ public class AnnounceScheduler {
     }
 
     // handle scheduling of announcements with a specific date and time
-    private void handleScheduledAnnouncement(Announcement announcement, long ticks) {
+    private void handleScheduledAnnouncement(Announcement announcement) {
         LocalDateTime now = LocalDateTime.now();
-        Integer condition = TIME_SET__TICKS_POSITIVE;
 
-        // announcement has time set
-        if (announcement.getTime() != null) {
-            // Check if the announcement is set to run before the current time
-            if (now.toLocalDate().isEqual(announcement.getDate()) && now.toLocalTime().isBefore(announcement.getTime())) {
-                condition = TIME_SET__BEFORE_TIME;
-            // Check if the announcement is set to run after the current time
-            } else if (now.toLocalDate().isEqual(announcement.getDate()) && ticks > 0) {
-                condition = TIME_SET__TICKS_POSITIVE;
-            // Check if the announcement is set to run on the same date as the current date
-            } else if (now.toLocalDate().isEqual(announcement.getDate())) {
-                condition = TIME_SET__DATE_EQUAL;
-            }
-        // announcement has no time set
-        } else {
-            // Check if the announcement is set to run on the same date as the current date
-            if (now.toLocalDate().isEqual(announcement.getDate())) {
-                condition = TIME_NULL__DATE_EQUAL;
-            }
-        }
+        // Check if the announcement date is today
+        if (now.toLocalDate().isEqual(announcement.getDate())) {
+            long delay = 0L;
 
-        switch (condition) {            
-            case TIME_SET__BEFORE_TIME:
-                // Schedule to run later at a specific time
-                long delay = Duration.between(now, LocalDateTime.of(announcement.getDate(), announcement.getTime())).toMillis() / 50L;
+            // If time is specified
+            if (announcement.getTime() != null) {
+                if (now.toLocalTime().isBefore(announcement.getTime())) {
+                    // Calculate delay until the specified time
+                    delay = Duration.between(now.toLocalTime(), announcement.getTime()).toMillis() / 50L;
+                } else {
+                    // Time has already passed today, do not schedule
+                    return;
+                }
+            }
+
+            // If recurrence is set, schedule periodically on the scheduled day
+            long ticks = announcement.getRecurrence() * 20L;
+            if (ticks > 0) {
+                ticks = applyRandomTicks(ticks);
+                BukkitTask task = new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        broadcastAnnouncement(announcement);
+                    }
+                }.runTaskTimer(plugin, delay, ticks);
+                scheduledTasks.put(announcement, task);
+            } else {
+                // Schedule the announcement to run once after the calculated delay
                 BukkitTask task = new BukkitRunnable() {
                     @Override
                     public void run() {
@@ -128,42 +135,7 @@ public class AnnounceScheduler {
                     }
                 }.runTaskLater(plugin, delay);
                 scheduledTasks.put(announcement, task);
-                return;
-            case TIME_SET__TICKS_POSITIVE:
-                // Schedule to run later with a positive ticks value
-                handlePeriodicAnnouncement(announcement, ticks);
-                return;
-
-            case TIME_SET__DATE_EQUAL:
-                // Schedule to run later without specific time
-                long delayDateEqual = Duration.between(now, LocalDateTime.of(announcement.getDate(), now.toLocalTime())).toMillis() / 50L;
-                BukkitTask taskDateEqual = new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        broadcastAnnouncement(announcement);
-                    }
-                }.runTaskLater(plugin, delayDateEqual);
-                scheduledTasks.put(announcement, taskDateEqual);
-                return;
-
-            case TIME_NULL__DATE_EQUAL:
-                // Schedule to run every 4 hours
-                int nextHour = ((now.getHour() / 4) + 1) * 4 % 24;
-                LocalDateTime nextTime = now.withHour(nextHour).withMinute(0).withSecond(0).withNano(0);
-                long delayNullTime = Duration.between(now, nextTime).toMillis() / 50L;
-                long period = 4 * 60L * 60L * 20L; // 4 hours in ticks
-
-                BukkitTask taskNullTime = new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        broadcastAnnouncement(announcement);
-                    }
-                }.runTaskTimer(plugin, delayNullTime, period);
-                scheduledTasks.put(announcement, taskNullTime);
-                return;
-            default:
-                // No action needed
-                break;
+            }
         }
     }
 
@@ -242,11 +214,9 @@ public class AnnounceScheduler {
     }
 
     public void cleanup() {
-
+        // Cancel all tasks and clear the map
+        shutdown();
+        scheduledTasks.clear();
     }
 
-    // Remove or comment out the saveConfig() method if it's no longer needed
-    // public void saveConfig() {
-    //     announceManager.saveConfig();
-    // }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceScheduler.java
@@ -15,8 +15,6 @@ public class AnnounceScheduler {
     // constant for random tick multiplier and default values
     private static final double RANDOM_TICK_MULTIPLIER_MIN = 0.9;
     private static final double RANDOM_TICK_MULTIPLIER_MAX = 1.1;
-    private static final long DEFAULT_RANDOM_RANGE = 144000 * 2;
-    private static final long DEFAULT_DELAY = 72000;
     private static final long DEFAULT_RECURRENCE_TICKS = 3 * 60 * 60 * 20L; // 3 hours in ticks
 
     private final RVNKTools plugin;
@@ -26,20 +24,16 @@ public class AnnounceScheduler {
     private final Random rand = new Random();
 
     // constants for improved readability in conditional statements
-    private static final int RECURRENCE_UNSET = -1;
-    private static final int TIME_SET__BEFORE_TIME = 0;
-    private static final int TIME_SET__TICKS_POSITIVE = 1;
-    private static final int TIME_SET__DATE_EQUAL = 3;
-    private static final int TIME_NULL__DATE_EQUAL = 4;    
+    private static final int RECURRENCE_UNSET = -1; 
 
-    // initialize the scheduler 
+    // Initialize the scheduler
     public AnnounceScheduler(RVNKTools plugin, AnnounceManager announceManager) {
         this.plugin = plugin;
         this.announceManager = announceManager;
         this.usingPlaceholderAPI = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
     }
 
-    // schedules all announcements
+    // Schedule all announcements
     public void scheduleAnnouncements() {
         // Cancel existing tasks if any
         cleanup();
@@ -55,7 +49,7 @@ public class AnnounceScheduler {
         }
     }
 
-    // schedule a single announcement given an announcement object
+    // Schedule a single announcement
     private void scheduleAnnouncement(Announcement announcement) {
 
         // Check if the announcement has an expiration date and if it has past, skip it
@@ -82,7 +76,7 @@ public class AnnounceScheduler {
         handlePeriodicAnnouncement(announcement, ticks);
     }
 
-    // handle scheduling of announcements with a specific date and time
+    // Handle scheduling of announcements with a specific date and time
     private void handleScheduledAnnouncement(Announcement announcement) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -125,7 +119,7 @@ public class AnnounceScheduler {
         }
     }
 
-    // handle scheduling of periodic announcements
+    // Handle scheduling of periodic announcements
     private void handlePeriodicAnnouncement(Announcement announcement, long ticks) {
         // if ticks is set to RECURRENCE_UNSET (-1), use the default recurrence of 3 hours
         if (ticks == RECURRENCE_UNSET) {
@@ -143,47 +137,23 @@ public class AnnounceScheduler {
         scheduledTasks.put(announcement, task);
     }
 
-    // applies a random multiplier to the ticks value
+    // Apply a random multiplier to the ticks value
     private long applyRandomTicks(long ticks) {
         return (long) (ticks * (RANDOM_TICK_MULTIPLIER_MIN + rand.nextDouble() * (RANDOM_TICK_MULTIPLIER_MAX - RANDOM_TICK_MULTIPLIER_MIN)));
     }
 
-    // log an informational message
+    // Log an informational message
     private void logInfo(String message) {
         plugin.getLogger().info(message);
     }
 
-    // parse the recurrence string to ticks
-    private long convertRecurrenceToTicks(String recurrence) {
-        if (recurrence == null) {
-            return RECURRENCE_UNSET;
-        }
-        recurrence = recurrence.toLowerCase();
-        long ticks = 0;
-        try {
-            if (recurrence.endsWith("h")) {
-                int hours = Integer.parseInt(recurrence.substring(0, recurrence.length() - 1));
-                ticks = hours * 60L * 60L * 20L;
-            } else if (recurrence.endsWith("m")) {
-                int minutes = Integer.parseInt(recurrence.substring(0, recurrence.length() - 1));
-                ticks = minutes * 60L * 20L;
-            } else if (recurrence.endsWith("s")) {
-                int seconds = Integer.parseInt(recurrence.substring(0, recurrence.length() - 1));
-                ticks = seconds * 20L;
-            }
-        } catch (NumberFormatException e) {
-            e.printStackTrace();
-        }
-        return ticks;
-    }
-
-    // broadcast the announcement to all players
+    // Broadcast the announcement to all players
     public void broadcastAnnouncement(Announcement announcement) {
         this.announceManager.broadcastAnnouncement(announcement);
 
     }
 
-    // shut down the scheduler and cancels all tasks
+    // Shut down the scheduler and cancel all tasks
     public void shutdown() {
         if (scheduledTasks != null) {
             for (BukkitTask task : scheduledTasks.values()) {
@@ -192,6 +162,7 @@ public class AnnounceScheduler {
         }
     }
 
+    // Cancel all tasks and clear the scheduled tasks map
     public void cleanup() {
         // Cancel all tasks and clear the map
         shutdown();

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceTabCompleter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceTabCompleter.java
@@ -110,7 +110,7 @@ public class AnnounceTabCompleter implements TabCompleter {
             
             switch (args[2].toLowerCase()) {
                 case "recurrence":
-                    return filterCompletions(Arrays.asList("none", "daily", "1h", "2h", "4h", "30m", "60m", "90m"), args[3]);
+                    return filterCompletions(Arrays.asList("none", "daily", "60m", "90m", "120m"), args[3]);
                 case "type":
                     return filterCompletions(new ArrayList<>(announceManager.getAnnounceTypes()), args[3]);
                 case "permission":

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceTabCompleter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceTabCompleter.java
@@ -10,7 +10,8 @@ import java.util.stream.Collectors;
 
 public class AnnounceTabCompleter implements TabCompleter {
     private final AnnounceManager announceManager;
-    private final List<String> subcommands = Arrays.asList("toggle", "status", "list", "add", "delete", "now", "help", "types");
+    private final List<String> subcommands = Arrays.asList("toggle", "status", "list", "add", "delete", "now", "help", "types", "set");
+    private final List<String> setProperties = Arrays.asList("recurrence", "date", "type", "permission");
 
     public AnnounceTabCompleter(AnnounceManager announceManager) {
         this.announceManager = announceManager;
@@ -27,6 +28,7 @@ public class AnnounceTabCompleter implements TabCompleter {
                     case "add" -> "rvnktools.command.announce.add";
                     case "delete" -> "rvnktools.command.announce.delete";
                     case "now" -> "rvnktools.command.announce.now";
+                    case "set" -> "rvnktools.command.announce.set";
                     default -> "rvnktools.command.announce";
                 };
                 if (sender.hasPermission(permission)) {
@@ -41,6 +43,7 @@ public class AnnounceTabCompleter implements TabCompleter {
                 case "add" -> "rvnktools.command.announce.add";
                 case "delete" -> "rvnktools.command.announce.delete";
                 case "now" -> "rvnktools.command.announce.now";
+                case "set" -> "rvnktools.command.announce.set";
                 default -> "rvnktools.command.announce";
             };
             
@@ -88,9 +91,36 @@ public class AnnounceTabCompleter implements TabCompleter {
                     return filterCompletions(listOptions, args[1]);
                 case "add":                    
                     return filterCompletions(new ArrayList<>(announceManager.getAnnounceTypes()), args[1]);
-                    
+                case "set":
+                    return filterCompletions(new ArrayList<>(announceManager.getAnnouncementIds()), args[1]);
             }
         }
+
+        if (args.length == 3 && args[0].toLowerCase().equals("set")) {
+            if (!sender.hasPermission("rvnktools.command.announce.set")) {
+                return completions;
+            }
+            return filterCompletions(setProperties, args[2]);
+        }
+
+        if (args.length == 4 && args[0].toLowerCase().equals("set")) {
+            if (!sender.hasPermission("rvnktools.command.announce.set")) {
+                return completions;
+            }
+            
+            switch (args[2].toLowerCase()) {
+                case "recurrence":
+                    return filterCompletions(Arrays.asList("none", "daily", "1h", "2h", "4h", "30m", "60m", "90m"), args[3]);
+                case "type":
+                    return filterCompletions(new ArrayList<>(announceManager.getAnnounceTypes()), args[3]);
+                case "permission":
+                    return filterCompletions(Arrays.asList("none"), args[3]);
+                case "date":
+                    // No specific completions for date as it requires a specific format
+                    break;
+            }
+        }
+        
         return completions;
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
@@ -8,7 +8,7 @@ public class Announcement {
     private String id;
     private String text;
     private String type;
-    private String recurrence;
+    private Long recurrence;
     private String owner;
     private String permission;
     private LocalDate date;
@@ -45,10 +45,10 @@ public class Announcement {
         }
         return;
     }
-    public String getRecurrence() {
+    public Long getRecurrence() {
         return recurrence;
     }
-    public void setRecurrence(String recurrence) {
+    public void setRecurrence(Long recurrence) {
         this.recurrence = recurrence;
     }
     public String getOwner() {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
@@ -9,6 +9,7 @@ public class Announcement {
     private String text;
     private String type;
     private Long recurrence;
+    private String recurrenceString;
     private String owner;
     private String permission;
     private LocalDate date;
@@ -50,6 +51,13 @@ public class Announcement {
     }
     public void setRecurrence(Long recurrence) {
         this.recurrence = recurrence;
+    }
+    public String getRecurrenceString() {
+        return recurrenceString;
+    }
+    
+    public void setRecurrenceString(String recurrenceString) {
+        this.recurrenceString = recurrenceString;
     }
     public String getOwner() {
         return owner;

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
@@ -27,4 +27,7 @@ public interface DataStore {
     void removePlayerDisabledType(UUID playerId, String type);
     Set<String> getPlayerDisabledTypes(UUID playerId);
     Map<UUID, Set<String>> getAllPlayerDisabledTypes();
+    
+    void savePlayerPreferences(UUID playerId, String preferences);
+    String getPlayerPreferences(UUID playerId);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
@@ -18,6 +18,9 @@ public interface DataStore {
     boolean announcementExists(String id);
     void saveAnnouncement(Announcement announcement);
     void deleteAnnouncement(String id);
+    
+    // This method now returns List for backward compatibility
+    // but internally uses Map for better performance
     List<Announcement> loadAnnouncements();
     
     void saveAnnounceType(AnnounceType announceType);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
@@ -8,18 +8,15 @@ import org.fourz.rvnktools.announceManager.Announcement;
 public interface DataStore {
     void connect();
     void disconnect();
+    void initializeTables();
+    
+    boolean isEmpty();
+    boolean announcementExists(String id);
+    
     void saveAnnouncement(Announcement announcement);
     void deleteAnnouncement(String id);
     List<Announcement> loadAnnouncements();
+    
     void saveAnnounceType(AnnounceType announceType);
     List<AnnounceType> loadAnnounceTypes();
-    
-    // Add new method
-    void initializeTables();
-
-    // Add new method
-    boolean announcementExists(String id);
-    
-    // Add new method
-    boolean isEmpty();
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
@@ -11,6 +11,10 @@ import org.fourz.rvnktools.announceManager.Announcement;
 public interface DataStore {
     void connect();
     void disconnect();
+    
+    // Add table state tracking methods
+    boolean areTablesInitialized();
+    void setTablesInitialized(boolean initialized);
     void initializeTables();
     
     boolean isEmpty();

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/DataStore.java
@@ -1,6 +1,9 @@
 package org.fourz.rvnktools.announceManager.data;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
@@ -11,12 +14,17 @@ public interface DataStore {
     void initializeTables();
     
     boolean isEmpty();
-    boolean announcementExists(String id);
     
+    boolean announcementExists(String id);
     void saveAnnouncement(Announcement announcement);
     void deleteAnnouncement(String id);
     List<Announcement> loadAnnouncements();
     
     void saveAnnounceType(AnnounceType announceType);
     List<AnnounceType> loadAnnounceTypes();
+    
+    void savePlayerDisabledType(UUID playerId, String type);
+    void removePlayerDisabledType(UUID playerId, String type);
+    Set<String> getPlayerDisabledTypes(UUID playerId);
+    Map<UUID, Set<String>> getAllPlayerDisabledTypes();
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -94,7 +94,7 @@ public class MySQLDataConnector implements DataStore {
 
     @Override
     public List<Announcement> loadAnnouncements() {
-        List<Announcement> announcements = new ArrayList<>();
+        Map<String, Announcement> announcements = new HashMap<>();
         String query = "SELECT * FROM announcements";
         try {
             ensureConnection();
@@ -111,13 +111,13 @@ public class MySQLDataConnector implements DataStore {
                     announcement.setDate(resultSet.getDate("date") != null ? resultSet.getDate("date").toLocalDate() : null);
                     announcement.setTime(resultSet.getTime("time") != null ? resultSet.getTime("time").toLocalTime() : null);
                     announcement.setExpiration(resultSet.getTimestamp("expiration") != null ? resultSet.getTimestamp("expiration").toLocalDateTime() : null);
-                    announcements.add(announcement);
+                    announcements.put(announcement.getId(), announcement);
                 }
             }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return announcements;
+        return new ArrayList<>(announcements.values());
     }
 
     @Override

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -250,7 +250,25 @@ public class MySQLDataConnector implements DataStore {
 
     @Override
     public boolean isEmpty() {
-        return empty;
+        try {
+            ensureConnection();
+            
+            // Check both tables for data
+            try (Statement stmt = connection.createStatement()) {
+                ResultSet rs1 = stmt.executeQuery("SELECT COUNT(*) FROM announcements");
+                rs1.next();
+                int announceCount = rs1.getInt(1);
+                
+                ResultSet rs2 = stmt.executeQuery("SELECT COUNT(*) FROM announce_types");
+                rs2.next();
+                int typeCount = rs2.getInt(1);
+                
+                return announceCount == 0 && typeCount == 0;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return true; // Assume empty on error
+        }
     }
 
     @Override

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -45,9 +45,9 @@ public class MySQLDataConnector implements DataStore {
     public void connect() {
         try {
             if (connection == null || connection.isClosed()) {
-                debug.log(LogLevel.INFO, "Attempting to establish MySQL connection to " + url);
+                debug.log(LogLevel.CONFIG, "Attempting to establish MySQL connection to " + url);
                 connection = DriverManager.getConnection(url, username, password);
-                debug.log(LogLevel.INFO, "MySQL connection established successfully");
+                debug.log(LogLevel.FINE, "MySQL connection established successfully");
                 initializeTables();
             }
         } catch (SQLException e) {
@@ -68,7 +68,7 @@ public class MySQLDataConnector implements DataStore {
 
     private void ensureConnection() throws SQLException {
         if (connection == null || connection.isClosed()) {
-            debug.log(LogLevel.INFO, "Re-establishing lost MySQL connection");
+            debug.log(LogLevel.FINE, "Re-establishing lost MySQL connection");
             connect();
         }
     }
@@ -186,12 +186,12 @@ public class MySQLDataConnector implements DataStore {
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
-            debug.log(LogLevel.INFO, "Checking and creating necessary MySQL tables");
+            debug.log(LogLevel.CONFIG, "Checking and creating necessary MySQL tables");
             
             // Check if announcements table exists
             tables = metaData.getTables(database, null, "announcements", null);
             if (!tables.next()) {
-                debug.log(LogLevel.INFO, "Creating announcements table");
+                debug.log(LogLevel.CONFIG, "Creating announcements table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncementsTable = "CREATE TABLE announcements (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -208,13 +208,13 @@ public class MySQLDataConnector implements DataStore {
                 debug.log(LogLevel.INFO, "announcements table created successfully");
                 empty = true;
             } else {
-                debug.log(LogLevel.INFO, "announcements table already exists");
+                debug.log(LogLevel.FINE, "announcements table already exists");
             }
             
             // Check if announce_types table exists
             tables = metaData.getTables(database, null, "announce_types", null);
             if (!tables.next()) {
-                debug.log(LogLevel.INFO, "Creating announce_types table");
+                debug.log(LogLevel.CONFIG, "Creating announce_types table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceTypesTable = "CREATE TABLE announce_types (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -232,7 +232,7 @@ public class MySQLDataConnector implements DataStore {
             // Check if announce_disabledtypes table exists
             tables = metaData.getTables(database, null, "announce_disabledtypes", null);
             if (!tables.next()) {
-                debug.log(LogLevel.INFO, "Creating announce_disabledtypes table");
+                debug.log(LogLevel.CONFIG, "Creating announce_disabledtypes table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
                     "player_id VARCHAR(36)," +
@@ -242,13 +242,13 @@ public class MySQLDataConnector implements DataStore {
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
                 debug.log(LogLevel.INFO, "announce_disabledtypes table created successfully");
             } else {
-                debug.log(LogLevel.INFO, "announce_disabledtypes table already exists");
+                debug.log(LogLevel.FINE, "announce_disabledtypes table already exists");
             }
 
             // Check if announce_prefs table exists
             tables = metaData.getTables(database, null, "announce_prefs", null);
             if (!tables.next()) {
-                debug.log(LogLevel.INFO, "Creating announce_prefs table");
+                debug.log(LogLevel.CONFIG, "Creating announce_prefs table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
                     "player_id VARCHAR(36) PRIMARY KEY," +
@@ -257,10 +257,10 @@ public class MySQLDataConnector implements DataStore {
                 stmt.executeUpdate(createAnnouncePrefsTable);
                 debug.log(LogLevel.INFO, "announce_prefs table created successfully");
             } else {
-                debug.log(LogLevel.INFO, "announce_prefs table already exists");
+                debug.log(LogLevel.FINE, "announce_prefs table already exists");
             }
             
-            debug.log(LogLevel.INFO, "All database tables verified/created successfully");
+            debug.log(LogLevel.CONFIG, "All database tables verified/created successfully");
             
         } catch (SQLException e) {
             debug.error("Failed to initialize database tables: " + e.getMessage(), e);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
+import org.bukkit.Bukkit;
 
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
@@ -31,10 +32,13 @@ public class MySQLDataConnector implements DataStore {
     public void connect() {
         try {
             if (connection == null || connection.isClosed()) {
+                Bukkit.getLogger().info("[RVNKToolKit] Attempting to establish MySQL connection to " + url);
                 connection = DriverManager.getConnection(url, username, password);
+                Bukkit.getLogger().info("[RVNKToolKit] MySQL connection established successfully");
                 initializeTables();
             }
         } catch (SQLException e) {
+            Bukkit.getLogger().severe("[RVNKToolKit] Failed to connect to MySQL: " + e.getMessage());
             e.printStackTrace();
         }
     }
@@ -52,6 +56,7 @@ public class MySQLDataConnector implements DataStore {
 
     private void ensureConnection() throws SQLException {
         if (connection == null || connection.isClosed()) {
+            Bukkit.getLogger().info("[RVNKToolKit] Re-establishing lost MySQL connection");
             connect();
         }
     }
@@ -169,9 +174,12 @@ public class MySQLDataConnector implements DataStore {
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
+            Bukkit.getLogger().info("[RVNKToolKit] Checking and creating necessary MySQL tables");
+            
             // Check if announcements table exists
             tables = metaData.getTables(database, null, "announcements", null);
             if (!tables.next()) {
+                Bukkit.getLogger().info("[RVNKToolKit] Creating announcements table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncementsTable = "CREATE TABLE announcements (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -185,12 +193,16 @@ public class MySQLDataConnector implements DataStore {
                     "expiration DATETIME" +
                     ")";
                 stmt.executeUpdate(createAnnouncementsTable);
+                Bukkit.getLogger().info("[RVNKToolKit] announcements table created successfully");
                 empty = true;
+            } else {
+                Bukkit.getLogger().info("[RVNKToolKit] announcements table already exists");
             }
             
             // Check if announce_types table exists
             tables = metaData.getTables(database, null, "announce_types", null);
             if (!tables.next()) {
+                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_types table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceTypesTable = "CREATE TABLE announce_types (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -200,11 +212,15 @@ public class MySQLDataConnector implements DataStore {
                     "listing_fee DOUBLE" +
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
+                Bukkit.getLogger().info("[RVNKToolKit] announce_types table created successfully");
+            } else {
+                Bukkit.getLogger().info("[RVNKToolKit] announce_types table already exists");
             }
 
             // Check if announce_disabledtypes table exists
             tables = metaData.getTables(database, null, "announce_disabledtypes", null);
             if (!tables.next()) {
+                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_disabledtypes table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
                     "player_id VARCHAR(36)," +
@@ -212,19 +228,30 @@ public class MySQLDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
+                Bukkit.getLogger().info("[RVNKToolKit] announce_disabledtypes table created successfully");
+            } else {
+                Bukkit.getLogger().info("[RVNKToolKit] announce_disabledtypes table already exists");
             }
 
             // Check if announce_prefs table exists
             tables = metaData.getTables(database, null, "announce_prefs", null);
             if (!tables.next()) {
+                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_prefs table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
                     "player_id VARCHAR(36) PRIMARY KEY," +
                     "text VARCHAR(512)" +
                     ")";
                 stmt.executeUpdate(createAnnouncePrefsTable);
+                Bukkit.getLogger().info("[RVNKToolKit] announce_prefs table created successfully");
+            } else {
+                Bukkit.getLogger().info("[RVNKToolKit] announce_prefs table already exists");
             }
+            
+            Bukkit.getLogger().info("[RVNKToolKit] All database tables verified/created successfully");
+            
         } catch (SQLException e) {
+            Bukkit.getLogger().severe("[RVNKToolKit] Failed to initialize database tables: " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -9,37 +9,49 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
+import org.fourz.rvnktools.util.Debug;
+import org.fourz.rvnktools.util.Debug.LogLevel;
 
 public class MySQLDataConnector implements DataStore {
+    private static final String CLASS_NAME = "MySQLDataConnector";
     private final String url;
     private final String username;
     private final String password;
     private final String database;
     private Connection connection;
     private boolean empty = false;
+    private final Debug debug;
 
-    public MySQLDataConnector(String host, int port, String database, String username, String password, boolean useSSL) {
+    public MySQLDataConnector(JavaPlugin plugin, String host, int port, String database, String username, String password, boolean useSSL) {
         this.url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
         this.username = username;
         this.password = password;
         this.database = database;
+        this.debug = new Debug(plugin, CLASS_NAME, LogLevel.INFO) {};
+    }
+    public MySQLDataConnector(JavaPlugin plugin, String host, int port, String database, String username, String password, boolean useSSL, LogLevel level) {
+        this.url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
+        this.username = username;
+        this.password = password;
+        this.database = database;
+        this.debug = new Debug(plugin, CLASS_NAME, level) {};
     }
 
     @Override
     public void connect() {
         try {
             if (connection == null || connection.isClosed()) {
-                Bukkit.getLogger().info("[RVNKToolKit] Attempting to establish MySQL connection to " + url);
+                debug.log(LogLevel.INFO, "Attempting to establish MySQL connection to " + url);
                 connection = DriverManager.getConnection(url, username, password);
-                Bukkit.getLogger().info("[RVNKToolKit] MySQL connection established successfully");
+                debug.log(LogLevel.INFO, "MySQL connection established successfully");
                 initializeTables();
             }
         } catch (SQLException e) {
-            Bukkit.getLogger().severe("[RVNKToolKit] Failed to connect to MySQL: " + e.getMessage());
-            e.printStackTrace();
+            debug.error("Failed to connect to MySQL: " + e.getMessage(), e);
         }
     }
 
@@ -50,13 +62,13 @@ public class MySQLDataConnector implements DataStore {
                 connection.close();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error disconnecting from database", e);
         }
     }
 
     private void ensureConnection() throws SQLException {
         if (connection == null || connection.isClosed()) {
-            Bukkit.getLogger().info("[RVNKToolKit] Re-establishing lost MySQL connection");
+            debug.log(LogLevel.INFO, "Re-establishing lost MySQL connection");
             connect();
         }
     }
@@ -79,7 +91,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error saving announcement: " + announcement.getId(), e);
         }
     }
 
@@ -93,7 +105,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error deleting announcement: " + id, e);
         }
     }
 
@@ -120,7 +132,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error loading announcements", e);
         }
         return new ArrayList<>(announcements.values());
     }
@@ -139,7 +151,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error saving announce type: " + announceType.getId(), e);
         }
     }
 
@@ -162,7 +174,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error loading announce types", e);
         }
         return announceTypes;
     }
@@ -174,12 +186,12 @@ public class MySQLDataConnector implements DataStore {
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
-            Bukkit.getLogger().info("[RVNKToolKit] Checking and creating necessary MySQL tables");
+            debug.log(LogLevel.INFO, "Checking and creating necessary MySQL tables");
             
             // Check if announcements table exists
             tables = metaData.getTables(database, null, "announcements", null);
             if (!tables.next()) {
-                Bukkit.getLogger().info("[RVNKToolKit] Creating announcements table");
+                debug.log(LogLevel.INFO, "Creating announcements table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncementsTable = "CREATE TABLE announcements (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -193,16 +205,16 @@ public class MySQLDataConnector implements DataStore {
                     "expiration DATETIME" +
                     ")";
                 stmt.executeUpdate(createAnnouncementsTable);
-                Bukkit.getLogger().info("[RVNKToolKit] announcements table created successfully");
+                debug.log(LogLevel.INFO, "announcements table created successfully");
                 empty = true;
             } else {
-                Bukkit.getLogger().info("[RVNKToolKit] announcements table already exists");
+                debug.log(LogLevel.INFO, "announcements table already exists");
             }
             
             // Check if announce_types table exists
             tables = metaData.getTables(database, null, "announce_types", null);
             if (!tables.next()) {
-                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_types table");
+                debug.log(LogLevel.INFO, "Creating announce_types table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceTypesTable = "CREATE TABLE announce_types (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -212,15 +224,15 @@ public class MySQLDataConnector implements DataStore {
                     "listing_fee DOUBLE" +
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
-                Bukkit.getLogger().info("[RVNKToolKit] announce_types table created successfully");
+                debug.log(LogLevel.INFO, "announce_types table created successfully");
             } else {
-                Bukkit.getLogger().info("[RVNKToolKit] announce_types table already exists");
+                debug.log(LogLevel.FINE, "announce_types table already exists");
             }
 
             // Check if announce_disabledtypes table exists
             tables = metaData.getTables(database, null, "announce_disabledtypes", null);
             if (!tables.next()) {
-                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_disabledtypes table");
+                debug.log(LogLevel.INFO, "Creating announce_disabledtypes table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
                     "player_id VARCHAR(36)," +
@@ -228,31 +240,30 @@ public class MySQLDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
-                Bukkit.getLogger().info("[RVNKToolKit] announce_disabledtypes table created successfully");
+                debug.log(LogLevel.INFO, "announce_disabledtypes table created successfully");
             } else {
-                Bukkit.getLogger().info("[RVNKToolKit] announce_disabledtypes table already exists");
+                debug.log(LogLevel.INFO, "announce_disabledtypes table already exists");
             }
 
             // Check if announce_prefs table exists
             tables = metaData.getTables(database, null, "announce_prefs", null);
             if (!tables.next()) {
-                Bukkit.getLogger().info("[RVNKToolKit] Creating announce_prefs table");
+                debug.log(LogLevel.INFO, "Creating announce_prefs table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
                     "player_id VARCHAR(36) PRIMARY KEY," +
                     "text VARCHAR(512)" +
                     ")";
                 stmt.executeUpdate(createAnnouncePrefsTable);
-                Bukkit.getLogger().info("[RVNKToolKit] announce_prefs table created successfully");
+                debug.log(LogLevel.INFO, "announce_prefs table created successfully");
             } else {
-                Bukkit.getLogger().info("[RVNKToolKit] announce_prefs table already exists");
+                debug.log(LogLevel.INFO, "announce_prefs table already exists");
             }
             
-            Bukkit.getLogger().info("[RVNKToolKit] All database tables verified/created successfully");
+            debug.log(LogLevel.INFO, "All database tables verified/created successfully");
             
         } catch (SQLException e) {
-            Bukkit.getLogger().severe("[RVNKToolKit] Failed to initialize database tables: " + e.getMessage());
-            e.printStackTrace();
+            debug.error("Failed to initialize database tables: " + e.getMessage(), e);
         }
     }
 
@@ -270,7 +281,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error checking if announcement exists: " + id, e);
         }
         return false;
     }
@@ -293,7 +304,7 @@ public class MySQLDataConnector implements DataStore {
                 return announceCount == 0 && typeCount == 0;
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error checking if database is empty", e);
             return true; // Assume empty on error
         }
     }
@@ -309,7 +320,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error saving player disabled type for playerId: " + playerId, e);
         }
     }
 
@@ -324,7 +335,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error removing player disabled type for playerId: " + playerId, e);
         }
     }
 
@@ -343,7 +354,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error retrieving disabled types for playerId: " + playerId, e);
         }
         return types;
     }
@@ -363,7 +374,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error retrieving all player disabled types", e);
         }
         return allTypes;
     }
@@ -380,7 +391,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.executeUpdate();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error saving player preferences for playerId: " + playerId, e);
         }
     }
 
@@ -398,7 +409,7 @@ public class MySQLDataConnector implements DataStore {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error retrieving player preferences for playerId: " + playerId, e);
         }
         return null;
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -3,6 +3,11 @@ package org.fourz.rvnktools.announceManager.data;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
@@ -11,7 +16,7 @@ public class MySQLDataConnector implements DataStore {
     private final String url;
     private final String username;
     private final String password;
-    private final String database; // Add database field
+    private final String database;
     private Connection connection;
     private boolean empty = false;
 
@@ -19,7 +24,7 @@ public class MySQLDataConnector implements DataStore {
         this.url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
         this.username = username;
         this.password = password;
-        this.database = database; // Store database name
+        this.database = database;
     }
 
     @Override
@@ -173,6 +178,18 @@ public class MySQLDataConnector implements DataStore {
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
             }
+
+            // Check if announce_disabledtypes table exists
+            tables = metaData.getTables(database, null, "announce_disabledtypes", null);
+            if (!tables.next()) {
+                Statement stmt = connection.createStatement();
+                String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
+                    "player_id VARCHAR(36)," +
+                    "type VARCHAR(64)," +
+                    "PRIMARY KEY (player_id, type)" +
+                    ")";
+                stmt.executeUpdate(createAnnounceDisabledTypesTable);
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -197,5 +214,63 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public boolean isEmpty() {
         return empty;
+    }
+
+    @Override
+    public void savePlayerDisabledType(UUID playerId, String type) {
+        String query = "INSERT IGNORE INTO announce_disabledtypes (player_id, type) VALUES (?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerId.toString());
+            statement.setString(2, type);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void removePlayerDisabledType(UUID playerId, String type) {
+        String query = "DELETE FROM announce_disabledtypes WHERE player_id = ? AND type = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerId.toString());
+            statement.setString(2, type);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Set<String> getPlayerDisabledTypes(UUID playerId) {
+        Set<String> types = new HashSet<>();
+        String query = "SELECT type FROM announce_disabledtypes WHERE player_id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerId.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    types.add(resultSet.getString("type"));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return types;
+    }
+
+    @Override
+    public Map<UUID, Set<String>> getAllPlayerDisabledTypes() {
+        Map<UUID, Set<String>> allTypes = new HashMap<>();
+        String query = "SELECT player_id, type FROM announce_disabledtypes";
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            while (resultSet.next()) {
+                UUID playerId = UUID.fromString(resultSet.getString("player_id"));
+                String type = resultSet.getString("type");
+                allTypes.computeIfAbsent(playerId, k -> new HashSet<>()).add(type);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return allTypes;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -8,7 +8,9 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
-import org.bukkit.Bukkit;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
 import org.bukkit.plugin.java.JavaPlugin;
 import java.util.logging.Level;
 
@@ -278,6 +280,59 @@ public class MySQLDataConnector implements DataStore {
                 debug.debug("announce_prefs table already exists");
             }
             
+            // Create stored procedure for hash calculation
+            try {
+                Statement dropStmt = connection.createStatement();
+                dropStmt.execute("DROP PROCEDURE IF EXISTS CalculateConfigHash");
+                
+                Statement createStmt = connection.createStatement();
+                String createHashProcedure = 
+                    "CREATE PROCEDURE CalculateConfigHash(OUT configHash INT) " +
+                    "BEGIN " +
+                    "    DECLARE done INT DEFAULT FALSE; " +
+                    "    DECLARE temp_str TEXT; " +
+                    "    DECLARE hash_str TEXT DEFAULT ''; " +
+                    "    DECLARE ann_cur CURSOR FOR " +
+                    "        SELECT CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(permission,'')) " +
+                    "        FROM announcements ORDER BY LOWER(id); " +
+                    "    DECLARE type_cur CURSOR FOR " +
+                    "        SELECT CONCAT('T|', LOWER(id), '|', COALESCE(prefix,''), '|', " +
+                    "                     COALESCE(suffix,''), '|', COALESCE(permission,''), '|', " +
+                    "                     COALESCE(listing_fee,'')) " +
+                    "        FROM announce_types ORDER BY LOWER(id); " +
+                    "    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE; " +
+                    
+                    "    SET hash_str = ''; " +  // Ensure clean start
+                    
+                    "    OPEN ann_cur; " +
+                    "    read_announcements: LOOP " +
+                    "        FETCH ann_cur INTO temp_str; " +
+                    "        IF done THEN " +
+                    "            LEAVE read_announcements; " +
+                    "        END IF; " +
+                    "        SET hash_str = CONCAT(hash_str, temp_str, '\n'); " +
+                    "    END LOOP; " +
+                    "    CLOSE ann_cur; " +
+                    
+                    "    SET done = FALSE; " +
+                    "    OPEN type_cur; " +
+                    "    read_types: LOOP " +
+                    "        FETCH type_cur INTO temp_str; " +
+                    "        IF done THEN " +
+                    "            LEAVE read_types; " +
+                    "        END IF; " +
+                    "        SET hash_str = CONCAT(hash_str, temp_str, '\n'); " +
+                    "    END LOOP; " +
+                    "    CLOSE type_cur; " +
+                    
+                    "    SET configHash = CAST(CONV(LEFT(MD5(hash_str), 8), 16, 10) AS SIGNED); " +
+                    "END";
+                createStmt.execute(createHashProcedure);
+                debug.debug("Created hash calculation stored procedure");
+            } catch (SQLException e) {
+                debug.error("Failed to create hash calculation stored procedure: " + e.getMessage(), e);
+            }
+            
             debug.debug("All database tables verified/created successfully");
             setTablesInitialized(true);
             
@@ -432,5 +487,125 @@ public class MySQLDataConnector implements DataStore {
             debug.error("Error retrieving player preferences for playerId: " + playerId, e);
         }
         return null;
+    }
+
+    /**
+     * Calculates configuration hash using database stored procedure
+     * @return Integer hash value of current database configuration
+     */
+    public Integer calculateDatabaseHash() {
+        try {
+            ensureConnection();
+            
+            // Get raw string for hashing
+            StringBuilder fullHashStr = new StringBuilder();
+            debug.debug("\nHASH CALCULATION SUMMARY");
+            debug.debug("------------------------");
+            
+            // Get announcements in sorted order
+            try (Statement stmt = connection.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery(
+                    "SELECT CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(recurrence,'')) AS data " +
+                    "FROM announcements ORDER BY LOWER(id)")) {
+                    while (rs.next()) {
+                        String dataLine = rs.getString("data");
+                        fullHashStr.append(dataLine).append("\n");
+                    }
+                }
+            }
+            
+            // Calculate both hash methods
+            String hashSource = fullHashStr.toString();
+            int javaHash = hashSource.hashCode();
+            
+            // Get MySQL stored procedure hash
+            CallableStatement cStmt = connection.prepareCall("{CALL CalculateConfigHash(?)}");
+            cStmt.registerOutParameter(1, Types.INTEGER);
+            cStmt.execute();
+            int mysqlHash = cStmt.getInt(1);
+            
+            // Log hash comparison
+            debug.debug("String length: " + hashSource.length());
+            debug.debug("Java hashCode(): " + javaHash);
+            debug.debug("MySQL proc hash: " + mysqlHash);
+            
+            if (javaHash != mysqlHash) {
+                debug.debug("!!! HASH MISMATCH DETECTED !!!");
+                debug.debug("Hash difference: " + (javaHash - mysqlHash));
+                
+                // Compare first different character
+                try (Statement diffStmt = connection.createStatement()) {
+                    String mysqlStr = "";
+                    try (ResultSet rs = diffStmt.executeQuery(
+                        "SELECT GROUP_CONCAT(CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(recurrence,'')) " + 
+                        "ORDER BY LOWER(id) SEPARATOR '\n') as str FROM announcements")) {
+                        if (rs.next()) {
+                            mysqlStr = rs.getString("str");
+                            for (int i = 0; i < Math.min(hashSource.length(), mysqlStr.length()); i++) {
+                                if (hashSource.charAt(i) != mysqlStr.charAt(i)) {
+                                    debug.debug(String.format("First difference at position %d: Java='%c' (ASCII: %d), MySQL='%c' (ASCII: %d)",
+                                        i, hashSource.charAt(i), (int)hashSource.charAt(i), 
+                                        mysqlStr.charAt(i), (int)mysqlStr.charAt(i)));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                debug.debug("✓ Hashes match perfectly");
+            }
+            debug.debug("------------------------\n");
+            
+            return mysqlHash;
+            
+        } catch (SQLException e) {
+            debug.error("Error calculating database hash", e);
+            return null;
+        }
+    }
+
+    /**
+     * @deprecated Use calculateDatabaseHash() instead
+     */
+    @Deprecated
+    private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
+        StringBuilder hashBuilder = new StringBuilder();
+        debug.debug("--- Java Hash Source Data ---");
+
+        // Process announcements
+        announcements.values().stream()
+            .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
+            .forEach(a -> {
+                String entry = String.format("A|%s|%s|%s|%s\n",
+                    a.getId().toLowerCase(),
+                    a.getType().toLowerCase(),
+                    a.getText(),
+                    Optional.ofNullable(a.getPermission()).orElse(""));
+                hashBuilder.append(entry);
+                debug.debug("Announcement entry: " + entry.trim());
+            });
+
+        // Process types
+        types.stream()
+            .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
+            .forEach(t -> {
+                String entry = String.format("T|%s|%s|%s|%s|%s\n",
+                    t.getId().toLowerCase(),
+                    Optional.ofNullable(t.getPrefix()).orElse(""),
+                    Optional.ofNullable(t.getSuffix()).orElse(""),
+                    Optional.ofNullable(t.getPermission()).orElse(""),
+                    Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""));
+                hashBuilder.append(entry);
+                debug.debug("Type entry: " + entry.trim());
+            });
+
+        debug.debug("--- End Java Hash Source Data ---");
+        
+        String hashStr = hashBuilder.toString();
+        int hash = hashStr.hashCode();
+        debug.debug("Java hash string length: " + hashStr.length());
+        debug.debug("Java raw hash value: " + hash);
+        return hash;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -8,9 +8,6 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Optional;
 import org.bukkit.plugin.java.JavaPlugin;
 import java.util.logging.Level;
 
@@ -56,9 +53,8 @@ public class MySQLDataConnector implements DataStore {
     public void connect() {
         try {
             if (connection == null || connection.isClosed()) {
-                debug.debug("Attempting to establish MySQL connection to " + url);
+                debug.debug("Establishing MySQL connection...");
                 connection = DriverManager.getConnection(url, username, password);
-                debug.debug("MySQL connection established successfully");
                 if (!areTablesInitialized()) {
                     initializeTables();
                 }
@@ -73,7 +69,7 @@ public class MySQLDataConnector implements DataStore {
         try {
             if (connection != null && !connection.isClosed()) {
                 connection.close();
-                debug.debug("MySQL connection closed successfully");
+                debug.debug("MySQL connection closed");
             }
         } catch (SQLException e) {
             debug.error("Error disconnecting from database", e);
@@ -282,53 +278,7 @@ public class MySQLDataConnector implements DataStore {
             
             // Create stored procedure for hash calculation
             try {
-                Statement dropStmt = connection.createStatement();
-                dropStmt.execute("DROP PROCEDURE IF EXISTS CalculateConfigHash");
-                
-                Statement createStmt = connection.createStatement();
-                String createHashProcedure = 
-                    "CREATE PROCEDURE CalculateConfigHash(OUT configHash INT) " +
-                    "BEGIN " +
-                    "    DECLARE done INT DEFAULT FALSE; " +
-                    "    DECLARE temp_str TEXT; " +
-                    "    DECLARE hash_str TEXT DEFAULT ''; " +
-                    "    DECLARE ann_cur CURSOR FOR " +
-                    "        SELECT CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(permission,'')) " +
-                    "        FROM announcements ORDER BY LOWER(id); " +
-                    "    DECLARE type_cur CURSOR FOR " +
-                    "        SELECT CONCAT('T|', LOWER(id), '|', COALESCE(prefix,''), '|', " +
-                    "                     COALESCE(suffix,''), '|', COALESCE(permission,''), '|', " +
-                    "                     COALESCE(listing_fee,'')) " +
-                    "        FROM announce_types ORDER BY LOWER(id); " +
-                    "    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE; " +
-                    
-                    "    SET hash_str = ''; " +  // Ensure clean start
-                    
-                    "    OPEN ann_cur; " +
-                    "    read_announcements: LOOP " +
-                    "        FETCH ann_cur INTO temp_str; " +
-                    "        IF done THEN " +
-                    "            LEAVE read_announcements; " +
-                    "        END IF; " +
-                    "        SET hash_str = CONCAT(hash_str, temp_str, '\n'); " +
-                    "    END LOOP; " +
-                    "    CLOSE ann_cur; " +
-                    
-                    "    SET done = FALSE; " +
-                    "    OPEN type_cur; " +
-                    "    read_types: LOOP " +
-                    "        FETCH type_cur INTO temp_str; " +
-                    "        IF done THEN " +
-                    "            LEAVE read_types; " +
-                    "        END IF; " +
-                    "        SET hash_str = CONCAT(hash_str, temp_str, '\n'); " +
-                    "    END LOOP; " +
-                    "    CLOSE type_cur; " +
-                    
-                    "    SET configHash = CAST(CONV(LEFT(MD5(hash_str), 8), 16, 10) AS SIGNED); " +
-                    "END";
-                createStmt.execute(createHashProcedure);
-                debug.debug("Created hash calculation stored procedure");
+                createHashProcedure();
             } catch (SQLException e) {
                 debug.error("Failed to create hash calculation stored procedure: " + e.getMessage(), e);
             }
@@ -338,6 +288,59 @@ public class MySQLDataConnector implements DataStore {
             
         } catch (SQLException e) {
             debug.error("Failed to initialize database tables: " + e.getMessage(), e);
+        }
+    }
+
+    private void createHashProcedure() throws SQLException {
+        Statement dropStmt = connection.createStatement();
+        dropStmt.execute("DROP PROCEDURE IF EXISTS CalculateConfigHash");
+        
+        String createHashProcedure = 
+            "CREATE PROCEDURE CalculateConfigHash(OUT configHash VARCHAR(32)) " +
+            "BEGIN " +
+            "    DECLARE done INT DEFAULT FALSE; " +
+            "    DECLARE temp_id VARCHAR(64); " +
+            "    DECLARE hash_str TEXT DEFAULT ''; " +
+            "    DECLARE ann_cur CURSOR FOR " +
+            "        SELECT LOWER(id) " +
+            "        FROM announcements " +
+            "        ORDER BY LOWER(id); " +
+            "    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE; " +
+            
+            "    OPEN ann_cur; " +
+            "    read_loop: LOOP " +
+            "        FETCH ann_cur INTO temp_id; " +
+            "        IF done THEN " +
+            "            LEAVE read_loop; " +
+            "        END IF; " +
+            "        SET hash_str = CONCAT(hash_str, temp_id, '\n'); " +
+            "    END LOOP; " +
+            "    CLOSE ann_cur; " +
+            
+            "    IF LENGTH(hash_str) = 0 THEN " +
+            "        SET configHash = NULL; " +
+            "    ELSE " +
+            "        SET configHash = MD5(hash_str); " +
+            "    END IF; " +
+            "END";
+            
+        Statement createStmt = connection.createStatement();
+        createStmt.execute(createHashProcedure);
+        debug.debug("Created hash calculation stored procedure");
+    }
+
+    public String calculateDatabaseHash() {
+        try {
+            ensureConnection();
+            
+            CallableStatement cStmt = connection.prepareCall("{CALL CalculateConfigHash(?)}");
+            cStmt.registerOutParameter(1, Types.VARCHAR);
+            cStmt.execute();
+            return cStmt.getString(1);
+            
+        } catch (SQLException e) {
+            debug.error("Error calculating database hash", e);
+            return null;
         }
     }
 
@@ -489,123 +492,20 @@ public class MySQLDataConnector implements DataStore {
         return null;
     }
 
-    /**
-     * Calculates configuration hash using database stored procedure
-     * @return Integer hash value of current database configuration
-     */
-    public Integer calculateDatabaseHash() {
+    public Set<String> getExistingAnnouncementIds() {
+        Set<String> ids = new HashSet<>();
         try {
             ensureConnection();
-            
-            // Get raw string for hashing
-            StringBuilder fullHashStr = new StringBuilder();
-            debug.debug("\nHASH CALCULATION SUMMARY");
-            debug.debug("------------------------");
-            
-            // Get announcements in sorted order
-            try (Statement stmt = connection.createStatement()) {
-                try (ResultSet rs = stmt.executeQuery(
-                    "SELECT CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(recurrence,'')) AS data " +
-                    "FROM announcements ORDER BY LOWER(id)")) {
-                    while (rs.next()) {
-                        String dataLine = rs.getString("data");
-                        fullHashStr.append(dataLine).append("\n");
-                    }
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT LOWER(id) FROM announcements")) {
+                while (rs.next()) {
+                    ids.add(rs.getString(1));
                 }
             }
-            
-            // Calculate both hash methods
-            String hashSource = fullHashStr.toString();
-            int javaHash = hashSource.hashCode();
-            
-            // Get MySQL stored procedure hash
-            CallableStatement cStmt = connection.prepareCall("{CALL CalculateConfigHash(?)}");
-            cStmt.registerOutParameter(1, Types.INTEGER);
-            cStmt.execute();
-            int mysqlHash = cStmt.getInt(1);
-            
-            // Log hash comparison
-            debug.debug("String length: " + hashSource.length());
-            debug.debug("Java hashCode(): " + javaHash);
-            debug.debug("MySQL proc hash: " + mysqlHash);
-            
-            if (javaHash != mysqlHash) {
-                debug.debug("!!! HASH MISMATCH DETECTED !!!");
-                debug.debug("Hash difference: " + (javaHash - mysqlHash));
-                
-                // Compare first different character
-                try (Statement diffStmt = connection.createStatement()) {
-                    String mysqlStr = "";
-                    try (ResultSet rs = diffStmt.executeQuery(
-                        "SELECT GROUP_CONCAT(CONCAT('A|', LOWER(id), '|', LOWER(type), '|', text, '|', COALESCE(recurrence,'')) " + 
-                        "ORDER BY LOWER(id) SEPARATOR '\n') as str FROM announcements")) {
-                        if (rs.next()) {
-                            mysqlStr = rs.getString("str");
-                            for (int i = 0; i < Math.min(hashSource.length(), mysqlStr.length()); i++) {
-                                if (hashSource.charAt(i) != mysqlStr.charAt(i)) {
-                                    debug.debug(String.format("First difference at position %d: Java='%c' (ASCII: %d), MySQL='%c' (ASCII: %d)",
-                                        i, hashSource.charAt(i), (int)hashSource.charAt(i), 
-                                        mysqlStr.charAt(i), (int)mysqlStr.charAt(i)));
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                debug.debug("✓ Hashes match perfectly");
-            }
-            debug.debug("------------------------\n");
-            
-            return mysqlHash;
-            
+            debug.debug("Retrieved " + ids.size() + " announcement IDs from database");
         } catch (SQLException e) {
-            debug.error("Error calculating database hash", e);
-            return null;
+            debug.error("Error retrieving announcement IDs", e);
         }
-    }
-
-    /**
-     * @deprecated Use calculateDatabaseHash() instead
-     */
-    @Deprecated
-    private Integer generateConfigHash(Map<String, Announcement> announcements, Collection<AnnounceType> types) {
-        StringBuilder hashBuilder = new StringBuilder();
-        debug.debug("--- Java Hash Source Data ---");
-
-        // Process announcements
-        announcements.values().stream()
-            .sorted(Comparator.comparing(a -> a.getId().toLowerCase()))
-            .forEach(a -> {
-                String entry = String.format("A|%s|%s|%s|%s\n",
-                    a.getId().toLowerCase(),
-                    a.getType().toLowerCase(),
-                    a.getText(),
-                    Optional.ofNullable(a.getPermission()).orElse(""));
-                hashBuilder.append(entry);
-                debug.debug("Announcement entry: " + entry.trim());
-            });
-
-        // Process types
-        types.stream()
-            .sorted(Comparator.comparing(t -> t.getId().toLowerCase()))
-            .forEach(t -> {
-                String entry = String.format("T|%s|%s|%s|%s|%s\n",
-                    t.getId().toLowerCase(),
-                    Optional.ofNullable(t.getPrefix()).orElse(""),
-                    Optional.ofNullable(t.getSuffix()).orElse(""),
-                    Optional.ofNullable(t.getPermission()).orElse(""),
-                    Optional.ofNullable(t.getListingFee()).map(Object::toString).orElse(""));
-                hashBuilder.append(entry);
-                debug.debug("Type entry: " + entry.trim());
-            });
-
-        debug.debug("--- End Java Hash Source Data ---");
-        
-        String hashStr = hashBuilder.toString();
-        int hash = hashStr.hashCode();
-        debug.debug("Java hash string length: " + hashStr.length());
-        debug.debug("Java raw hash value: " + hash);
-        return hash;
+        return ids;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -30,9 +30,10 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void connect() {
         try {
-            connection = DriverManager.getConnection(url, username, password);
-            // Initialize tables immediately after connection
-            initializeTables();
+            if (connection == null || connection.isClosed()) {
+                connection = DriverManager.getConnection(url, username, password);
+                initializeTables();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -49,20 +50,29 @@ public class MySQLDataConnector implements DataStore {
         }
     }
 
+    private void ensureConnection() throws SQLException {
+        if (connection == null || connection.isClosed()) {
+            connect();
+        }
+    }
+
     @Override
     public void saveAnnouncement(Announcement announcement) {
         String query = "INSERT INTO announcements (id, text, type, recurrence, owner, permission, date, time, expiration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, announcement.getId());
-            statement.setString(2, announcement.getText());
-            statement.setString(3, announcement.getType());
-            statement.setString(4, announcement.getRecurrence());
-            statement.setString(5, announcement.getOwner());
-            statement.setString(6, announcement.getPermission());
-            statement.setDate(7, announcement.getDate() != null ? Date.valueOf(announcement.getDate()) : null);
-            statement.setTime(8, announcement.getTime() != null ? Time.valueOf(announcement.getTime()) : null);
-            statement.setTimestamp(9, announcement.getExpiration() != null ? Timestamp.valueOf(announcement.getExpiration()) : null);
-            statement.executeUpdate();
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, announcement.getId());
+                statement.setString(2, announcement.getText());
+                statement.setString(3, announcement.getType());
+                statement.setString(4, announcement.getRecurrence());
+                statement.setString(5, announcement.getOwner());
+                statement.setString(6, announcement.getPermission());
+                statement.setDate(7, announcement.getDate() != null ? Date.valueOf(announcement.getDate()) : null);
+                statement.setTime(8, announcement.getTime() != null ? Time.valueOf(announcement.getTime()) : null);
+                statement.setTimestamp(9, announcement.getExpiration() != null ? Timestamp.valueOf(announcement.getExpiration()) : null);
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -71,9 +81,12 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void deleteAnnouncement(String id) {
         String query = "DELETE FROM announcements WHERE id = ?";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, id);
-            statement.executeUpdate();
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, id);
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -83,20 +96,23 @@ public class MySQLDataConnector implements DataStore {
     public List<Announcement> loadAnnouncements() {
         List<Announcement> announcements = new ArrayList<>();
         String query = "SELECT * FROM announcements";
-        try (Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(query)) {
-            while (resultSet.next()) {
-                Announcement announcement = new Announcement();
-                announcement.setId(resultSet.getString("id"));
-                announcement.setText(resultSet.getString("text"));
-                announcement.setType(resultSet.getString("type"));
-                announcement.setRecurrence(resultSet.getString("recurrence"));
-                announcement.setOwner(resultSet.getString("owner"));
-                announcement.setPermission(resultSet.getString("permission"));
-                announcement.setDate(resultSet.getDate("date") != null ? resultSet.getDate("date").toLocalDate() : null);
-                announcement.setTime(resultSet.getTime("time") != null ? resultSet.getTime("time").toLocalTime() : null);
-                announcement.setExpiration(resultSet.getTimestamp("expiration") != null ? resultSet.getTimestamp("expiration").toLocalDateTime() : null);
-                announcements.add(announcement);
+        try {
+            ensureConnection();
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery(query)) {
+                while (resultSet.next()) {
+                    Announcement announcement = new Announcement();
+                    announcement.setId(resultSet.getString("id"));
+                    announcement.setText(resultSet.getString("text"));
+                    announcement.setType(resultSet.getString("type"));
+                    announcement.setRecurrence(resultSet.getString("recurrence"));
+                    announcement.setOwner(resultSet.getString("owner"));
+                    announcement.setPermission(resultSet.getString("permission"));
+                    announcement.setDate(resultSet.getDate("date") != null ? resultSet.getDate("date").toLocalDate() : null);
+                    announcement.setTime(resultSet.getTime("time") != null ? resultSet.getTime("time").toLocalTime() : null);
+                    announcement.setExpiration(resultSet.getTimestamp("expiration") != null ? resultSet.getTimestamp("expiration").toLocalDateTime() : null);
+                    announcements.add(announcement);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -107,13 +123,16 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void saveAnnounceType(AnnounceType announceType) {
         String query = "INSERT INTO announce_types (id, prefix, suffix, permission, listing_fee) VALUES (?, ?, ?, ?, ?)";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, announceType.getId());
-            statement.setString(2, announceType.getPrefix());
-            statement.setString(3, announceType.getSuffix());
-            statement.setString(4, announceType.getPermission());
-            statement.setDouble(5, announceType.getListingFee() != null ? announceType.getListingFee() : 0.0);
-            statement.executeUpdate();
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, announceType.getId());
+                statement.setString(2, announceType.getPrefix());
+                statement.setString(3, announceType.getSuffix());
+                statement.setString(4, announceType.getPermission());
+                statement.setDouble(5, announceType.getListingFee() != null ? announceType.getListingFee() : 0.0);
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -123,16 +142,19 @@ public class MySQLDataConnector implements DataStore {
     public List<AnnounceType> loadAnnounceTypes() {
         List<AnnounceType> announceTypes = new ArrayList<>();
         String query = "SELECT * FROM announce_types";
-        try (Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(query)) {
-            while (resultSet.next()) {
-                AnnounceType announceType = new AnnounceType();
-                announceType.setId(resultSet.getString("id"));
-                announceType.setPrefix(resultSet.getString("prefix"));
-                announceType.setSuffix(resultSet.getString("suffix"));
-                announceType.setPermission(resultSet.getString("permission"));
-                announceType.setListingFee(resultSet.getDouble("listing_fee"));
-                announceTypes.add(announceType);
+        try {
+            ensureConnection();
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery(query)) {
+                while (resultSet.next()) {
+                    AnnounceType announceType = new AnnounceType();
+                    announceType.setId(resultSet.getString("id"));
+                    announceType.setPrefix(resultSet.getString("prefix"));
+                    announceType.setSuffix(resultSet.getString("suffix"));
+                    announceType.setPermission(resultSet.getString("permission"));
+                    announceType.setListingFee(resultSet.getDouble("listing_fee"));
+                    announceTypes.add(announceType);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -143,6 +165,7 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void initializeTables() {
         try {
+            ensureConnection();
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
@@ -197,12 +220,15 @@ public class MySQLDataConnector implements DataStore {
 
     public boolean announcementExists(String id) {
         String query = "SELECT COUNT(*) FROM announcements WHERE id = ?";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, id);
-            try (ResultSet resultSet = statement.executeQuery()) {
-                if (resultSet.next()) {
-                    int count = resultSet.getInt(1);
-                    return count > 0;
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, id);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        int count = resultSet.getInt(1);
+                        return count > 0;
+                    }
                 }
             }
         } catch (SQLException e) {
@@ -219,10 +245,13 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void savePlayerDisabledType(UUID playerId, String type) {
         String query = "INSERT IGNORE INTO announce_disabledtypes (player_id, type) VALUES (?, ?)";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, playerId.toString());
-            statement.setString(2, type);
-            statement.executeUpdate();
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerId.toString());
+                statement.setString(2, type);
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -231,10 +260,13 @@ public class MySQLDataConnector implements DataStore {
     @Override
     public void removePlayerDisabledType(UUID playerId, String type) {
         String query = "DELETE FROM announce_disabledtypes WHERE player_id = ? AND type = ?";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, playerId.toString());
-            statement.setString(2, type);
-            statement.executeUpdate();
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerId.toString());
+                statement.setString(2, type);
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -244,11 +276,14 @@ public class MySQLDataConnector implements DataStore {
     public Set<String> getPlayerDisabledTypes(UUID playerId) {
         Set<String> types = new HashSet<>();
         String query = "SELECT type FROM announce_disabledtypes WHERE player_id = ?";
-        try (PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, playerId.toString());
-            try (ResultSet resultSet = statement.executeQuery()) {
-                while (resultSet.next()) {
-                    types.add(resultSet.getString("type"));
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerId.toString());
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {
+                        types.add(resultSet.getString("type"));
+                    }
                 }
             }
         } catch (SQLException e) {
@@ -261,12 +296,15 @@ public class MySQLDataConnector implements DataStore {
     public Map<UUID, Set<String>> getAllPlayerDisabledTypes() {
         Map<UUID, Set<String>> allTypes = new HashMap<>();
         String query = "SELECT player_id, type FROM announce_disabledtypes";
-        try (Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(query)) {
-            while (resultSet.next()) {
-                UUID playerId = UUID.fromString(resultSet.getString("player_id"));
-                String type = resultSet.getString("type");
-                allTypes.computeIfAbsent(playerId, k -> new HashSet<>()).add(type);
+        try {
+            ensureConnection();
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery(query)) {
+                while (resultSet.next()) {
+                    UUID playerId = UUID.fromString(resultSet.getString("player_id"));
+                    String type = resultSet.getString("type");
+                    allTypes.computeIfAbsent(playerId, k -> new HashSet<>()).add(type);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -10,11 +10,12 @@ import java.util.Map;
 import java.util.HashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import java.util.logging.Level;
 
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
 import org.fourz.rvnktools.util.Debug;
-import org.fourz.rvnktools.util.Debug.LogLevel;
+import org.fourz.rvnktools.announceManager.AnnounceConfig;
 
 public class MySQLDataConnector implements DataStore {
     private static final String CLASS_NAME = "MySQLDataConnector";
@@ -25,33 +26,43 @@ public class MySQLDataConnector implements DataStore {
     private Connection connection;
     private boolean empty = false;
     private final Debug debug;
+    private boolean tablesInitialized = false;
 
     public MySQLDataConnector(JavaPlugin plugin, String host, int port, String database, String username, String password, boolean useSSL) {
         this.url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
         this.username = username;
         this.password = password;
         this.database = database;
-        this.debug = new Debug(plugin, CLASS_NAME, LogLevel.INFO) {};
+        this.debug = new Debug(plugin, CLASS_NAME, AnnounceConfig.getLogLevel()) {};
     }
-    public MySQLDataConnector(JavaPlugin plugin, String host, int port, String database, String username, String password, boolean useSSL, LogLevel level) {
-        this.url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
-        this.username = username;
-        this.password = password;
-        this.database = database;
-        this.debug = new Debug(plugin, CLASS_NAME, level) {};
+
+    public MySQLDataConnector(JavaPlugin plugin, String host, int port, String database, String username, String password, boolean useSSL, Level level) {
+        this(plugin, host, port, database, username, password, useSSL);
+    }
+
+    @Override
+    public boolean areTablesInitialized() {
+        return tablesInitialized;
+    }
+
+    @Override
+    public void setTablesInitialized(boolean initialized) {
+        this.tablesInitialized = initialized;
     }
 
     @Override
     public void connect() {
         try {
             if (connection == null || connection.isClosed()) {
-                debug.log(LogLevel.CONFIG, "Attempting to establish MySQL connection to " + url);
+                debug.debug("Attempting to establish MySQL connection to " + url);
                 connection = DriverManager.getConnection(url, username, password);
-                debug.log(LogLevel.FINE, "MySQL connection established successfully");
-                initializeTables();
+                debug.debug("MySQL connection established successfully");
+                if (!areTablesInitialized()) {
+                    initializeTables();
+                }
             }
         } catch (SQLException e) {
-            debug.error("Failed to connect to MySQL: " + e.getMessage(), e);
+            debug.error("Failed to connect to MySQL", e);
         }
     }
 
@@ -60,6 +71,7 @@ public class MySQLDataConnector implements DataStore {
         try {
             if (connection != null && !connection.isClosed()) {
                 connection.close();
+                debug.debug("MySQL connection closed successfully");
             }
         } catch (SQLException e) {
             debug.error("Error disconnecting from database", e);
@@ -68,7 +80,7 @@ public class MySQLDataConnector implements DataStore {
 
     private void ensureConnection() throws SQLException {
         if (connection == null || connection.isClosed()) {
-            debug.log(LogLevel.FINE, "Re-establishing lost MySQL connection");
+            debug.debug("Re-establishing lost MySQL connection");
             connect();
         }
     }
@@ -131,6 +143,7 @@ public class MySQLDataConnector implements DataStore {
                     announcements.put(announcement.getId(), announcement);
                 }
             }
+            debug.log(Level.FINE, "Loaded " + announcements.size() + " announcements from database");
         } catch (SQLException e) {
             debug.error("Error loading announcements", e);
         }
@@ -181,17 +194,22 @@ public class MySQLDataConnector implements DataStore {
 
     @Override
     public void initializeTables() {
+        if (areTablesInitialized()) {
+            debug.debug("Tables already initialized, skipping verification");
+            return;
+        }
+
         try {
             ensureConnection();
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
-            debug.log(LogLevel.CONFIG, "Checking and creating necessary MySQL tables");
+            debug.debug("Checking and creating necessary MySQL tables");
             
             // Check if announcements table exists
             tables = metaData.getTables(database, null, "announcements", null);
             if (!tables.next()) {
-                debug.log(LogLevel.CONFIG, "Creating announcements table");
+                debug.debug("Creating announcements table - table does not exist");
                 Statement stmt = connection.createStatement();
                 String createAnnouncementsTable = "CREATE TABLE announcements (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -205,16 +223,16 @@ public class MySQLDataConnector implements DataStore {
                     "expiration DATETIME" +
                     ")";
                 stmt.executeUpdate(createAnnouncementsTable);
-                debug.log(LogLevel.INFO, "announcements table created successfully");
+                debug.debug("announcements table created successfully");
                 empty = true;
             } else {
-                debug.log(LogLevel.FINE, "announcements table already exists");
+                debug.debug("announcements table already exists");
             }
             
             // Check if announce_types table exists
             tables = metaData.getTables(database, null, "announce_types", null);
             if (!tables.next()) {
-                debug.log(LogLevel.CONFIG, "Creating announce_types table");
+                debug.debug("Creating announce_types table - table does not exist");
                 Statement stmt = connection.createStatement();
                 String createAnnounceTypesTable = "CREATE TABLE announce_types (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -224,15 +242,15 @@ public class MySQLDataConnector implements DataStore {
                     "listing_fee DOUBLE" +
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
-                debug.log(LogLevel.INFO, "announce_types table created successfully");
+                debug.debug("announce_types table created successfully");
             } else {
-                debug.log(LogLevel.FINE, "announce_types table already exists");
+                debug.debug("announce_types table already exists");
             }
 
             // Check if announce_disabledtypes table exists
             tables = metaData.getTables(database, null, "announce_disabledtypes", null);
             if (!tables.next()) {
-                debug.log(LogLevel.CONFIG, "Creating announce_disabledtypes table");
+                debug.debug("Creating announce_disabledtypes table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
                     "player_id VARCHAR(36)," +
@@ -240,27 +258,28 @@ public class MySQLDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
-                debug.log(LogLevel.INFO, "announce_disabledtypes table created successfully");
+                debug.debug("announce_disabledtypes table created successfully");
             } else {
-                debug.log(LogLevel.FINE, "announce_disabledtypes table already exists");
+                debug.debug("announce_disabledtypes table already exists");
             }
 
             // Check if announce_prefs table exists
             tables = metaData.getTables(database, null, "announce_prefs", null);
             if (!tables.next()) {
-                debug.log(LogLevel.CONFIG, "Creating announce_prefs table");
+                debug.debug("Creating announce_prefs table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
                     "player_id VARCHAR(36) PRIMARY KEY," +
                     "text VARCHAR(512)" +
                     ")";
                 stmt.executeUpdate(createAnnouncePrefsTable);
-                debug.log(LogLevel.INFO, "announce_prefs table created successfully");
+                debug.debug("announce_prefs table created successfully");
             } else {
-                debug.log(LogLevel.FINE, "announce_prefs table already exists");
+                debug.debug("announce_prefs table already exists");
             }
             
-            debug.log(LogLevel.CONFIG, "All database tables verified/created successfully");
+            debug.debug("All database tables verified/created successfully");
+            setTablesInitialized(true);
             
         } catch (SQLException e) {
             debug.error("Failed to initialize database tables: " + e.getMessage(), e);
@@ -290,6 +309,7 @@ public class MySQLDataConnector implements DataStore {
     public boolean isEmpty() {
         try {
             ensureConnection();
+            debug.debug("Checking if the database is empty");
             
             // Check both tables for data
             try (Statement stmt = connection.createStatement()) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/MySQLDataConnector.java
@@ -65,7 +65,7 @@ public class MySQLDataConnector implements DataStore {
                 statement.setString(1, announcement.getId());
                 statement.setString(2, announcement.getText());
                 statement.setString(3, announcement.getType());
-                statement.setString(4, announcement.getRecurrence());
+                statement.setObject(4, announcement.getRecurrence()); // Changed to handle Long
                 statement.setString(5, announcement.getOwner());
                 statement.setString(6, announcement.getPermission());
                 statement.setDate(7, announcement.getDate() != null ? Date.valueOf(announcement.getDate()) : null);
@@ -105,7 +105,7 @@ public class MySQLDataConnector implements DataStore {
                     announcement.setId(resultSet.getString("id"));
                     announcement.setText(resultSet.getString("text"));
                     announcement.setType(resultSet.getString("type"));
-                    announcement.setRecurrence(resultSet.getString("recurrence"));
+                    announcement.setRecurrence(resultSet.getObject("recurrence") != null ? resultSet.getLong("recurrence") : null);
                     announcement.setOwner(resultSet.getString("owner"));
                     announcement.setPermission(resultSet.getString("permission"));
                     announcement.setDate(resultSet.getDate("date") != null ? resultSet.getDate("date").toLocalDate() : null);
@@ -177,7 +177,7 @@ public class MySQLDataConnector implements DataStore {
                     "id VARCHAR(64) PRIMARY KEY," +
                     "text TEXT NOT NULL," +
                     "type VARCHAR(32) NOT NULL," +
-                    "recurrence VARCHAR(32)," +
+                    "recurrence BIGINT," + // Changed from VARCHAR to BIGINT
                     "owner VARCHAR(64)," +
                     "permission VARCHAR(128)," +
                     "date DATE," +
@@ -212,6 +212,17 @@ public class MySQLDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
+            }
+
+            // Check if announce_prefs table exists
+            tables = metaData.getTables(database, null, "announce_prefs", null);
+            if (!tables.next()) {
+                Statement stmt = connection.createStatement();
+                String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
+                    "player_id VARCHAR(36) PRIMARY KEY," +
+                    "text VARCHAR(512)" +
+                    ")";
+                stmt.executeUpdate(createAnnouncePrefsTable);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -310,5 +321,40 @@ public class MySQLDataConnector implements DataStore {
             e.printStackTrace();
         }
         return allTypes;
+    }
+
+    @Override
+    public void savePlayerPreferences(UUID playerId, String preferences) {
+        String query = "INSERT INTO announce_prefs (player_id, text) VALUES (?, ?) ON DUPLICATE KEY UPDATE text = ?";
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerId.toString());
+                statement.setString(2, preferences);
+                statement.setString(3, preferences);
+                statement.executeUpdate();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String getPlayerPreferences(UUID playerId) {
+        String query = "SELECT text FROM announce_prefs WHERE player_id = ?";
+        try {
+            ensureConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerId.toString());
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        return resultSet.getString("text");
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -116,9 +116,10 @@ public class SQLiteDataConnector implements DataStore {
                 pstmt.setString(8, announcement.getTime() != null ? announcement.getTime().toString() : null);
                 pstmt.setString(9, announcement.getExpiration() != null ? announcement.getExpiration().toString() : null);
                 pstmt.executeUpdate();
+                debug.debug("Saved announcement with ID: " + announcement.getId());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error saving announcement: " + announcement.getId(), e);
         }
     }
 
@@ -126,16 +127,14 @@ public class SQLiteDataConnector implements DataStore {
     public void deleteAnnouncement(String id) {
         try {
             ensureConnected();
+            String sql = "DELETE FROM announcements WHERE id = ?";
+            try (PreparedStatement pstmt = this.connection.prepareStatement(sql)) {
+                pstmt.setString(1, id);
+                int rows = pstmt.executeUpdate();
+                debug.debug("Deleted announcement with ID: " + id + " (" + rows + " rows affected)");
+            }
         } catch (SQLException e) {
-            e.printStackTrace();
-            return;
-        }
-        String sql = "DELETE FROM announcements WHERE id = ?";
-        try (PreparedStatement pstmt = this.connection.prepareStatement(sql)) {
-            pstmt.setString(1, id);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error deleting announcement: " + id, e);
         }
     }
 
@@ -161,8 +160,9 @@ public class SQLiteDataConnector implements DataStore {
                     announcements.put(announcement.getId(), announcement);
                 }
             }
+            debug.debug("Loaded " + announcements.size() + " announcements from database");
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error loading announcements", e);
         }
         return new ArrayList<>(announcements.values());
     }
@@ -221,9 +221,12 @@ public class SQLiteDataConnector implements DataStore {
             DatabaseMetaData metaData = connection.getMetaData();
             ResultSet tables;
             
+            debug.debug("Starting table initialization check");
+            
             // Check if announcements table exists
             tables = metaData.getTables(null, null, "announcements", null);
             if (!tables.next()) {
+                debug.debug("Creating announcements table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncementsTable = "CREATE TABLE announcements (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -237,12 +240,14 @@ public class SQLiteDataConnector implements DataStore {
                     "expiration DATETIME" +
                     ")";
                 stmt.executeUpdate(createAnnouncementsTable);
+                debug.debug("Announcements table created successfully");
                 empty = true;
             }
             
             // Check if announce_types table exists
             tables = metaData.getTables(null, null, "announce_types", null);
             if (!tables.next()) {
+                debug.debug("Creating announce_types table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceTypesTable = "CREATE TABLE announce_types (" +
                     "id VARCHAR(64) PRIMARY KEY," +
@@ -252,11 +257,13 @@ public class SQLiteDataConnector implements DataStore {
                     "listing_fee DOUBLE" +
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
+                debug.debug("announce_types table created successfully");
             }
             
             // Check if announce_disabledtypes table exists
             tables = metaData.getTables(null, null, "announce_disabledtypes", null);
             if (!tables.next()) {
+                debug.debug("Creating announce_disabledtypes table");
                 Statement stmt = connection.createStatement();
                 String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
                     "player_id VARCHAR(36)," +
@@ -264,20 +271,26 @@ public class SQLiteDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
+                debug.debug("announce_disabledtypes table created successfully");
             }
             
             // Check if announce_prefs table exists
             tables = metaData.getTables(null, null, "announce_prefs", null);
             if (!tables.next()) {
+                debug.debug("Creating announce_prefs table");
                 Statement stmt = connection.createStatement();
                 String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
                     "player_id VARCHAR(36) PRIMARY KEY," +
                     "text VARCHAR(512)" +
                     ")";
                 stmt.executeUpdate(createAnnouncePrefsTable);
+                debug.debug("announce_prefs table created successfully");
             }
+            
+            debug.debug("Table initialization complete");
+            
         } catch (SQLException e) {
-            e.printStackTrace();
+            debug.error("Error initializing database tables", e);
         }
     }
 
@@ -302,6 +315,7 @@ public class SQLiteDataConnector implements DataStore {
 
     @Override
     public boolean isEmpty() {
+        debug.debug("Checking if database is empty");
         return empty;
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -137,33 +137,30 @@ public class SQLiteDataConnector implements DataStore {
 
     @Override
     public List<Announcement> loadAnnouncements() {
+        Map<String, Announcement> announcements = new HashMap<>();
+        String sql = "SELECT * FROM announcements";
         try {
             ensureConnected();
-        } catch (SQLException e) {
-            e.printStackTrace();
-            return new ArrayList<>();
-        }
-        List<Announcement> announcements = new ArrayList<>();
-        String sql = "SELECT * FROM announcements";
-        try (Statement stmt = this.connection.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
-            while (rs.next()) {
-                Announcement announcement = new Announcement();
-                announcement.setId(rs.getString("id"));
-                announcement.setText(rs.getString("text"));
-                announcement.setType(rs.getString("type"));
-                announcement.setRecurrence(rs.getObject("recurrence") != null ? rs.getLong("recurrence") : null);
-                announcement.setOwner(rs.getString("owner"));
-                announcement.setPermission(rs.getString("permission"));
-                announcement.setDate(rs.getString("date") != null ? LocalDate.parse(rs.getString("date")) : null);
-                announcement.setTime(rs.getString("time") != null ? LocalTime.parse(rs.getString("time")) : null);
-                announcement.setExpiration(rs.getString("expiration") != null ? LocalDateTime.parse(rs.getString("expiration")) : null);
-                announcements.add(announcement);
+            try (Statement stmt = this.connection.createStatement();
+                ResultSet rs = stmt.executeQuery(sql)) {
+                while (rs.next()) {
+                    Announcement announcement = new Announcement();
+                    announcement.setId(rs.getString("id"));
+                    announcement.setText(rs.getString("text"));
+                    announcement.setType(rs.getString("type"));
+                    announcement.setRecurrence(rs.getObject("recurrence") != null ? rs.getLong("recurrence") : null);
+                    announcement.setOwner(rs.getString("owner"));
+                    announcement.setPermission(rs.getString("permission"));
+                    announcement.setDate(rs.getString("date") != null ? LocalDate.parse(rs.getString("date")) : null);
+                    announcement.setTime(rs.getString("time") != null ? LocalTime.parse(rs.getString("time")) : null);
+                    announcement.setExpiration(rs.getString("expiration") != null ? LocalDateTime.parse(rs.getString("expiration")) : null);
+                    announcements.put(announcement.getId(), announcement);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return announcements;
+        return new ArrayList<>(announcements.values());
     }
 
     @Override

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -28,6 +28,7 @@ public class SQLiteDataConnector implements DataStore {
     private Connection connection;
     private final JavaPlugin plugin;
     private boolean empty = false;
+    private boolean tablesInitialized = false;
 
     public SQLiteDataConnector(JavaPlugin plugin, String databasePath) {
         this.plugin = plugin;
@@ -404,5 +405,15 @@ public class SQLiteDataConnector implements DataStore {
             e.printStackTrace();
         }
         return preferences;
+    }
+
+    @Override
+    public boolean areTablesInitialized() {
+        return tablesInitialized;
+    }
+
+    @Override
+    public void setTablesInitialized(boolean initialized) {
+        this.tablesInitialized = initialized;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -105,7 +105,7 @@ public class SQLiteDataConnector implements DataStore {
                 pstmt.setString(1, announcement.getId());
                 pstmt.setString(2, announcement.getText());
                 pstmt.setString(3, announcement.getType());
-                pstmt.setString(4, announcement.getRecurrence());
+                pstmt.setObject(4, announcement.getRecurrence()); // Changed to handle Long
                 pstmt.setString(5, announcement.getOwner());
                 pstmt.setString(6, announcement.getPermission());
                 pstmt.setString(7, announcement.getDate() != null ? announcement.getDate().toString() : null);
@@ -152,7 +152,7 @@ public class SQLiteDataConnector implements DataStore {
                 announcement.setId(rs.getString("id"));
                 announcement.setText(rs.getString("text"));
                 announcement.setType(rs.getString("type"));
-                announcement.setRecurrence(rs.getString("recurrence"));
+                announcement.setRecurrence(rs.getObject("recurrence") != null ? rs.getLong("recurrence") : null);
                 announcement.setOwner(rs.getString("owner"));
                 announcement.setPermission(rs.getString("permission"));
                 announcement.setDate(rs.getString("date") != null ? LocalDate.parse(rs.getString("date")) : null);
@@ -228,7 +228,7 @@ public class SQLiteDataConnector implements DataStore {
                     "id VARCHAR(64) PRIMARY KEY," +
                     "text TEXT NOT NULL," +
                     "type VARCHAR(32) NOT NULL," +
-                    "recurrence VARCHAR(32)," +
+                    "recurrence BIGINT," + // Changed from VARCHAR to BIGINT
                     "owner VARCHAR(64)," +
                     "permission VARCHAR(128)," +
                     "date DATE," +
@@ -263,6 +263,17 @@ public class SQLiteDataConnector implements DataStore {
                     "PRIMARY KEY (player_id, type)" +
                     ")";
                 stmt.executeUpdate(createAnnounceDisabledTypesTable);
+            }
+            
+            // Check if announce_prefs table exists
+            tables = metaData.getTables(null, null, "announce_prefs", null);
+            if (!tables.next()) {
+                Statement stmt = connection.createStatement();
+                String createAnnouncePrefsTable = "CREATE TABLE announce_prefs (" +
+                    "player_id VARCHAR(36) PRIMARY KEY," +
+                    "text VARCHAR(512)" +
+                    ")";
+                stmt.executeUpdate(createAnnouncePrefsTable);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -361,5 +372,40 @@ public class SQLiteDataConnector implements DataStore {
             e.printStackTrace();
         }
         return allTypes;
+    }
+
+    @Override
+    public void savePlayerPreferences(UUID playerId, String preferences) {
+        try {
+            ensureConnected();
+            String sql = "INSERT OR REPLACE INTO announce_prefs (player_id, text) VALUES (?, ?)";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, playerId.toString());
+                pstmt.setString(2, preferences);
+                pstmt.executeUpdate();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String getPlayerPreferences(UUID playerId) {
+        String preferences = null;
+        try {
+            ensureConnected();
+            String sql = "SELECT text FROM announce_prefs WHERE player_id = ?";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, playerId.toString());
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    if (rs.next()) {
+                        preferences = rs.getString("text");
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return preferences;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -37,26 +37,27 @@ public class SQLiteDataConnector implements DataStore {
     @Override
     public void connect() {
         try {
-            File dbFile = new File(this.databasePath);
-            File parentDir = dbFile.getParentFile();
-            
-            if (!parentDir.exists()) {
-                parentDir.mkdirs();
-            }
-            
-            if (!dbFile.exists()) {
-                dbFile.createNewFile();
-                plugin.getLogger().info("SQLite database file created at: " + dbFile.getAbsolutePath());
-            }
+            if (connection == null || connection.isClosed()) {
+                File dbFile = new File(this.databasePath);
+                File parentDir = dbFile.getParentFile();
+                
+                if (!parentDir.exists()) {
+                    parentDir.mkdirs();
+                }
+                
+                if (!dbFile.exists()) {
+                    dbFile.createNewFile();
+                    plugin.getLogger().info("SQLite database file created at: " + dbFile.getAbsolutePath());
+                }
 
-            Class.forName("org.sqlite.JDBC");
-            this.connection = DriverManager.getConnection("jdbc:sqlite:" + this.databasePath);
-            this.connection.setAutoCommit(true);
-            
-            // Initialize tables immediately after connection
-            initializeTables();
-            plugin.getLogger().info("Successfully connected to SQLite database");
-            
+                Class.forName("org.sqlite.JDBC");
+                this.connection = DriverManager.getConnection("jdbc:sqlite:" + this.databasePath);
+                this.connection.setAutoCommit(true);
+                
+                // Initialize tables immediately after connection
+                initializeTables();
+                plugin.getLogger().info("Successfully connected to SQLite database");
+            }
         } catch (ClassNotFoundException | SQLException | IOException e) {
             plugin.getLogger().severe("Failed to connect to SQLite database: " + e.getMessage());
             e.printStackTrace();
@@ -97,24 +98,21 @@ public class SQLiteDataConnector implements DataStore {
 
     @Override
     public void saveAnnouncement(Announcement announcement) {
+        String sql = "INSERT INTO announcements (id, text, type, recurrence, owner, permission, date, time, expiration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         try {
             ensureConnected();
-        } catch (SQLException e) {
-            e.printStackTrace();
-            return;
-        }
-        String sql = "INSERT INTO announcements (id, text, type, recurrence, owner, permission, date, time, expiration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        try (PreparedStatement pstmt = this.connection.prepareStatement(sql)) {
-            pstmt.setString(1, announcement.getId());
-            pstmt.setString(2, announcement.getText());
-            pstmt.setString(3, announcement.getType());
-            pstmt.setString(4, announcement.getRecurrence());
-            pstmt.setString(5, announcement.getOwner());
-            pstmt.setString(6, announcement.getPermission());
-            pstmt.setString(7, announcement.getDate() != null ? announcement.getDate().toString() : null);
-            pstmt.setString(8, announcement.getTime() != null ? announcement.getTime().toString() : null);
-            pstmt.setString(9, announcement.getExpiration() != null ? announcement.getExpiration().toString() : null);
-            pstmt.executeUpdate();
+            try (PreparedStatement pstmt = this.connection.prepareStatement(sql)) {
+                pstmt.setString(1, announcement.getId());
+                pstmt.setString(2, announcement.getText());
+                pstmt.setString(3, announcement.getType());
+                pstmt.setString(4, announcement.getRecurrence());
+                pstmt.setString(5, announcement.getOwner());
+                pstmt.setString(6, announcement.getPermission());
+                pstmt.setString(7, announcement.getDate() != null ? announcement.getDate().toString() : null);
+                pstmt.setString(8, announcement.getTime() != null ? announcement.getTime().toString() : null);
+                pstmt.setString(9, announcement.getExpiration() != null ? announcement.getExpiration().toString() : null);
+                pstmt.executeUpdate();
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -1,5 +1,8 @@
 package org.fourz.rvnktools.announceManager.data;
 
+// Add new import
+import org.fourz.rvnktools.util.Debug;
+import org.fourz.rvnktools.announceManager.AnnounceConfig;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.fourz.rvnktools.announceManager.AnnounceType;
 import org.fourz.rvnktools.announceManager.Announcement;
@@ -24,15 +27,18 @@ import java.io.File;
 import java.io.IOException;
 
 public class SQLiteDataConnector implements DataStore {
+    private static final String CLASS_NAME = "SQLiteDataConnector";
     private final String databasePath;
     private Connection connection;
     private final JavaPlugin plugin;
     private boolean empty = false;
     private boolean tablesInitialized = false;
+    private final Debug debug;  // Add Debug field
 
     public SQLiteDataConnector(JavaPlugin plugin, String databasePath) {
         this.plugin = plugin;
         this.databasePath = new File(plugin.getDataFolder(), databasePath).getAbsolutePath();
+        this.debug = new Debug(plugin, CLASS_NAME, AnnounceConfig.getLogLevel()) {};
     }
 
     @Override
@@ -48,20 +54,18 @@ public class SQLiteDataConnector implements DataStore {
                 
                 if (!dbFile.exists()) {
                     dbFile.createNewFile();
-                    plugin.getLogger().info("SQLite database file created at: " + dbFile.getAbsolutePath());
+                    debug.debug("SQLite database file created at: " + dbFile.getAbsolutePath());
                 }
 
                 Class.forName("org.sqlite.JDBC");
                 this.connection = DriverManager.getConnection("jdbc:sqlite:" + this.databasePath);
                 this.connection.setAutoCommit(true);
                 
-                // Initialize tables immediately after connection
                 initializeTables();
-                plugin.getLogger().info("Successfully connected to SQLite database");
+                debug.debug("Successfully connected to SQLite database");
             }
         } catch (ClassNotFoundException | SQLException | IOException e) {
-            plugin.getLogger().severe("Failed to connect to SQLite database: " + e.getMessage());
-            e.printStackTrace();
+            debug.error("Failed to connect to SQLite database: " + e.getMessage(), e);
             this.connection = null;
         }
     }
@@ -73,8 +77,7 @@ public class SQLiteDataConnector implements DataStore {
                 this.connection.close();
                 this.connection = null;
             } catch (SQLException e) {
-                plugin.getLogger().severe("Error closing SQLite connection: " + e.getMessage());
-                e.printStackTrace();
+                debug.error("Error closing SQLite connection: " + e.getMessage(), e);
             }
         }
     }
@@ -415,5 +418,62 @@ public class SQLiteDataConnector implements DataStore {
     @Override
     public void setTablesInitialized(boolean initialized) {
         this.tablesInitialized = initialized;
+    }
+
+    public String calculateDatabaseHash() {
+        List<String> ids = new ArrayList<>();
+        try {
+            ensureConnected();
+            String sql = "SELECT LOWER(id) FROM announcements ORDER BY LOWER(id)";
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery(sql)) {
+                while (rs.next()) {
+                    ids.add(rs.getString(1));
+                }
+            }
+
+            if (ids.isEmpty()) {
+                return null;
+            }
+
+            StringBuilder hashStr = new StringBuilder();
+            for (String id : ids) {
+                hashStr.append(id).append('\n');
+            }
+
+            try {
+                java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+                byte[] digest = md.digest(hashStr.toString().getBytes());
+                StringBuilder hexString = new StringBuilder();
+                for (byte b : digest) {
+                    hexString.append(String.format("%02x", b));
+                }
+                return hexString.toString();
+            } catch (java.security.NoSuchAlgorithmException e) {
+                debug.error("MD5 algorithm not available: " + e.getMessage(), e);
+                return null;
+            }
+
+        } catch (SQLException e) {
+            debug.error("Error calculating database hash: " + e.getMessage(), e);
+            return null;
+        }
+    }
+
+    public Set<String> getExistingAnnouncementIds() {
+        Set<String> ids = new HashSet<>();
+        try {
+            ensureConnected();
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT LOWER(id) FROM announcements")) {
+                while (rs.next()) {
+                    ids.add(rs.getString(1));
+                }
+            }
+            debug.debug("Retrieved " + ids.size() + " announcement IDs from database");
+        } catch (SQLException e) {
+            debug.error("Error retrieving announcement IDs: " + e.getMessage(), e);
+        }
+        return ids;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/data/SQLiteDataConnector.java
@@ -15,6 +15,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.UUID;
 import java.io.File;
 import java.io.IOException;
 
@@ -249,6 +254,18 @@ public class SQLiteDataConnector implements DataStore {
                     ")";
                 stmt.executeUpdate(createAnnounceTypesTable);
             }
+            
+            // Check if announce_disabledtypes table exists
+            tables = metaData.getTables(null, null, "announce_disabledtypes", null);
+            if (!tables.next()) {
+                Statement stmt = connection.createStatement();
+                String createAnnounceDisabledTypesTable = "CREATE TABLE announce_disabledtypes (" +
+                    "player_id VARCHAR(36)," +
+                    "type VARCHAR(64)," +
+                    "PRIMARY KEY (player_id, type)" +
+                    ")";
+                stmt.executeUpdate(createAnnounceDisabledTypesTable);
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -276,5 +293,75 @@ public class SQLiteDataConnector implements DataStore {
     @Override
     public boolean isEmpty() {
         return empty;
+    }
+
+    @Override
+    public void savePlayerDisabledType(UUID playerId, String type) {
+        try {
+            ensureConnected();
+            String sql = "INSERT OR IGNORE INTO announce_disabledtypes (player_id, type) VALUES (?, ?)";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, playerId.toString());
+                pstmt.setString(2, type);
+                pstmt.executeUpdate();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void removePlayerDisabledType(UUID playerId, String type) {
+        try {
+            ensureConnected();
+            String sql = "DELETE FROM announce_disabledtypes WHERE player_id = ? AND type = ?";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, playerId.toString());
+                pstmt.setString(2, type);
+                pstmt.executeUpdate();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Set<String> getPlayerDisabledTypes(UUID playerId) {
+        Set<String> types = new HashSet<>();
+        try {
+            ensureConnected();
+            String sql = "SELECT type FROM announce_disabledtypes WHERE player_id = ?";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, playerId.toString());
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    while (rs.next()) {
+                        types.add(rs.getString("type"));
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return types;
+    }
+
+    @Override
+    public Map<UUID, Set<String>> getAllPlayerDisabledTypes() {
+        Map<UUID, Set<String>> allTypes = new HashMap<>();
+        try {
+            ensureConnected();
+            String sql = "SELECT player_id, type FROM announce_disabledtypes";
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery(sql)) {
+                while (rs.next()) {
+                    UUID playerId = UUID.fromString(rs.getString("player_id"));
+                    String type = rs.getString("type");
+                    allTypes.computeIfAbsent(playerId, k -> new HashSet<>()).add(type);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return allTypes;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommand.java
@@ -1,4 +1,3 @@
-
 package org.fourz.rvnktools.announceManager.subcommand;
 
 import org.bukkit.Bukkit;
@@ -32,5 +31,13 @@ public abstract class AnnounceSubCommand {
         
         TextComponent constructedMessage = ChatFormat.parse(message, plugin.linkMaker);
         player.spigot().sendMessage(constructedMessage);
+    }
+
+    protected boolean checkPermission(Player player, String permission) {
+        if (!player.hasPermission(permission)) {
+            messagePlayer(player, "&cYou don't have permission to do this");
+            return false;
+        }
+        return true;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
@@ -53,7 +53,8 @@ public class AnnounceSubCommandSet extends AnnounceSubCommand {
                     return false;
                 }                
                 if (isValidRecurrence(value)) {
-                    announcement.setRecurrence(convertRecurrenceToSecondsLong(value));                    
+                    announcement.setRecurrence(convertRecurrenceToSecondsLong(value));
+                    announcement.setRecurrenceString(value);                    
                     messagePlayer(player, "&aSet recurrence to: " + value);
                 } else {
                     messagePlayer(player, "&cInvalid recurrence value. Use: daily or none, or time values like 90m, 2h");

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
@@ -1,0 +1,139 @@
+package org.fourz.rvnktools.announceManager.subcommand;
+
+import org.bukkit.entity.Player;
+import org.fourz.rvnktools.RVNKTools;
+import org.fourz.rvnktools.announceManager.AnnounceManager;
+import org.fourz.rvnktools.announceManager.Announcement;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class AnnounceSubCommandSet extends AnnounceSubCommand {
+    
+    public AnnounceSubCommandSet(AnnounceManager announceManager, RVNKTools plugin) {
+        super(announceManager, plugin);
+    }
+
+    @Override
+    public boolean execute(Player player, String[] args) {
+        if (!checkPermission(player, "rvnktools.command.announce.set")) {
+            return false;
+        }
+
+        if (args.length < 4) {
+            messagePlayer(player, "&cUsage: /announce set <id> <property> <value>");
+            return false;
+        }
+
+        String id = args[1];
+        String property = args[2].toLowerCase();
+        String value = String.join(" ", java.util.Arrays.copyOfRange(args, 3, args.length));
+
+        Announcement announcement = null;
+        for (Announcement a : announceManager.getAnnouncements()) {
+            if (a.getId().equalsIgnoreCase(id)) {
+                announcement = a;
+                break;
+            }
+        }
+
+        if (announcement == null) {
+            messagePlayer(player, "&cAnnouncement with ID '" + id + "' not found");
+            return false;
+        }
+
+        switch (property) {
+            case "recurrence":
+                // Allow owners to modify recurrence without permission check
+                boolean isOwner = announcement.getOwner() != null && 
+                                announcement.getOwner().equalsIgnoreCase(player.getName());
+                if (!isOwner || !checkPermission(player, "rvnktools.command.announce.set")) return false;
+                
+                if (isValidRecurrence(value)) {
+                    announcement.setRecurrence(value);
+                    messagePlayer(player, "&aSet recurrence to: " + value);
+                } else {
+                    messagePlayer(player, "&cInvalid recurrence value. Use: daily or none, or time values like 90m, 2h");
+                    return false;
+                }
+                break;
+
+            case "date":
+                if (!checkPermission(player, "rvnktools.command.announce.set")) return false;
+                try {
+                    LocalDate date = LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    announcement.setDate(date);
+                    messagePlayer(player, "&aSet date to: " + value);
+                } catch (DateTimeParseException e) {
+                    messagePlayer(player, "&cInvalid date format. Use: YYYY-MM-DD");
+                    return false;
+                }
+                break;
+
+            case "type":
+                if (!checkPermission(player, "rvnktools.command.announce.set")) return false;
+                if (announceManager.validateAnnounceType(value)) {
+                    announcement.setType(value);
+                    messagePlayer(player, "&aSet type to: " + value);
+                } else {
+                    messagePlayer(player, "&cInvalid announcement type: " + value);
+                    return false;
+                }
+                break;
+
+            case "permission":
+                if (!checkPermission(player, "rvnktools.command.announce.set")) return false;
+                if (value.equalsIgnoreCase("none")) {
+                    announcement.setPermission(null);
+                    messagePlayer(player, "&aRemoved permission requirement");
+                } else {
+                    announcement.setPermission(value);
+                    messagePlayer(player, "&aSet permission to: " + value);
+                }
+                break;
+
+            default:
+                messagePlayer(player, "&cUnknown property: " + property);
+                messagePlayer(player, "&cValid properties: recurrence, date, type, permission");
+                return false;
+        }
+
+        announceManager.saveConfig();
+        return true;
+    }
+
+    private boolean isValidRecurrence(String recurrence) {
+        if (recurrence == null || recurrence.isEmpty()) {
+            return false;
+        }
+        
+        // Support for named periods
+        if (recurrence.equalsIgnoreCase("none") ||
+            recurrence.equalsIgnoreCase("daily")) {
+            return true;
+        }
+
+        // Support for time-based formats like "90m", "2h", "4h", etc.
+        String pattern = "^\\d+[mh]$";
+        if (recurrence.matches(pattern)) {
+            // Extract number and unit
+            String number = recurrence.substring(0, recurrence.length() - 1);
+            char unit = recurrence.charAt(recurrence.length() - 1);
+            
+            try {
+                int value = Integer.parseInt(number);
+                if (unit == 'm' && value > 0 && value <= 1440) { // Up to 24 hours in minutes
+                    return true;
+                }
+                if (unit == 'h' && value > 0 && value <= 24) { // Up to 24 hours
+                    return true;
+                }
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }        
+        return false;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/subcommand/AnnounceSubCommandSet.java
@@ -49,10 +49,11 @@ public class AnnounceSubCommandSet extends AnnounceSubCommand {
                 // Allow owners to modify recurrence without permission check
                 boolean isOwner = announcement.getOwner() != null && 
                                 announcement.getOwner().equalsIgnoreCase(player.getName());
-                if (!isOwner || !checkPermission(player, "rvnktools.command.announce.set")) return false;
-                
+                if (!isOwner || !checkPermission(player, "rvnktools.command.announce.set")) {
+                    return false;
+                }                
                 if (isValidRecurrence(value)) {
-                    announcement.setRecurrence(value);
+                    announcement.setRecurrence(convertRecurrenceToSecondsLong(value));                    
                     messagePlayer(player, "&aSet recurrence to: " + value);
                 } else {
                     messagePlayer(player, "&cInvalid recurrence value. Use: daily or none, or time values like 90m, 2h");
@@ -135,5 +136,24 @@ public class AnnounceSubCommandSet extends AnnounceSubCommand {
             }
         }        
         return false;
+    }
+
+    private Long convertRecurrenceToSecondsLong (String recurrence) {
+        if (recurrence.equalsIgnoreCase("none")) {
+            return null;
+        }
+        if (recurrence.equalsIgnoreCase("daily")) {
+            return 86400L;
+        }
+        String number = recurrence.substring(0, recurrence.length() - 1);
+        char unit = recurrence.charAt(recurrence.length() - 1);
+        int value = Integer.parseInt(number);
+        if (unit == 'm') {
+            return (long) value * 60;
+        }
+        if (unit == 'h') {
+            return (long) value * 3600;
+        }
+        return null;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
@@ -1,22 +1,11 @@
 package org.fourz.rvnktools.util;
 
 import org.bukkit.plugin.java.JavaPlugin;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
-// This class is used for logging debug messages
-// with different log levels and timestamps in the format [HH:mm:ss.SSS]
-// It also provides a method to log errors with stack traces
-// and a method to check if debug mode is enabled
-// The log level can be set and retrieved
-// The log level is used to determine which messages should be logged
-// based on their log level
-// The log level can be set to OFF to disable logging
-// The log level can be set to ALL to log all messages
-// The log level can be set to a specific level to log messages of that level and higher
-
+// Provides debug logging functionality with configurable log levels and timestamp formatting
 public abstract class Debug {
+    // Maps internal log levels to Java logging levels
     public enum LogLevel {
         OFF(Level.OFF),
         SEVERE(Level.SEVERE),
@@ -50,26 +39,28 @@ public abstract class Debug {
     private final JavaPlugin plugin;
     private final String className;
     private LogLevel logLevel;
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
+    // Initializes debug logger with plugin instance, class name and log level
     protected Debug(JavaPlugin plugin, String className, LogLevel level) {
         this.plugin = plugin;
         this.className = className;
         this.logLevel = level;
     }
 
+    // Logs a message with default INFO level
     public void log(String message) {
         log(LogLevel.INFO, message);
     }
 
+    // Logs a message with specified level
     public void log(LogLevel level, String message) {
         if (shouldLog(level)) {
-            String timestamp = LocalDateTime.now().format(TIME_FORMAT);
             plugin.getLogger().log(level.getLevel(), 
-                String.format("%s [%s] %s", timestamp, className, message));
+                String.format("[%s] %s", className, message));
         }
     }
 
+    // Logs an error message with optional stack trace
     public void error(String message, Throwable e) {
         log(LogLevel.SEVERE, message);
         if (e != null && shouldLog(LogLevel.SEVERE)) {
@@ -77,18 +68,25 @@ public abstract class Debug {
         }
     }
 
+    // Checks if debug logging is enabled (FINE or lower level)
     public boolean isDebugEnabled() {
         return logLevel.ordinal() <= LogLevel.FINE.ordinal();
     }
 
+    // Determines if a message should be logged based on current log level
     private boolean shouldLog(LogLevel level) {
-        return logLevel != LogLevel.OFF && level.ordinal() >= logLevel.ordinal();
+        // INFO (ordinal 800) should be >= INFO (800)
+        return logLevel != LogLevel.OFF && 
+               level.getLevel().intValue() >= logLevel.getLevel().intValue();
     }
+    
 
+    // Sets the current log level
     public void setLogLevel(LogLevel level) {
         this.logLevel = level;
     }
 
+    // Gets the current log level
     public LogLevel getLogLevel() {
         return logLevel;
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
@@ -2,92 +2,76 @@ package org.fourz.rvnktools.util;
 
 import org.bukkit.plugin.java.JavaPlugin;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
-// Provides debug logging functionality with configurable log levels and timestamp formatting
 public abstract class Debug {
-    // Maps internal log levels to Java logging levels
-    public enum LogLevel {
-        OFF(Level.OFF),
-        SEVERE(Level.SEVERE),
-        WARNING(Level.WARNING),
-        INFO(Level.INFO),
-        CONFIG(Level.CONFIG),
-        FINE(Level.FINE),
-        FINER(Level.FINER),
-        FINEST(Level.FINEST),
-        ALL(Level.ALL);
-
-        private final Level level;
-
-        LogLevel(Level level) {
-            this.level = level;
-        }
-
-        public Level getLevel() {
-            return level;
-        }
-
-        public static LogLevel fromString(String level) {
-            try {
-                return valueOf(level.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                return INFO;
-            }
-        }
-    }
-
     private final JavaPlugin plugin;
     private final String className;
-    private LogLevel logLevel;
+    private Level logLevel;
+    private boolean debugEnabled;
 
-    // Initializes debug logger with plugin instance, class name and log level
-    protected Debug(JavaPlugin plugin, String className, LogLevel level) {
+    protected Debug(JavaPlugin plugin, String className, Level level) {
         this.plugin = plugin;
         this.className = className;
-        this.logLevel = level;
+        setLogLevel(level);
     }
 
-    // Logs a message with default INFO level
     public void log(String message) {
-        log(LogLevel.INFO, message);
+        log(Level.INFO, message);
     }
 
-    // Logs a message with specified level
-    public void log(LogLevel level, String message) {
+    public void log(Level level, String message) {
         if (shouldLog(level)) {
-            plugin.getLogger().log(level.getLevel(), 
-                String.format("[%s] %s", className, message));
+            // Map FINE to INFO when actually logging
+            Level logLevel = (level == Level.FINE) ? Level.INFO : level;
+            plugin.getLogger().log(logLevel,
+                String.format("[%s] %s%s", 
+                    className,
+                    (level == Level.FINE) ? "[DEBUG] " : "",
+                    message));
         }
     }
 
-    // Logs an error message with optional stack trace
     public void error(String message, Throwable e) {
-        log(LogLevel.SEVERE, message);
-        if (e != null && shouldLog(LogLevel.SEVERE)) {
+        log(Level.SEVERE, message);
+        if (e != null && shouldLog(Level.SEVERE)) {
             e.printStackTrace();
         }
     }
 
-    // Checks if debug logging is enabled (FINE or lower level)
-    public boolean isDebugEnabled() {
-        return logLevel.ordinal() <= LogLevel.FINE.ordinal();
+    public void debug(String message) {
+        log(Level.FINE, message);
     }
 
-    // Determines if a message should be logged based on current log level
-    private boolean shouldLog(LogLevel level) {
-        // INFO (ordinal 800) should be >= INFO (800)
-        return logLevel != LogLevel.OFF && 
-               level.getLevel().intValue() >= logLevel.getLevel().intValue();
+    private boolean shouldLog(Level messageLevel) {
+        if (logLevel == Level.OFF) {
+            return false;
+        }
+        // Special handling for FINE (debug) level
+        if (messageLevel == Level.FINE) {
+            return logLevel == Level.FINE;
+        }
+        return messageLevel.intValue() >= logLevel.intValue();
     }
-    
 
-    // Sets the current log level
-    public void setLogLevel(LogLevel level) {
+    public static Level parseLevel(String levelStr) {
+        if (levelStr == null) return Level.INFO;
+        try {
+            if (levelStr.equalsIgnoreCase("DEBUG")) {
+                return Level.FINE;
+            }
+            return Level.parse(levelStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return Level.INFO;
+        }
+    }
+
+    public void setLogLevel(Level level) {
         this.logLevel = level;
+        debugEnabled = (level == Level.FINE);
     }
 
-    // Gets the current log level
-    public LogLevel getLogLevel() {
+    public Level getLogLevel() {
         return logLevel;
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/util/Debug.java
@@ -1,0 +1,95 @@
+package org.fourz.rvnktools.util;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Level;
+
+// This class is used for logging debug messages
+// with different log levels and timestamps in the format [HH:mm:ss.SSS]
+// It also provides a method to log errors with stack traces
+// and a method to check if debug mode is enabled
+// The log level can be set and retrieved
+// The log level is used to determine which messages should be logged
+// based on their log level
+// The log level can be set to OFF to disable logging
+// The log level can be set to ALL to log all messages
+// The log level can be set to a specific level to log messages of that level and higher
+
+public abstract class Debug {
+    public enum LogLevel {
+        OFF(Level.OFF),
+        SEVERE(Level.SEVERE),
+        WARNING(Level.WARNING),
+        INFO(Level.INFO),
+        CONFIG(Level.CONFIG),
+        FINE(Level.FINE),
+        FINER(Level.FINER),
+        FINEST(Level.FINEST),
+        ALL(Level.ALL);
+
+        private final Level level;
+
+        LogLevel(Level level) {
+            this.level = level;
+        }
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public static LogLevel fromString(String level) {
+            try {
+                return valueOf(level.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                return INFO;
+            }
+        }
+    }
+
+    private final JavaPlugin plugin;
+    private final String className;
+    private LogLevel logLevel;
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+
+    protected Debug(JavaPlugin plugin, String className, LogLevel level) {
+        this.plugin = plugin;
+        this.className = className;
+        this.logLevel = level;
+    }
+
+    public void log(String message) {
+        log(LogLevel.INFO, message);
+    }
+
+    public void log(LogLevel level, String message) {
+        if (shouldLog(level)) {
+            String timestamp = LocalDateTime.now().format(TIME_FORMAT);
+            plugin.getLogger().log(level.getLevel(), 
+                String.format("%s [%s] %s", timestamp, className, message));
+        }
+    }
+
+    public void error(String message, Throwable e) {
+        log(LogLevel.SEVERE, message);
+        if (e != null && shouldLog(LogLevel.SEVERE)) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isDebugEnabled() {
+        return logLevel.ordinal() <= LogLevel.FINE.ordinal();
+    }
+
+    private boolean shouldLog(LogLevel level) {
+        return logLevel != LogLevel.OFF && level.ordinal() >= logLevel.ordinal();
+    }
+
+    public void setLogLevel(LogLevel level) {
+        this.logLevel = level;
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+}

--- a/toolkitplugin/src/main/resources/announcements.yml
+++ b/toolkitplugin/src/main/resources/announcements.yml
@@ -158,3 +158,11 @@ storage:
     tablePrefix: announce_
   sqlite:
     database: announcements.db
+
+debug:
+  # Available levels: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
+  level: INFO
+  # Enable timing logs
+  timing: false
+  # Log file name (optional)
+  file: announcements.log

--- a/toolkitplugin/src/main/resources/announcements.yml
+++ b/toolkitplugin/src/main/resources/announcements.yml
@@ -31,7 +31,6 @@ announcements:
   text: '&e&lEvents &7are held every &eSaturday &7at &e7pm CST.'
   type: news
   recurrence: 90m
-  owner: wizardofire
   imported: false
 - id: trains
   text: '&7Use &d/trains &7for train help pages.'
@@ -47,20 +46,6 @@ announcements:
   text: '&6Vote daily &7for &eMickyHats&7! Do &6/vote'
   type: help
   recurrence: 2h  
-  imported: false
-- id: ant_shop1
-  text: '&e&lBarterSigns &acoming Soon!'
-  type: advert
-  recurrence: 40m
-  owner: wizardofire
-  cost: 1  
-  imported: false
-- id: toastyday
-  text: '&e&lHappy &6Cheese Toasty &e&lDay!'
-  type: scheduled
-  recurrence: 120m
-  date: '2028-09-24'
-  time: '1900'  
   imported: false
 - id: ads
   text: '&aUse &d/ads &ato toggle &eplayer adverts &aon and off.'
@@ -117,29 +102,6 @@ announcements:
   type: guide
   recurrence: 2h  
   imported: false
-- id: xmasevent
-  text: '&2Get started on your &c&lHOLIDAY VILLAGE &2build. &aDates and times are
-    coming soon!'
-  type: scheduled
-  recurrence: 4h
-  date: '2028-12-25'  
-  imported: false
-- id: xmasevent_week1
-  text: Winter Village Build Event starts tonite at 8PM EST! RVSP on the {discord-link}
-    if you can.
-  type: news
-  recurrence: 4h  
-  imported: false
-- id: xmasevent_reminder
-  text: The last day for Winter Village Build event will be January 18th.
-  type: news
-  recurrence: 3h  
-  imported: false
-- id: todayexample
-  text: '&e&lToday &7is &a day.'
-  type: scheduled
-  date: '2024-11-16'  
-  imported: false
 - id: announcer
   text: '&7Use &d/announcer &7to cycle &eannouncer &7modes.'
   type: server
@@ -160,9 +122,12 @@ storage:
     database: announcements.db
 
 debug:
-  # Available levels: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
-  level: INFO
-  # Enable timing logs
-  timing: false
+  # Available levels: OFF, SEVERE, WARNING, INFO, DEBUG
+  # OFF: No logging
+  # SEVERE: Only critical errors
+  # WARNING: Errors and warnings
+  # INFO: Standard operational messages
+  # DEBUG: Detailed debugging information
+  level: WARNING
   # Log file name (optional)
   file: announcements.log

--- a/toolkitplugin/src/main/resources/announcements.yml
+++ b/toolkitplugin/src/main/resources/announcements.yml
@@ -32,98 +32,119 @@ announcements:
   type: news
   recurrence: 90m
   owner: wizardofire
+  imported: false
 - id: trains
   text: '&7Use &d/trains &7for train help pages.'
   type: help
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: welcome
   text: '&e&lWelcome &7to &aRavenkraft&7!'
   type: help
-  permission: rvnktools.announce.welcome
+  permission: rvnktools.announce.welcome  
+  imported: false
 - id: mickyhats
   text: '&6Vote daily &7for &eMickyHats&7! Do &6/vote'
   type: help
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: ant_shop1
   text: '&e&lBarterSigns &acoming Soon!'
   type: advert
   recurrence: 40m
   owner: wizardofire
-  cost: 1
+  cost: 1  
+  imported: false
 - id: toastyday
   text: '&e&lHappy &6Cheese Toasty &e&lDay!'
   type: scheduled
   recurrence: 120m
   date: '2028-09-24'
-  time: '1900'
+  time: '1900'  
+  imported: false
 - id: ads
   text: '&aUse &d/ads &ato toggle &eplayer adverts &aon and off.'
   type: server
-  recurrence: 100m
+  recurrence: 100m  
+  imported: false
 - id: railroad
   text: '&aUse &d/railroad &ato toggle &eTraincart modes.'
   type: help
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: announcements
   text: '&aUse &d/announce toggle help &ato toggle &eserver help tips &aon and off.'
   type: server
-  recurrence: 80m
+  recurrence: 80m  
+  imported: false
 - id: announcements_disabled
   text: '&aUse &d/announce disabled &ato see which announcement types you have disabled.'
   type: help
-  recurrence: 80m
+  recurrence: 80m  
+  imported: false
 - id: ignoreclaims
   text: '&7Use &d/ignoreclaims &7or &d/ic &7if you need to bypass claims.'
   type: server
   recurrence: 90m
-  permission: griefprevention.ignoreclaims
+  permission: griefprevention.ignoreclaims  
+  imported: false
 - id: facebook
   text: '&aCheck out our &9{facebook-link}'
-  type: help
+  type: help  
+  imported: false
 - id: information
   text: '&aCheck out &e{information-link} &achannel on {discord-link}'
   type: help
-  recurrence: 120m
+  recurrence: 120m  
+  imported: false
 - id: trains_help
   text: '&7Use &d/trains &7for train help pages.'
   type: guide
-  recurrence: 1h
+  recurrence: 1h  
+  imported: false
 - id: help_guide
   text: '&7Try &d/help &7for a command guide'
   type: guide
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: patreon
   text: '&aCheck out our &c{patreon-link}!'
   type: guide
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: discord
   text: '&aJoin us on &9{discord-link}!'
   type: guide
-  recurrence: 2h
+  recurrence: 2h  
+  imported: false
 - id: xmasevent
   text: '&2Get started on your &c&lHOLIDAY VILLAGE &2build. &aDates and times are
     coming soon!'
   type: scheduled
   recurrence: 4h
-  date: '2028-12-25'
+  date: '2028-12-25'  
+  imported: false
 - id: xmasevent_week1
   text: Winter Village Build Event starts tonite at 8PM EST! RVSP on the {discord-link}
     if you can.
   type: news
-  recurrence: 4h
+  recurrence: 4h  
+  imported: false
 - id: xmasevent_reminder
   text: The last day for Winter Village Build event will be January 18th.
   type: news
-  recurrence: 3h
+  recurrence: 3h  
+  imported: false
 - id: todayexample
   text: '&e&lToday &7is &a day.'
   type: scheduled
-  date: '2024-11-16'
+  date: '2024-11-16'  
+  imported: false
 - id: announcer
   text: '&7Use &d/announcer &7to cycle &eannouncer &7modes.'
   type: server
   recurrence: 2h
-
+  imported: false
 storage:
 # types: mysql, sqlite, flatfile
   type: flatfile 


### PR DESCRIPTION
This pull request includes significant updates to the RVNKTools Minecraft plugin, focusing on enhancing server administration features, improving code quality, and updating dependencies. The most important changes are summarized below:

### Documentation and Installation

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R68): Updated with comprehensive installation instructions, key features, suggested use cases, and contribution guidelines.

### Dependency Management

* [`toolkitplugin/pom.xml`](diffhunk://#diff-aa868023b236a23b51f77fc1fed89f74da2cae6ee8e9a0b58bf582855cf32a7aL8-R8): Updated the plugin version to `1.1-alpha` and added a new dependency on `commons-codec` version `1.15`. [[1]](diffhunk://#diff-aa868023b236a23b51f77fc1fed89f74da2cae6ee8e9a0b58bf582855cf32a7aL8-R8) [[2]](diffhunk://#diff-aa868023b236a23b51f77fc1fed89f74da2cae6ee8e9a0b58bf582855cf32a7aR95-R101)

### Code Quality and Stability

* [`toolkitplugin/src/main/java/org/fourz/rvnktools/RVNKTools.java`](diffhunk://#diff-324d386fde96674723d7252adfc1698463b77d1a399f3124e54d8fb7452e80b2L80-L99): Enhanced the `onDisable` method to include null checks and proper shutdown procedures for `announceManager`.

### Announcement Management

* [`toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java`](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1R7-L24): Refactored the `AnnounceManager` to use a `ConcurrentHashMap` for announcements, added new methods for checking and parsing announcements, and improved the `shutdown` method to ensure all announcements are saved before shutdown. [[1]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1R7-L24) [[2]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1L33-R72) [[3]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1L102-L112) [[4]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1R123-R136) [[5]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1L175-R204) [[6]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1R215-R219) [[7]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1R240-R249) [[8]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1L283-L325) [[9]](diffhunk://#diff-3097695de1174386c4a9a5a16285f24c69e619f14db94005ada24d9510a135b1L340-R380)