### PR TITLE
Merge derek/dev: announcements overhaul, auth, webhooks, API endpoints

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.4.3-alpha</version>
+    <version>1.4.4-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.4.4-alpha</version>
+    <version>1.4.5-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AnnouncementController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AnnouncementController.java
@@ -365,8 +365,26 @@ public class AnnouncementController extends HttpServlet {
         }
     }
 
+    private static final List<String> ANNOUNCEMENT_PERMISSION_NODES = List.of(
+            "rvnk.announcements.create",
+            "rvnk.announcements.edit",
+            "rvnk.announcements.edit.own",
+            "rvnk.announcements.delete",
+            "rvnk.announcements.pin"
+    );
+
+    private static final Map<String, String> PERM_NODE_TO_KEY = Map.of(
+            "rvnk.announcements.create", "canCreate",
+            "rvnk.announcements.edit", "canEdit",
+            "rvnk.announcements.edit.own", "canEditOwn",
+            "rvnk.announcements.delete", "canDelete",
+            "rvnk.announcements.pin", "canPin"
+    );
+
     /**
      * Resolves announcement permissions for a UUID via LuckPerms.
+     * Uses {@code QueryOptions.nonContextual()} so inherited group permissions
+     * resolve correctly for offline players.
      * Falls back to all-false if LuckPerms is unavailable.
      */
     private Map<String, Boolean> resolvePermissions(UUID uuid) {
@@ -378,16 +396,14 @@ public class AnnouncementController extends HttpServlet {
         perms.put("canPin", false);
 
         try {
-            net.luckperms.api.LuckPerms lp = org.fourz.rvnktools.permission.LuckPermsManager.getLuckPerms();
-            net.luckperms.api.model.user.User user = lp.getUserManager().loadUser(uuid).join();
-            if (user == null) return perms;
-
-            net.luckperms.api.cacheddata.CachedPermissionData permData = user.getCachedData().getPermissionData();
-            perms.put("canCreate", permData.checkPermission("rvnk.announcements.create").asBoolean());
-            perms.put("canEdit", permData.checkPermission("rvnk.announcements.edit").asBoolean());
-            perms.put("canEditOwn", permData.checkPermission("rvnk.announcements.edit.own").asBoolean());
-            perms.put("canDelete", permData.checkPermission("rvnk.announcements.delete").asBoolean());
-            perms.put("canPin", permData.checkPermission("rvnk.announcements.pin").asBoolean());
+            Map<String, Boolean> resolved = org.fourz.rvnktools.permission.LuckPermsGroupResolver
+                    .checkPermissionsAsync(uuid, ANNOUNCEMENT_PERMISSION_NODES).join();
+            for (Map.Entry<String, Boolean> entry : resolved.entrySet()) {
+                String key = PERM_NODE_TO_KEY.get(entry.getKey());
+                if (key != null) {
+                    perms.put(key, entry.getValue());
+                }
+            }
         } catch (Exception e) {
             logger.warning("LuckPerms unavailable for permission check: " + e.getMessage());
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AnnouncementController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AnnouncementController.java
@@ -373,6 +373,7 @@ public class AnnouncementController extends HttpServlet {
         Map<String, Boolean> perms = new LinkedHashMap<>();
         perms.put("canCreate", false);
         perms.put("canEdit", false);
+        perms.put("canEditOwn", false);
         perms.put("canDelete", false);
         perms.put("canPin", false);
 
@@ -384,6 +385,7 @@ public class AnnouncementController extends HttpServlet {
             net.luckperms.api.cacheddata.CachedPermissionData permData = user.getCachedData().getPermissionData();
             perms.put("canCreate", permData.checkPermission("rvnk.announcements.create").asBoolean());
             perms.put("canEdit", permData.checkPermission("rvnk.announcements.edit").asBoolean());
+            perms.put("canEditOwn", permData.checkPermission("rvnk.announcements.edit.own").asBoolean());
             perms.put("canDelete", permData.checkPermission("rvnk.announcements.delete").asBoolean());
             perms.put("canPin", permData.checkPermission("rvnk.announcements.pin").asBoolean());
         } catch (Exception e) {
@@ -398,6 +400,8 @@ public class AnnouncementController extends HttpServlet {
     private void handleGetAllAnnouncements(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             List<AnnouncementDTO> announcements = announcementService.getAllAnnouncements().get(15, TimeUnit.SECONDS);
+            // Filter out payment-depleted announcements from REST response
+            announcements = filterPaymentDepleted(announcements);
             ApiUtils.sendSuccess(response, gson, announcements);
         } catch (Exception e) {
             logger.error("Error retrieving all announcements", e);
@@ -553,11 +557,14 @@ public class AnnouncementController extends HttpServlet {
                 return;
             }
 
+            String ownerUuid = json.has("ownerUuid") ? json.get("ownerUuid").getAsString() : null;
+
             AnnouncementDTO announcement = new AnnouncementDTO.Builder()
                 .title(title)
                 .message(message)
                 .type(type)
                 .active(active)
+                .ownerUuid(ownerUuid)
                 .build();
 
             AnnouncementDTO created = announcementService.createAnnouncement(announcement).join();
@@ -640,9 +647,51 @@ public class AnnouncementController extends HttpServlet {
                 return;
             }
 
+            // Check X-User-UUID header for ownership-based updates
+            String callerUuid = request.getHeader("X-User-UUID");
+            if (callerUuid != null && !callerUuid.isEmpty()) {
+                UUID uuid = UUID.fromString(callerUuid);
+                Map<String, Boolean> perms = resolvePermissions(uuid);
+                boolean canEdit = Boolean.TRUE.equals(perms.get("canEdit"));
+                boolean canEditOwn = Boolean.TRUE.equals(perms.get("canEditOwn"));
+
+                if (!canEdit && !canEditOwn) {
+                    sendError(response, 403, "No permission to edit announcements");
+                    return;
+                }
+
+                if (!canEdit && canEditOwn) {
+                    // Verify ownership
+                    Optional<AnnouncementDTO> existing = announcementService.getAnnouncement(id).get(15, TimeUnit.SECONDS);
+                    if (existing.isEmpty()) {
+                        sendError(response, 404, "Announcement not found: " + id);
+                        return;
+                    }
+                    if (!callerUuid.equals(existing.get().getOwnerUuid())) {
+                        sendError(response, 403, "You can only edit your own announcements");
+                        return;
+                    }
+                    // Owner can only update message — parse body and restrict fields
+                    JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+                    AnnouncementDTO update = new AnnouncementDTO(id);
+                    if (json.has("message")) {
+                        update.setMessage(json.get("message").getAsString());
+                    } else if (json.has("content")) {
+                        update.setMessage(json.get("content").getAsString());
+                    }
+                    // Ignore title/type/active changes for canEditOwn callers
+                    AnnouncementDTO updated = announcementService.updateAnnouncement(update).get(15, TimeUnit.SECONDS);
+                    ApiUtils.sendSuccess(response, gson, updated);
+                    return;
+                }
+            }
+
+            // Global canEdit or no X-User-UUID header — full update
             AnnouncementDTO announcement = parseAnnouncementFromJson(body, id);
             AnnouncementDTO updated = announcementService.updateAnnouncement(announcement).get(15, TimeUnit.SECONDS);
             ApiUtils.sendSuccess(response, gson, updated);
+        } catch (IllegalArgumentException e) {
+            sendError(response, 400, "Invalid UUID: " + e.getMessage());
         } catch (Exception e) {
             logger.error("Error handling update announcement request for ID: " + id, e);
             sendError(response, 500, "Internal server error: " + e.getMessage());
@@ -651,6 +700,9 @@ public class AnnouncementController extends HttpServlet {
 
     private void handleActivateAnnouncement(String id, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
+            // Ownership check for canEditOwn callers
+            if (!checkTogglePermission(id, request, response)) return;
+
             announcementService.activateAnnouncement(id).get(15, TimeUnit.SECONDS);
             ApiUtils.sendSuccess(response, gson, Map.of("message", "Announcement " + id + " activated"));
         } catch (Exception e) {
@@ -661,11 +713,57 @@ public class AnnouncementController extends HttpServlet {
 
     private void handleDeactivateAnnouncement(String id, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
+            // Ownership check for canEditOwn callers
+            if (!checkTogglePermission(id, request, response)) return;
+
             announcementService.deactivateAnnouncement(id).get(15, TimeUnit.SECONDS);
             ApiUtils.sendSuccess(response, gson, Map.of("message", "Announcement " + id + " deactivated"));
         } catch (Exception e) {
             logger.error("Error deactivating announcement: " + id, e);
             sendError(response, 500, "Failed to deactivate announcement: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Checks toggle (activate/deactivate) permission. If X-User-UUID is present and caller
+     * has only canEditOwn (not global canEdit), verifies ownership.
+     *
+     * @return true if the operation should proceed, false if a response has already been sent
+     */
+    private boolean checkTogglePermission(String id, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String callerUuid = request.getHeader("X-User-UUID");
+        if (callerUuid == null || callerUuid.isEmpty()) return true; // Legacy behavior
+
+        try {
+            UUID uuid = UUID.fromString(callerUuid);
+            Map<String, Boolean> perms = resolvePermissions(uuid);
+            boolean canEdit = Boolean.TRUE.equals(perms.get("canEdit"));
+            if (canEdit) return true; // Global edit permission — allow all
+
+            boolean canEditOwn = Boolean.TRUE.equals(perms.get("canEditOwn"));
+            if (!canEditOwn) {
+                sendError(response, 403, "No permission to toggle announcements");
+                return false;
+            }
+
+            // Verify ownership
+            Optional<AnnouncementDTO> existing = announcementService.getAnnouncement(id).get(15, TimeUnit.SECONDS);
+            if (existing.isEmpty()) {
+                sendError(response, 404, "Announcement not found: " + id);
+                return false;
+            }
+            if (!callerUuid.equals(existing.get().getOwnerUuid())) {
+                sendError(response, 403, "You can only toggle your own announcements");
+                return false;
+            }
+            return true;
+        } catch (IllegalArgumentException e) {
+            sendError(response, 400, "Invalid UUID: " + callerUuid);
+            return false;
+        } catch (Exception e) {
+            logger.error("Error checking toggle permission for: " + id, e);
+            sendError(response, 500, "Permission check failed: " + e.getMessage());
+            return false;
         }
     }
 
@@ -743,8 +841,21 @@ public class AnnouncementController extends HttpServlet {
 
     private void handleDeleteAnnouncement(String id, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
+            // If caller identifies via X-User-UUID, they must have global canDelete
+            String callerUuid = request.getHeader("X-User-UUID");
+            if (callerUuid != null && !callerUuid.isEmpty()) {
+                UUID uuid = UUID.fromString(callerUuid);
+                Map<String, Boolean> perms = resolvePermissions(uuid);
+                if (!Boolean.TRUE.equals(perms.get("canDelete"))) {
+                    sendError(response, 403, "Only administrators can delete announcements");
+                    return;
+                }
+            }
+
             announcementService.deleteAnnouncement(id).get(15, TimeUnit.SECONDS);
             response.setStatus(204);
+        } catch (IllegalArgumentException e) {
+            sendError(response, 400, "Invalid UUID: " + e.getMessage());
         } catch (Exception e) {
             logger.error("Error deleting announcement: " + id, e);
             sendError(response, 500, "Failed to delete announcement: " + e.getMessage());
@@ -777,6 +888,23 @@ public class AnnouncementController extends HttpServlet {
             announcements.add(dto);
         }
         return announcements;
+    }
+
+    // ====== Filtering helpers ======
+
+    /**
+     * Filters out announcements that were deactivated due to payment depletion.
+     * These are hidden from the WebUI (distinct from admin-deactivated announcements).
+     */
+    private List<AnnouncementDTO> filterPaymentDepleted(List<AnnouncementDTO> announcements) {
+        return announcements.stream()
+            .filter(ann -> {
+                Map<String, Object> metadata = ann.getMetadata();
+                if (metadata == null) return true;
+                Object reason = metadata.get("deactivation_reason");
+                return reason == null || !"payment_depleted".equals(reason.toString());
+            })
+            .collect(Collectors.toList());
     }
 
     // ====== Response helpers ======

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
@@ -6,13 +6,21 @@ import com.google.gson.JsonSyntaxException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.bukkit.BanList;
+import org.bukkit.Bukkit;
 import org.fourz.rvnkcore.api.auth.AuthTokenStore;
+import org.fourz.rvnkcore.api.model.PlayerDTO;
+import org.fourz.rvnkcore.api.service.PlayerService;
 import org.fourz.rvnkcore.api.util.ApiUtils;
 import org.fourz.rvnkcore.util.log.LogManager;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * REST API controller for authentication endpoints.
@@ -21,7 +29,8 @@ import java.util.Map;
  * <h3>Endpoints</h3>
  * <ul>
  *   <li>{@code POST /v1/auth/verify} — Exchange a one-time magic link token for player data</li>
- *   <li>{@code GET  /v1/auth/session} — Validate an existing session (stub for Phase 2.5)</li>
+ *   <li>{@code POST /v1/auth/session-token} — Generate a short-lived token for QR code session sharing</li>
+ *   <li>{@code GET  /v1/auth/session} — Validate an existing session</li>
  * </ul>
  *
  * @since 1.5.0
@@ -29,11 +38,13 @@ import java.util.Map;
 public class AuthController extends HttpServlet {
 
     private final AuthTokenStore authTokenStore;
+    private final PlayerService playerService;
     private final Gson gson;
     private final LogManager logger;
 
-    public AuthController(AuthTokenStore authTokenStore, Gson gson, LogManager logger) {
+    public AuthController(AuthTokenStore authTokenStore, PlayerService playerService, Gson gson, LogManager logger) {
         this.authTokenStore = authTokenStore;
+        this.playerService = playerService;
         this.gson = gson;
         this.logger = logger;
     }
@@ -45,6 +56,8 @@ public class AuthController extends HttpServlet {
         try {
             if (pathInfo != null && pathInfo.equals("/verify")) {
                 handleVerify(req, resp);
+            } else if (pathInfo != null && pathInfo.equals("/session-token")) {
+                handleSessionToken(req, resp);
             } else {
                 ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
                         "Unknown auth endpoint: POST " + pathInfo);
@@ -126,11 +139,142 @@ public class AuthController extends HttpServlet {
     }
 
     /**
-     * GET /v1/auth/session — Validate an existing JWT session.
-     * Stub for Phase 2.5 — returns 501 Not Implemented.
+     * POST /v1/auth/session-token — Generate a short-lived auth token for QR code session sharing.
+     * Body: {"uuid": "player-uuid"}
+     *
+     * <p>Allows an already-authenticated user to generate a token that can be
+     * encoded in a QR code and scanned on another device (e.g., mobile) to
+     * create a new session without requiring the in-game /link command.</p>
+     *
+     * <p>Uses the same AuthTokenStore as magic-link tokens. Rate limited to
+     * prevent token flooding.</p>
+     *
+     * Returns: { "token": "...", "expiresIn": 300 }
      */
-    private void handleSession(HttpServletRequest req, HttpServletResponse resp) {
-        ApiUtils.sendError(resp, gson, 501, "NOT_IMPLEMENTED",
-                "Session validation is not yet implemented");
+    private void handleSessionToken(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String body = ApiUtils.readRequestBody(req);
+
+        String uuidStr;
+        try {
+            JsonObject json = gson.fromJson(body, JsonObject.class);
+            if (json == null || !json.has("uuid") || json.get("uuid").isJsonNull()) {
+                ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Missing required field: uuid");
+                return;
+            }
+            uuidStr = json.get("uuid").getAsString();
+        } catch (JsonSyntaxException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid JSON body");
+            return;
+        }
+
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(uuidStr);
+        } catch (IllegalArgumentException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid UUID format");
+            return;
+        }
+
+        // Rate limit: reuse AuthTokenStore's per-player rate limiting
+        if (authTokenStore.isRateLimited(uuid)) {
+            ApiUtils.sendError(resp, gson, 429, "RATE_LIMITED",
+                    "Please wait before generating another session token");
+            return;
+        }
+
+        try {
+            // Look up the player to get current name and groups
+            Optional<PlayerDTO> optPlayer = playerService.getPlayer(uuid).get(10, TimeUnit.SECONDS);
+            if (optPlayer.isEmpty()) {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND", "Player not found");
+                return;
+            }
+
+            PlayerDTO player = optPlayer.get();
+
+            // Check ban status — don't generate tokens for banned players
+            boolean banned = player.isBanned()
+                    || Bukkit.getBanList(BanList.Type.NAME).isBanned(player.getCurrentName());
+            if (banned) {
+                ApiUtils.sendError(resp, gson, 403, "FORBIDDEN", "Cannot generate token for banned player");
+                return;
+            }
+
+            List<String> groups = player.getGroups() != null ? player.getGroups() : List.of();
+            String token = authTokenStore.generateToken(uuid, player.getCurrentName(), groups);
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("token", token);
+            result.put("expiresIn", 300); // 5 min (tokens are 15 min TTL but we advertise 5 for UX)
+
+            logger.info("Session token generated for " + player.getCurrentName()
+                    + " (QR login) from " + ApiUtils.getClientIP(req));
+            ApiUtils.sendSuccess(resp, gson, result);
+        } catch (Exception e) {
+            logger.error("Failed to generate session token for " + uuid, e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to generate session token");
+        }
+    }
+
+    /**
+     * GET /v1/auth/session — Validate an existing JWT session.
+     * Checks player existence, ban status, and resolves current LuckPerms groups.
+     *
+     * <p>Query params:</p>
+     * <ul>
+     *   <li>{@code uuid} — Player UUID (required)</li>
+     * </ul>
+     *
+     * <p>Response: {@code { valid: bool, banned: bool, groups: [...], name: "..." }}</p>
+     */
+    private void handleSession(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String uuidParam = req.getParameter("uuid");
+        if (uuidParam == null || uuidParam.isBlank()) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Missing required query parameter: uuid");
+            return;
+        }
+
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(uuidParam);
+        } catch (IllegalArgumentException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid UUID format");
+            return;
+        }
+
+        try {
+            Optional<PlayerDTO> optPlayer = playerService.getPlayer(uuid).get(10, TimeUnit.SECONDS);
+
+            if (optPlayer.isEmpty()) {
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put("valid", false);
+                result.put("banned", false);
+                result.put("groups", List.of());
+                result.put("name", "");
+                ApiUtils.sendSuccess(resp, gson, result);
+                return;
+            }
+
+            PlayerDTO player = optPlayer.get();
+
+            // Check ban status via Bukkit ban list
+            boolean banned = player.isBanned();
+            if (!banned) {
+                // Also check server ban list by name (covers console bans)
+                banned = Bukkit.getBanList(BanList.Type.NAME).isBanned(player.getCurrentName());
+            }
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("valid", !banned);
+            result.put("banned", banned);
+            result.put("groups", player.getGroups() != null ? player.getGroups() : List.of());
+            result.put("name", player.getCurrentName());
+            ApiUtils.sendSuccess(resp, gson, result);
+
+            logger.debug("Session validated for " + player.getCurrentName() + " (banned=" + banned + ")");
+        } catch (Exception e) {
+            logger.error("Failed to validate session for UUID " + uuid, e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Session validation failed");
+        }
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
@@ -34,6 +34,7 @@ public class BarterShopsController extends HttpServlet {
     private static final Pattern SHOP_BY_ID_PATTERN = Pattern.compile("^/shops/([^/]+)$");
     private static final Pattern TRADE_BY_ID_PATTERN = Pattern.compile("^/trades/([^/]+)$");
     private static final Pattern STATS_SHOPS_PATTERN = Pattern.compile("^/stats/shops/?(.*)$");
+    private static final Pattern GROUP_BY_ID_PATTERN = Pattern.compile("^/groups/(\\d+)$");
 
     public BarterShopsController(IBarterShopsApiService ignored, Gson gson, LogManager logger) {
         this.gson = gson;
@@ -99,6 +100,12 @@ public class BarterShopsController extends HttpServlet {
                 future = apiService.getShopStats(shopId);
             } else if (pathInfo.equals("/health")) {
                 future = apiService.getHealthStatus();
+            } else if (pathInfo.equals("/groups")) {
+                future = apiService.getGroups(ApiUtils.extractQueryParams(req));
+            } else if (GROUP_BY_ID_PATTERN.matcher(pathInfo).matches()) {
+                Matcher m = GROUP_BY_ID_PATTERN.matcher(pathInfo);
+                m.matches();
+                future = apiService.getGroupById(m.group(1));
             } else {
                 sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
                 return;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/NotificationController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/NotificationController.java
@@ -1,0 +1,229 @@
+package org.fourz.rvnkcore.api.controller;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.model.PushSubscriptionDTO;
+import org.fourz.rvnkcore.api.service.PushSubscriptionService;
+import org.fourz.rvnkcore.api.util.ApiUtils;
+import org.fourz.rvnkcore.service.registry.ServiceRegistry;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * REST API controller for push notification subscription management.
+ * Mounted at {@code /v1/notifications/*}.
+ *
+ * <h3>Endpoints</h3>
+ * <ul>
+ *   <li>{@code POST /v1/notifications/subscribe} — Store a push subscription</li>
+ *   <li>{@code DELETE /v1/notifications/subscribe} — Remove a push subscription by endpoint</li>
+ *   <li>{@code GET /v1/notifications/subscriptions} — List all subscriptions (broadcast)</li>
+ *   <li>{@code GET /v1/notifications/subscriptions/{uuid}} — List subscriptions for a player</li>
+ * </ul>
+ *
+ * @since 1.6.0
+ */
+public class NotificationController extends HttpServlet {
+
+    private final Gson gson;
+    private final LogManager logger;
+
+    public NotificationController(PushSubscriptionService ignored, Gson gson, LogManager logger) {
+        this.gson = gson;
+        this.logger = logger;
+    }
+
+    /**
+     * Lazily resolves the PushSubscriptionService from ServiceRegistry.
+     */
+    private PushSubscriptionService getService() {
+        RVNKCore core = RVNKCore.getInstance();
+        if (core != null) {
+            ServiceRegistry registry = core.getServiceRegistry();
+            if (registry != null && registry.hasService(PushSubscriptionService.class)) {
+                return registry.getService(PushSubscriptionService.class);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo != null && pathInfo.equals("/subscribe")) {
+                handleSubscribe(req, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown notification endpoint: POST " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling notification POST request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo != null && pathInfo.equals("/subscribe")) {
+                handleUnsubscribe(req, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown notification endpoint: DELETE " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling notification DELETE request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo == null || pathInfo.equals("/subscriptions") || pathInfo.equals("/subscriptions/")) {
+                handleGetAllSubscriptions(resp);
+            } else if (pathInfo.startsWith("/subscriptions/")) {
+                String uuid = pathInfo.substring("/subscriptions/".length());
+                handleGetPlayerSubscriptions(uuid, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown notification endpoint: GET " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling notification GET request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    private void handleSubscribe(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        PushSubscriptionService service = getService();
+        if (service == null) {
+            ApiUtils.sendError(resp, gson, 503, "SERVICE_UNAVAILABLE", "Push notification service not available");
+            return;
+        }
+
+        String body = ApiUtils.readRequestBody(req);
+
+        JsonObject json;
+        try {
+            json = gson.fromJson(body, JsonObject.class);
+        } catch (JsonSyntaxException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid JSON body");
+            return;
+        }
+
+        if (json == null) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Empty request body");
+            return;
+        }
+
+        String uuid = getJsonString(json, "uuid");
+        String endpoint = getJsonString(json, "endpoint");
+        String p256dh = getJsonString(json, "p256dh");
+        String authKey = getJsonString(json, "authKey");
+
+        if (uuid.isBlank() || endpoint.isBlank() || p256dh.isBlank() || authKey.isBlank()) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST",
+                    "Missing required fields: uuid, endpoint, p256dh, authKey");
+            return;
+        }
+
+        try {
+            PushSubscriptionDTO dto = new PushSubscriptionDTO(uuid, endpoint, p256dh, authKey);
+            service.saveSubscription(dto).get(10, TimeUnit.SECONDS);
+            logger.info("Push subscription stored for " + uuid);
+            ApiUtils.sendSuccess(resp, gson, "Subscription stored");
+        } catch (Exception e) {
+            logger.error("Failed to store push subscription", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to store subscription");
+        }
+    }
+
+    private void handleUnsubscribe(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        PushSubscriptionService service = getService();
+        if (service == null) {
+            ApiUtils.sendError(resp, gson, 503, "SERVICE_UNAVAILABLE", "Push notification service not available");
+            return;
+        }
+
+        String body = ApiUtils.readRequestBody(req);
+
+        JsonObject json;
+        try {
+            json = gson.fromJson(body, JsonObject.class);
+        } catch (JsonSyntaxException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid JSON body");
+            return;
+        }
+
+        String endpoint = json != null ? getJsonString(json, "endpoint") : "";
+        if (endpoint.isBlank()) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Missing required field: endpoint");
+            return;
+        }
+
+        try {
+            service.deleteByEndpoint(endpoint).get(10, TimeUnit.SECONDS);
+            logger.info("Push subscription removed for endpoint");
+            ApiUtils.sendSuccess(resp, gson, "Subscription removed");
+        } catch (Exception e) {
+            logger.error("Failed to remove push subscription", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to remove subscription");
+        }
+    }
+
+    private void handleGetAllSubscriptions(HttpServletResponse resp) {
+        PushSubscriptionService service = getService();
+        if (service == null) {
+            ApiUtils.sendError(resp, gson, 503, "SERVICE_UNAVAILABLE", "Push notification service not available");
+            return;
+        }
+
+        try {
+            List<PushSubscriptionDTO> subs = service.getAllSubscriptions()
+                    .get(10, TimeUnit.SECONDS);
+            ApiUtils.sendSuccess(resp, gson, subs);
+        } catch (Exception e) {
+            logger.error("Failed to fetch subscriptions", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to fetch subscriptions");
+        }
+    }
+
+    private void handleGetPlayerSubscriptions(String uuid, HttpServletResponse resp) {
+        PushSubscriptionService service = getService();
+        if (service == null) {
+            ApiUtils.sendError(resp, gson, 503, "SERVICE_UNAVAILABLE", "Push notification service not available");
+            return;
+        }
+
+        try {
+            List<PushSubscriptionDTO> subs = service.getSubscriptionsByPlayer(uuid)
+                    .get(10, TimeUnit.SECONDS);
+            ApiUtils.sendSuccess(resp, gson, subs);
+        } catch (Exception e) {
+            logger.error("Failed to fetch subscriptions for " + uuid, e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to fetch subscriptions");
+        }
+    }
+
+    private static String getJsonString(JsonObject json, String key) {
+        if (json.has(key) && !json.get(key).isJsonNull()) {
+            return json.get(key).getAsString();
+        }
+        return "";
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerBanListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerBanListener.java
@@ -1,0 +1,79 @@
+package org.fourz.rvnkcore.api.event;
+
+import org.bukkit.BanList;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.fourz.rvnkcore.api.model.PlayerDTO;
+import org.fourz.rvnkcore.api.service.PlayerService;
+import org.fourz.rvnkcore.api.webhook.WebhookNotifier;
+import org.fourz.rvnkcore.service.registry.ServiceRegistry;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+/**
+ * Listens for player kick events and detects bans.
+ * When a ban is detected, updates the player record and fires a webhook
+ * to trigger session revocation on the web frontend.
+ *
+ * @since 1.6.0
+ */
+public class PlayerBanListener implements Listener {
+
+    private final ServiceRegistry registry;
+    private final LogManager logger;
+
+    public PlayerBanListener(ServiceRegistry registry, LogManager logger) {
+        this.registry = registry;
+        this.logger = logger;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerKick(PlayerKickEvent event) {
+        Player player = event.getPlayer();
+        String playerName = player.getName();
+
+        // Check if this kick is due to a ban (ban list is updated before kick fires)
+        if (!Bukkit.getBanList(BanList.Type.NAME).isBanned(playerName)) {
+            return;
+        }
+
+        logger.info("Ban detected for " + playerName + " — updating record and firing webhook");
+
+        // Update player record with banned status
+        try {
+            PlayerService playerService = registry.getService(PlayerService.class);
+            if (playerService != null) {
+                playerService.getPlayer(player.getUniqueId())
+                    .thenAccept(optDto -> {
+                        optDto.ifPresent(dto -> {
+                            dto.setBanned(true);
+                            playerService.savePlayer(dto)
+                                .exceptionally(ex -> {
+                                    logger.error("Failed to save ban status for " + playerName, (Throwable) ex);
+                                    return null;
+                                });
+                        });
+                    })
+                    .exceptionally(ex -> {
+                        logger.error("Failed to fetch player for ban update: " + playerName, (Throwable) ex);
+                        return null;
+                    });
+            }
+        } catch (Exception e) {
+            logger.error("Failed to update ban status for " + playerName, e);
+        }
+
+        // Fire webhook immediately (no debounce — bans are critical)
+        try {
+            WebhookNotifier notifier = registry.getService(WebhookNotifier.class);
+            if (notifier != null) {
+                notifier.notifyPlayerBanned(player.getUniqueId().toString(), playerName);
+            }
+        } catch (Exception e) {
+            logger.debug("Webhook notifier not available for ban event: " + e.getMessage());
+        }
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/AnnouncementDTO.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/AnnouncementDTO.java
@@ -30,7 +30,8 @@ public class AnnouncementDTO {
     private List<String> targetWorlds;
     private List<String> targetGroups;
     private Map<String, Object> metadata;
-    
+    private String ownerUuid;
+
     /**
      * Creates a new AnnouncementDTO with default values.
      */
@@ -170,6 +171,14 @@ public class AnnouncementDTO {
         this.metadata = metadata != null ? metadata : new HashMap<>();
     }
     
+    public String getOwnerUuid() {
+        return ownerUuid;
+    }
+
+    public void setOwnerUuid(String ownerUuid) {
+        this.ownerUuid = ownerUuid;
+    }
+
     /**
      * Gets a metadata value by key.
      * 
@@ -310,7 +319,12 @@ public class AnnouncementDTO {
             dto.metadata.put(key, value);
             return this;
         }
-        
+
+        public Builder ownerUuid(String ownerUuid) {
+            dto.ownerUuid = ownerUuid;
+            return this;
+        }
+
         public AnnouncementDTO build() {
             return dto;
         }
@@ -323,6 +337,7 @@ public class AnnouncementDTO {
                 ", title='" + title + '\'' +
                 ", type='" + type + '\'' +
                 ", active=" + active +
+                ", ownerUuid='" + ownerUuid + '\'' +
                 ", scheduledFor=" + scheduledFor +
                 ", expiresAt=" + expiresAt +
                 '}';

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/PushSubscriptionDTO.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/PushSubscriptionDTO.java
@@ -1,0 +1,46 @@
+package org.fourz.rvnkcore.api.model;
+
+import java.sql.Timestamp;
+
+/**
+ * Data transfer object for web push subscriptions.
+ * Stores browser push endpoint and encryption keys per player.
+ *
+ * @since 1.6.0
+ */
+public class PushSubscriptionDTO {
+
+    private int id;
+    private String playerId;
+    private String endpoint;
+    private String p256dh;
+    private String authKey;
+    private Timestamp createdAt;
+
+    public PushSubscriptionDTO() {}
+
+    public PushSubscriptionDTO(String playerId, String endpoint, String p256dh, String authKey) {
+        this.playerId = playerId;
+        this.endpoint = endpoint;
+        this.p256dh = p256dh;
+        this.authKey = authKey;
+    }
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+
+    public String getPlayerId() { return playerId; }
+    public void setPlayerId(String playerId) { this.playerId = playerId; }
+
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+
+    public String getP256dh() { return p256dh; }
+    public void setP256dh(String p256dh) { this.p256dh = p256dh; }
+
+    public String getAuthKey() { return authKey; }
+    public void setAuthKey(String authKey) { this.authKey = authKey; }
+
+    public Timestamp getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Timestamp createdAt) { this.createdAt = createdAt; }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
@@ -12,6 +12,7 @@ import org.fourz.rvnkcore.api.controller.AuthController;
 import org.fourz.rvnkcore.api.controller.BarterShopsController;
 import org.fourz.rvnkcore.api.controller.HealthController;
 import org.fourz.rvnkcore.api.controller.LoreController;
+import org.fourz.rvnkcore.api.controller.NotificationController;
 import org.fourz.rvnkcore.api.controller.RVNKWorldsController;
 import org.fourz.rvnkcore.api.controller.PlayerController;
 import org.fourz.rvnkcore.api.controller.AnnouncementController;
@@ -20,6 +21,7 @@ import org.fourz.rvnkcore.api.docs.OpenApiHandler;
 import org.fourz.rvnkcore.api.security.AuthFilter;
 import org.fourz.rvnkcore.api.service.PlayerService;
 import org.fourz.rvnkcore.api.service.PlayerWorldService;
+import org.fourz.rvnkcore.api.service.PushSubscriptionService;
 import org.fourz.rvnkcore.api.service.AnnouncementService;
 import org.fourz.rvnkcore.api.service.WorldService;
 import org.fourz.rvnkcore.util.log.LogManager;
@@ -136,6 +138,9 @@ public class ServletFactory {
         // Register auth controller
         registerAuthController(context);
 
+        // Register notification controller
+        registerNotificationController(context);
+
         // Plugin controllers — registered if their API service is available in ServiceRegistry
         registerBarterShopsController(context);
         registerLoreController(context);
@@ -177,9 +182,22 @@ public class ServletFactory {
      */
     private void registerAuthController(ServletContextHandler context) {
         LogManager authLogger = LogManager.getInstance(plugin, AuthController.class);
-        AuthController authController = new AuthController(authTokenStore, gson, authLogger);
+        AuthController authController = new AuthController(authTokenStore, playerService, gson, authLogger);
         context.addServlet(new ServletHolder(authController), "/v1/auth/*");
         logger.info("Auth API controller registered at /v1/auth/*");
+    }
+
+    /**
+     * Registers the notification controller for push subscription management.
+     * The controller resolves PushSubscriptionService lazily from ServiceRegistry at request time.
+     *
+     * @param context The servlet context to configure
+     */
+    private void registerNotificationController(ServletContextHandler context) {
+        LogManager notifLogger = LogManager.getInstance(plugin, NotificationController.class);
+        NotificationController controller = new NotificationController(null, gson, notifLogger);
+        context.addServlet(new ServletHolder(controller), "/v1/notifications/*");
+        logger.info("Notification API controller registered at /v1/notifications/*");
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
@@ -60,4 +60,16 @@ public interface IBarterShopsApiService {
      * GET /api/bartershops/health — health check.
      */
     CompletableFuture<ApiResponse<?>> getHealthStatus();
+
+    /**
+     * GET /api/bartershops/groups — list groups with optional filters.
+     *
+     * @param filters query parameters (owner, world, page, limit)
+     */
+    CompletableFuture<ApiResponse<?>> getGroups(Map<String, String> filters);
+
+    /**
+     * GET /api/bartershops/groups/{id} — get group by ID with shops and co-owners.
+     */
+    CompletableFuture<ApiResponse<?>> getGroupById(String groupId);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/PushSubscriptionService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/PushSubscriptionService.java
@@ -1,0 +1,22 @@
+package org.fourz.rvnkcore.api.service;
+
+import org.fourz.rvnkcore.api.model.PushSubscriptionDTO;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service interface for managing web push notification subscriptions.
+ *
+ * @since 1.6.0
+ */
+public interface PushSubscriptionService {
+
+    CompletableFuture<Void> saveSubscription(PushSubscriptionDTO subscription);
+
+    CompletableFuture<Void> deleteByEndpoint(String endpoint);
+
+    CompletableFuture<List<PushSubscriptionDTO>> getAllSubscriptions();
+
+    CompletableFuture<List<PushSubscriptionDTO>> getSubscriptionsByPlayer(String playerId);
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
@@ -227,6 +227,42 @@ public class WebhookNotifier {
             });
     }
 
+    /**
+     * Fires a webhook notification for a player ban event.
+     * No debounce — bans are critical security events that must propagate immediately
+     * to trigger session revocation on the web frontend.
+     *
+     * @param uuid       The banned player's UUID
+     * @param playerName The banned player's name
+     */
+    public void notifyPlayerBanned(String uuid, String playerName) {
+        String payload = "{\"event\":\"player_banned\",\"server\":\""
+            + escapeJson(config.getServerId())
+            + "\",\"uuid\":\""
+            + escapeJson(uuid)
+            + "\",\"playerName\":\""
+            + escapeJson(playerName)
+            + "\",\"timestamp\":\""
+            + Instant.now().toString()
+            + "\"}";
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(config.getUrl()))
+            .header("Content-Type", "application/json")
+            .header("X-Webhook-Secret", config.getSecret())
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .timeout(Duration.ofMillis(config.getTimeoutMs()))
+            .build();
+
+        httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+            .thenAccept(response ->
+                logger.warning("Webhook ban " + config.getServerId() + " -> " + response.statusCode()))
+            .exceptionally(e -> {
+                logger.warning("Webhook ban failed: " + e.getMessage());
+                return null;
+            });
+    }
+
     private static String escapeJson(String value) {
         if (value == null) return "";
         return value.replace("\\", "\\\\").replace("\"", "\\\"");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/AnnouncementRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/AnnouncementRepository.java
@@ -319,6 +319,16 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
                 builder.targetGroups(targetGroups);
             }
             
+            // Parse owner_uuid
+            try {
+                String ownerUuid = rs.getString("owner_uuid");
+                if (ownerUuid != null && !ownerUuid.trim().isEmpty()) {
+                    builder.ownerUuid(ownerUuid);
+                }
+            } catch (SQLException ignored) {
+                // Column may not exist yet (pre-migration)
+            }
+
             // Parse metadata from JSON-like string (simplified implementation)
             String metadataStr = rs.getString("metadata");
             if (metadataStr != null && !metadataStr.trim().isEmpty()) {
@@ -326,7 +336,7 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
                 // In a full implementation, this would be proper JSON deserialization
                 builder.metadata("raw_metadata", metadataStr);
             }
-            
+
             AnnouncementDTO result = builder.build();
             logger.debug("Successfully mapped announcement DTO: " + id);
             return result;
@@ -357,8 +367,8 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
         QueryBuilder builder = createQueryBuilder();
         return builder.insert(tableName)
             .columns("id", "title", "message", "type", "active", "pinned", "created_at", "updated_at",
-                    "scheduled_for", "expires_at", "interval_seconds", "target_worlds", "target_groups", "metadata")
-            .values("?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?")
+                    "scheduled_for", "expires_at", "interval_seconds", "target_worlds", "target_groups", "metadata", "owner_uuid")
+            .values("?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?")
             .build();
     }
     
@@ -379,6 +389,7 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
             .set("target_worlds", "?")
             .set("target_groups", "?")
             .set("metadata", "?")
+            .set("owner_uuid", "?")
             .where("id = ?")
             .build();
     }
@@ -406,8 +417,9 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
             metadataStr.append(entry.getKey()).append("=").append(entry.getValue());
         }
         stmt.setString(14, metadataStr.toString());
+        stmt.setString(15, entity.getOwnerUuid());
     }
-    
+
     @Override
     protected void setUpdateParameters(PreparedStatement stmt, AnnouncementDTO entity) throws SQLException {
         stmt.setString(1, entity.getTitle());
@@ -429,9 +441,43 @@ public class AnnouncementRepository extends BaseRepository<AnnouncementDTO, Stri
             metadataStr.append(entry.getKey()).append("=").append(entry.getValue());
         }
         stmt.setString(12, metadataStr.toString());
-        stmt.setString(13, entity.getId()); // WHERE clause
+        stmt.setString(13, entity.getOwnerUuid());
+        stmt.setString(14, entity.getId()); // WHERE clause
     }
     
+    /**
+     * Finds announcements owned by a specific player UUID.
+     *
+     * @param ownerUuid The UUID of the owner
+     * @return CompletableFuture containing list of announcements owned by the player
+     */
+    public CompletableFuture<List<AnnouncementDTO>> findByOwnerUuid(String ownerUuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String query = queryBuilder.select("*")
+                .from(tableName)
+                .where("owner_uuid = ?")
+                .orderBy("created_at", false)
+                .build();
+
+            try (var conn = connectionProvider.getConnection();
+                 var stmt = conn.prepareStatement(query)) {
+
+                stmt.setString(1, ownerUuid);
+
+                try (ResultSet rs = stmt.executeQuery()) {
+                    List<AnnouncementDTO> results = new ArrayList<>();
+                    while (rs.next()) {
+                        results.add(mapResultSet(rs));
+                    }
+                    return results;
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to find announcements by owner UUID: " + ownerUuid, e);
+                throw new org.fourz.rvnkcore.api.exception.DatabaseException("Announcements by owner lookup failed", e);
+            }
+        });
+    }
+
     // === Additional methods required by service ===
     
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PushSubscriptionRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PushSubscriptionRepository.java
@@ -1,0 +1,139 @@
+package org.fourz.rvnkcore.database.repository;
+
+import org.bukkit.plugin.Plugin;
+import org.fourz.rvnkcore.api.model.PushSubscriptionDTO;
+import org.fourz.rvnkcore.database.connection.ConnectionProvider;
+import org.fourz.rvnkcore.database.query.BasicSQLQueryBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository for web push subscription storage.
+ * Table: {@code rvnk_push_subscriptions}
+ *
+ * @since 1.6.0
+ */
+public class PushSubscriptionRepository extends BaseRepository<PushSubscriptionDTO, Integer> {
+
+    public PushSubscriptionRepository(ConnectionProvider connectionProvider, Plugin plugin) {
+        super(connectionProvider, new BasicSQLQueryBuilder(), "rvnk_push_subscriptions",
+                PushSubscriptionDTO.class, plugin);
+    }
+
+    @Override
+    protected PushSubscriptionDTO mapResultSet(ResultSet rs) throws SQLException {
+        PushSubscriptionDTO dto = new PushSubscriptionDTO();
+        dto.setId(rs.getInt("id"));
+        dto.setPlayerId(rs.getString("player_id"));
+        dto.setEndpoint(rs.getString("endpoint"));
+        dto.setP256dh(rs.getString("p256dh"));
+        dto.setAuthKey(rs.getString("auth_key"));
+        dto.setCreatedAt(rs.getTimestamp("created_at"));
+        return dto;
+    }
+
+    @Override
+    protected String getPrimaryKeyColumn() {
+        return "id";
+    }
+
+    @Override
+    protected Integer getId(PushSubscriptionDTO entity) {
+        return entity.getId();
+    }
+
+    @Override
+    protected void setPrimaryKeyParameter(PreparedStatement stmt, int parameterIndex, Integer id) throws SQLException {
+        stmt.setInt(parameterIndex, id);
+    }
+
+    @Override
+    protected String buildInsertQuery() {
+        return "INSERT INTO " + tableName
+                + " (player_id, endpoint, p256dh, auth_key) VALUES (?, ?, ?, ?)"
+                + " ON DUPLICATE KEY UPDATE player_id = VALUES(player_id), p256dh = VALUES(p256dh), auth_key = VALUES(auth_key)";
+    }
+
+    @Override
+    protected String buildUpdateQuery() {
+        return "UPDATE " + tableName
+                + " SET player_id = ?, endpoint = ?, p256dh = ?, auth_key = ? WHERE id = ?";
+    }
+
+    @Override
+    protected void setInsertParameters(PreparedStatement stmt, PushSubscriptionDTO dto) throws SQLException {
+        stmt.setString(1, dto.getPlayerId());
+        stmt.setString(2, dto.getEndpoint());
+        stmt.setString(3, dto.getP256dh());
+        stmt.setString(4, dto.getAuthKey());
+    }
+
+    @Override
+    protected void setUpdateParameters(PreparedStatement stmt, PushSubscriptionDTO dto) throws SQLException {
+        stmt.setString(1, dto.getPlayerId());
+        stmt.setString(2, dto.getEndpoint());
+        stmt.setString(3, dto.getP256dh());
+        stmt.setString(4, dto.getAuthKey());
+        stmt.setInt(5, dto.getId());
+    }
+
+    public CompletableFuture<List<PushSubscriptionDTO>> findByPlayerId(String playerId) {
+        return CompletableFuture.supplyAsync(() -> {
+            List<PushSubscriptionDTO> results = new ArrayList<>();
+            try (var conn = connectionProvider.getConnection();
+                 var stmt = conn.prepareStatement("SELECT * FROM " + tableName + " WHERE player_id = ?")) {
+                stmt.setString(1, playerId);
+                try (var rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        results.add(mapResultSet(rs));
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to query subscriptions by player " + playerId, e);
+            }
+            return results;
+        });
+    }
+
+    public CompletableFuture<Void> deleteByEndpoint(String endpoint) {
+        return CompletableFuture.runAsync(() -> {
+            try (var conn = connectionProvider.getConnection();
+                 var stmt = conn.prepareStatement("DELETE FROM " + tableName + " WHERE endpoint = ?")) {
+                stmt.setString(1, endpoint);
+                stmt.executeUpdate();
+            } catch (SQLException e) {
+                logger.error("Failed to delete subscription by endpoint", e);
+            }
+        });
+    }
+
+    /**
+     * Creates the push subscriptions table if it doesn't exist.
+     */
+    public CompletableFuture<Void> createTable() {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "CREATE TABLE IF NOT EXISTS " + tableName + " ("
+                    + "id INT AUTO_INCREMENT PRIMARY KEY, "
+                    + "player_id VARCHAR(36) NOT NULL, "
+                    + "endpoint TEXT NOT NULL, "
+                    + "p256dh TEXT NOT NULL, "
+                    + "auth_key VARCHAR(128) NOT NULL, "
+                    + "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                    + "INDEX idx_push_player (player_id), "
+                    + "UNIQUE INDEX idx_push_endpoint (endpoint(255))"
+                    + ")";
+            try (var conn = connectionProvider.getConnection();
+                 var stmt = conn.prepareStatement(sql)) {
+                stmt.executeUpdate();
+                logger.info("Push subscriptions table ensured");
+            } catch (SQLException e) {
+                logger.error("Failed to create push subscriptions table", e);
+            }
+        });
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
@@ -666,7 +666,76 @@ public class DatabaseSetup {
             }
         }
 
+        // Migration 5: Add owner_uuid column to announcements table
+        if (!columnExists(connection, announcementsTable, "owner_uuid")) {
+            logger.info("Adding 'owner_uuid' column to " + announcementsTable);
+            try (var stmt = connection.createStatement()) {
+                if ("MySQL".equalsIgnoreCase(databaseType)) {
+                    stmt.execute("ALTER TABLE " + announcementsTable + " ADD COLUMN owner_uuid VARCHAR(36) NULL");
+                } else {
+                    stmt.execute("ALTER TABLE " + announcementsTable + " ADD COLUMN owner_uuid TEXT NULL");
+                }
+                logger.info("Successfully added 'owner_uuid' column");
+            } catch (SQLException e) {
+                logger.warning("Failed to add owner_uuid column: " + e.getMessage());
+            }
+
+            // Create index on owner_uuid for lookup queries
+            try (var stmt = connection.createStatement()) {
+                String prefix = getTablePrefix().isEmpty() ? "" : getTablePrefix();
+                stmt.execute("CREATE INDEX IF NOT EXISTS idx_" + prefix + "announcements_owner_uuid ON " + announcementsTable + "(owner_uuid)");
+                logger.info("Created index on owner_uuid");
+            } catch (SQLException e) {
+                logger.warning("Failed to create owner_uuid index: " + e.getMessage());
+            }
+
+            // Best-effort backfill: resolve owner names from metadata to UUIDs via rvnk_players
+            backfillOwnerUuids(connection, announcementsTable);
+        }
+
         logger.debug("Database migrations completed");
+    }
+
+    /**
+     * Backfills owner_uuid from metadata owner= entries by looking up rvnk_players.
+     * Best-effort: unresolvable names stay NULL.
+     */
+    private void backfillOwnerUuids(Connection connection, String announcementsTable) {
+        String playersTable = table(TABLE_PLAYERS);
+        try {
+            // Extract owner name from metadata (format: "owner=Name,key=val" or "raw_metadata=owner=Name,...")
+            // and join against rvnk_players to resolve UUID
+            String sql;
+            if ("MySQL".equalsIgnoreCase(databaseType)) {
+                // MySQL: use SUBSTRING_INDEX to extract owner value from metadata
+                sql = "UPDATE " + announcementsTable + " a " +
+                    "INNER JOIN " + playersTable + " p ON p.current_name = " +
+                    "TRIM(SUBSTRING_INDEX(SUBSTRING_INDEX(a.metadata, 'owner=', -1), ',', 1)) " +
+                    "SET a.owner_uuid = p.id " +
+                    "WHERE a.owner_uuid IS NULL AND a.metadata LIKE '%owner=%'";
+            } else {
+                // SQLite: simpler approach — only handle direct owner=Name metadata format
+                sql = "UPDATE " + announcementsTable + " SET owner_uuid = (" +
+                    "SELECT p.id FROM " + playersTable + " p " +
+                    "WHERE p.current_name = TRIM(REPLACE(SUBSTR(" +
+                    announcementsTable + ".metadata, INSTR(" + announcementsTable + ".metadata, 'owner=') + 6), " +
+                    "SUBSTR(SUBSTR(" + announcementsTable + ".metadata, INSTR(" + announcementsTable + ".metadata, 'owner=') + 6), " +
+                    "INSTR(SUBSTR(" + announcementsTable + ".metadata, INSTR(" + announcementsTable + ".metadata, 'owner=') + 6), ',')), '')) " +
+                    "LIMIT 1) " +
+                    "WHERE owner_uuid IS NULL AND metadata LIKE '%owner=%'";
+            }
+
+            try (var stmt = connection.createStatement()) {
+                int rows = stmt.executeUpdate(sql);
+                if (rows > 0) {
+                    logger.info("Backfilled owner_uuid for " + rows + " announcement(s)");
+                } else {
+                    logger.info("No announcements needed owner_uuid backfill");
+                }
+            }
+        } catch (SQLException e) {
+            logger.warning("owner_uuid backfill failed (non-fatal): " + e.getMessage());
+        }
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/CoreServiceFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/CoreServiceFactory.java
@@ -7,6 +7,7 @@ import org.fourz.rvnkcore.api.service.ITeleportService;
 import org.fourz.rvnkcore.api.service.PlayerPreferencesService;
 import org.fourz.rvnkcore.api.service.PlayerService;
 import org.fourz.rvnkcore.api.service.PlayerWorldService;
+import org.fourz.rvnkcore.api.service.PushSubscriptionService;
 import org.fourz.rvnkcore.api.service.WorldService;
 import org.fourz.rvnkcore.database.connection.ConnectionProvider;
 import org.fourz.rvnkcore.database.query.BasicSQLQueryBuilder;
@@ -15,11 +16,13 @@ import org.fourz.rvnkcore.database.repository.AnnouncementTypeRepository;
 import org.fourz.rvnkcore.database.repository.PlayerPreferencesRepository;
 import org.fourz.rvnkcore.database.repository.PlayerRepository;
 import org.fourz.rvnkcore.database.repository.PlayerWorldDataRepository;
+import org.fourz.rvnkcore.database.repository.PushSubscriptionRepository;
 import org.fourz.rvnkcore.database.repository.DefaultWorldRepository;
 import org.fourz.rvnkcore.service.announcement.DefaultAnnouncementService;
 import org.fourz.rvnkcore.service.player.DefaultPlayerService;
 import org.fourz.rvnkcore.service.player.DefaultPlayerWorldService;
 import org.fourz.rvnkcore.service.preferences.DefaultPlayerPreferencesService;
+import org.fourz.rvnkcore.service.push.DefaultPushSubscriptionService;
 import org.fourz.rvnkcore.service.teleport.CoreTeleportService;
 import org.fourz.rvnkcore.service.world.DefaultWorldService;
 import org.fourz.rvnkcore.service.registry.ServiceRegistry;
@@ -106,8 +109,11 @@ public class CoreServiceFactory {
         registerMojangAPI(registry);
         logger.debug("  + MojangAPI registered (" + (System.currentTimeMillis() - startTime) + "ms)");
 
+        registerPushSubscriptionService(registry);
+        logger.debug("  + PushSubscriptionService registered (" + (System.currentTimeMillis() - startTime) + "ms)");
+
         long totalTime = System.currentTimeMillis() - startTime;
-        logger.info("Core services registered: PlayerService, PlayerWorldService, WorldService, AnnouncementService, PlayerPreferencesService, ITeleportService, MojangAPI (" + totalTime + "ms)");
+        logger.info("Core services registered: PlayerService, PlayerWorldService, WorldService, AnnouncementService, PlayerPreferencesService, ITeleportService, MojangAPI, PushSubscriptionService (" + totalTime + "ms)");
     }
 
     /**
@@ -246,6 +252,23 @@ public class CoreServiceFactory {
      * api.getUuidByName("Player").thenAccept(uuid -> ...);
      * </pre>
      */
+    /**
+     * Registers the PushSubscriptionService for web push notification subscriptions.
+     */
+    private void registerPushSubscriptionService(ServiceRegistry registry) {
+        try {
+            LogManager pushLogger = LogManager.getInstance(plugin, DefaultPushSubscriptionService.class);
+            PushSubscriptionRepository pushRepo = new PushSubscriptionRepository(connectionProvider, plugin);
+            DefaultPushSubscriptionService pushService = new DefaultPushSubscriptionService(pushRepo, pushLogger);
+
+            registry.registerService(PushSubscriptionService.class, pushService);
+            logger.info("PushSubscriptionService registered");
+        } catch (Exception e) {
+            logger.error("Failed to register PushSubscriptionService", e);
+            throw new RuntimeException("PushSubscriptionService registration failed", e);
+        }
+    }
+
     private void registerMojangAPI(ServiceRegistry registry) {
         try {
             mojangAPI = new MojangAPI(plugin);

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
@@ -3,6 +3,7 @@ package org.fourz.rvnkcore.init;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.event.PlayerBanListener;
 import org.fourz.rvnkcore.api.event.PlayerTrackingListener;
 import org.fourz.rvnkcore.api.event.WorldTrackingListener;
 import org.fourz.rvnkcore.command.PlayerPreferencesCommand;
@@ -230,6 +231,10 @@ public class RVNKToolsInitializer {
                 WorldTrackingListener worldTracker = new WorldTrackingListener(plugin, plugin);
                 plugin.getServer().getPluginManager().registerEvents(worldTracker, plugin);
                 worldTracker.syncAllLoadedWorlds();
+
+                // Register ban detection listener
+                PlayerBanListener banListener = new PlayerBanListener(registry, logger);
+                plugin.getServer().getPluginManager().registerEvents(banListener, plugin);
 
                 // Register LuckPerms integration
                 try {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/announcement/DefaultAnnouncementService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/announcement/DefaultAnnouncementService.java
@@ -191,6 +191,9 @@ public class DefaultAnnouncementService implements AnnouncementService {
                     if (announcement.getTitle() == null) {
                         announcement.setTitle(existing.getTitle());
                     }
+                    if (announcement.getOwnerUuid() == null) {
+                        announcement.setOwnerUuid(existing.getOwnerUuid());
+                    }
                 }
 
                 // Update timestamp
@@ -645,6 +648,30 @@ public class DefaultAnnouncementService implements AnnouncementService {
                            cache.size(), hits, misses, hitRate);
     }
     
+    /**
+     * Deactivates an announcement due to payment depletion.
+     * Sets active=false and adds deactivation_reason=payment_depleted to metadata.
+     *
+     * @param id The announcement ID
+     * @return CompletableFuture that completes when deactivation is finished
+     */
+    public CompletableFuture<Void> deactivateForPayment(String id) {
+        return deactivateAnnouncement(id)
+            .thenCompose(v -> updateAnnouncementMetadata(id, "deactivation_reason", "payment_depleted"));
+    }
+
+    /**
+     * Reactivates an announcement that was deactivated for payment.
+     * Sets active=true and clears the deactivation_reason metadata.
+     *
+     * @param id The announcement ID
+     * @return CompletableFuture that completes when reactivation is finished
+     */
+    public CompletableFuture<Void> reactivateFromPayment(String id) {
+        return activateAnnouncement(id)
+            .thenCompose(v -> updateAnnouncementMetadata(id, "deactivation_reason", ""));
+    }
+
     /**
      * Clears the announcement cache.
      */

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/push/DefaultPushSubscriptionService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/push/DefaultPushSubscriptionService.java
@@ -1,0 +1,53 @@
+package org.fourz.rvnkcore.service.push;
+
+import org.fourz.rvnkcore.api.model.PushSubscriptionDTO;
+import org.fourz.rvnkcore.api.service.PushSubscriptionService;
+import org.fourz.rvnkcore.database.repository.PushSubscriptionRepository;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default implementation of {@link PushSubscriptionService}.
+ * Delegates all operations to {@link PushSubscriptionRepository}.
+ *
+ * @since 1.6.0
+ */
+public class DefaultPushSubscriptionService implements PushSubscriptionService {
+
+    private final PushSubscriptionRepository repository;
+    private final LogManager logger;
+
+    public DefaultPushSubscriptionService(PushSubscriptionRepository repository, LogManager logger) {
+        this.repository = repository;
+        this.logger = logger;
+
+        // Ensure table exists on service creation
+        repository.createTable()
+                .exceptionally(ex -> {
+                    logger.error("Failed to initialize push subscriptions table", (Throwable) ex);
+                    return null;
+                });
+    }
+
+    @Override
+    public CompletableFuture<Void> saveSubscription(PushSubscriptionDTO subscription) {
+        return repository.save(subscription).thenApply(saved -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteByEndpoint(String endpoint) {
+        return repository.deleteByEndpoint(endpoint);
+    }
+
+    @Override
+    public CompletableFuture<List<PushSubscriptionDTO>> getAllSubscriptions() {
+        return repository.findAll();
+    }
+
+    @Override
+    public CompletableFuture<List<PushSubscriptionDTO>> getSubscriptionsByPlayer(String playerId) {
+        return repository.findByPlayerId(playerId);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/BackLocationService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/BackLocationService.java
@@ -1,0 +1,19 @@
+package org.fourz.rvnkcore.service.teleport;
+
+import org.bukkit.Location;
+
+import java.util.UUID;
+import java.util.Optional;
+
+/**
+ * Tracks the pre-teleport location for each player so they can /back.
+ * In-memory only — data is lost on restart (acceptable for /back).
+ */
+public interface BackLocationService {
+
+    void setBackLocation(UUID playerUUID, Location location);
+
+    Optional<Location> getBackLocation(UUID playerUUID);
+
+    void clearBackLocation(UUID playerUUID);
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/DefaultBackLocationService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/DefaultBackLocationService.java
@@ -1,0 +1,44 @@
+package org.fourz.rvnkcore.service.teleport;
+
+import org.bukkit.Location;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of BackLocationService.
+ * Stores one "back" location per player.
+ */
+public class DefaultBackLocationService implements BackLocationService {
+
+    private final ConcurrentHashMap<UUID, Location> backLocations = new ConcurrentHashMap<>();
+
+    @Override
+    public void setBackLocation(UUID playerUUID, Location location) {
+        if (location != null && location.getWorld() != null) {
+            backLocations.put(playerUUID, location.clone());
+        }
+    }
+
+    @Override
+    public Optional<Location> getBackLocation(UUID playerUUID) {
+        Location loc = backLocations.get(playerUUID);
+        if (loc != null && loc.getWorld() != null) {
+            return Optional.of(loc);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void clearBackLocation(UUID playerUUID) {
+        backLocations.remove(playerUUID);
+    }
+
+    /**
+     * Clean up data for a disconnected player to prevent memory leaks.
+     */
+    public void handlePlayerQuit(UUID playerUUID) {
+        backLocations.remove(playerUUID);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequest.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequest.java
@@ -1,0 +1,36 @@
+package org.fourz.rvnkcore.service.teleport;
+
+import java.util.UUID;
+
+/**
+ * Represents a pending TPA teleport request between two players.
+ */
+public class TpaRequest {
+
+    public enum Type { TPA, TPAHERE }
+
+    private final UUID sender;
+    private final UUID target;
+    private final Type type;
+    private final long createdAt;
+    private int expiryTaskId = -1;
+
+    public TpaRequest(UUID sender, UUID target, Type type) {
+        this.sender = sender;
+        this.target = target;
+        this.type = type;
+        this.createdAt = System.currentTimeMillis();
+    }
+
+    public UUID getSender() { return sender; }
+    public UUID getTarget() { return target; }
+    public Type getType() { return type; }
+    public long getCreatedAt() { return createdAt; }
+
+    public int getExpiryTaskId() { return expiryTaskId; }
+    public void setExpiryTaskId(int taskId) { this.expiryTaskId = taskId; }
+
+    public boolean isExpired(long expireMs) {
+        return System.currentTimeMillis() - createdAt > expireMs;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequestService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequestService.java
@@ -1,0 +1,318 @@
+package org.fourz.rvnkcore.service.teleport;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages TPA teleport requests, warmup timers, and cooldowns.
+ *
+ * <p>Request model: one outbound request per sender, one inbound per target.
+ * Requests expire after a configurable timeout (default 60s).</p>
+ *
+ * <p>Warmup: configurable delay before teleport executes. Cancelled if player
+ * moves more than 1 block. Bypassed with permission.</p>
+ *
+ * <p>Cooldown: configurable delay between sending requests. Bypassed with permission.</p>
+ */
+public class TpaRequestService {
+
+    private final Plugin plugin;
+    private final LogManager logger;
+
+    // Keyed by target UUID — the player who received the request
+    private final ConcurrentHashMap<UUID, TpaRequest> inboundRequests = new ConcurrentHashMap<>();
+    // Keyed by sender UUID — the player who sent the request
+    private final ConcurrentHashMap<UUID, TpaRequest> outboundRequests = new ConcurrentHashMap<>();
+    // Cooldown expiry timestamps keyed by player UUID
+    private final ConcurrentHashMap<UUID, Long> cooldowns = new ConcurrentHashMap<>();
+    // Active warmup tasks keyed by player UUID (the player being teleported)
+    private final ConcurrentHashMap<UUID, WarmupState> activeWarmups = new ConcurrentHashMap<>();
+
+    // Config values
+    private int requestExpireSeconds = 60;
+    private int warmupSeconds = 3;
+    private int cooldownSeconds = 10;
+
+    public static final String BYPASS_COOLDOWN_PERM = "rvnktools.tpa.bypass.cooldown";
+    public static final String BYPASS_WARMUP_PERM = "rvnktools.tpa.bypass.warmup";
+
+    public TpaRequestService(Plugin plugin) {
+        this.plugin = plugin;
+        this.logger = LogManager.getInstance(plugin, getClass());
+    }
+
+    public void setRequestExpireSeconds(int seconds) { this.requestExpireSeconds = seconds; }
+    public void setWarmupSeconds(int seconds) { this.warmupSeconds = seconds; }
+    public void setCooldownSeconds(int seconds) { this.cooldownSeconds = seconds; }
+    public int getWarmupSeconds() { return warmupSeconds; }
+    public int getCooldownSeconds() { return cooldownSeconds; }
+
+    /**
+     * Send a TPA request from sender to target.
+     * @return empty if successful, or error message
+     */
+    public Optional<String> sendRequest(Player sender, Player target, TpaRequest.Type type) {
+        UUID senderUUID = sender.getUniqueId();
+        UUID targetUUID = target.getUniqueId();
+
+        if (senderUUID.equals(targetUUID)) {
+            return Optional.of("You cannot send a teleport request to yourself.");
+        }
+
+        // Check cooldown
+        if (isOnCooldown(sender)) {
+            long remaining = getRemainingCooldown(senderUUID);
+            return Optional.of("You must wait " + remaining + "s before sending another request.");
+        }
+
+        // Check for existing outbound request
+        TpaRequest existing = outboundRequests.get(senderUUID);
+        if (existing != null) {
+            // Cancel the old one
+            cancelRequest(senderUUID);
+        }
+
+        // Check if target already has a pending inbound
+        TpaRequest existingInbound = inboundRequests.get(targetUUID);
+        if (existingInbound != null) {
+            // Cancel the old inbound so the new one takes priority
+            cancelRequestByTarget(targetUUID);
+        }
+
+        TpaRequest request = new TpaRequest(senderUUID, targetUUID, type);
+
+        // Schedule expiry
+        BukkitTask expiryTask = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            expireRequest(senderUUID, targetUUID);
+        }, requestExpireSeconds * 20L);
+        request.setExpiryTaskId(expiryTask.getTaskId());
+
+        outboundRequests.put(senderUUID, request);
+        inboundRequests.put(targetUUID, request);
+
+        logger.debug("TPA request: " + sender.getName() + " -> " + target.getName() + " (" + type + ")");
+        return Optional.empty();
+    }
+
+    /**
+     * Get the pending inbound request for a target player.
+     */
+    public Optional<TpaRequest> getInboundRequest(UUID targetUUID) {
+        return Optional.ofNullable(inboundRequests.get(targetUUID));
+    }
+
+    /**
+     * Accept the pending request for the target player.
+     * Removes the request from both maps and sets cooldown on sender.
+     * @return the accepted request, or empty if none pending
+     */
+    public Optional<TpaRequest> acceptRequest(UUID targetUUID) {
+        TpaRequest request = inboundRequests.remove(targetUUID);
+        if (request == null) return Optional.empty();
+
+        outboundRequests.remove(request.getSender());
+        cancelExpiryTask(request);
+        setCooldown(request.getSender());
+
+        logger.debug("TPA accepted: target=" + targetUUID);
+        return Optional.of(request);
+    }
+
+    /**
+     * Deny the pending request for the target player.
+     * @return the denied request, or empty if none pending
+     */
+    public Optional<TpaRequest> denyRequest(UUID targetUUID) {
+        TpaRequest request = inboundRequests.remove(targetUUID);
+        if (request == null) return Optional.empty();
+
+        outboundRequests.remove(request.getSender());
+        cancelExpiryTask(request);
+
+        logger.debug("TPA denied: target=" + targetUUID);
+        return Optional.of(request);
+    }
+
+    /**
+     * Cancel an outbound request by sender UUID.
+     */
+    public void cancelRequest(UUID senderUUID) {
+        TpaRequest request = outboundRequests.remove(senderUUID);
+        if (request != null) {
+            inboundRequests.remove(request.getTarget());
+            cancelExpiryTask(request);
+        }
+    }
+
+    private void cancelRequestByTarget(UUID targetUUID) {
+        TpaRequest request = inboundRequests.remove(targetUUID);
+        if (request != null) {
+            outboundRequests.remove(request.getSender());
+            cancelExpiryTask(request);
+        }
+    }
+
+    private void expireRequest(UUID senderUUID, UUID targetUUID) {
+        TpaRequest request = outboundRequests.remove(senderUUID);
+        if (request != null) {
+            inboundRequests.remove(targetUUID);
+
+            Player sender = Bukkit.getPlayer(senderUUID);
+            Player target = Bukkit.getPlayer(targetUUID);
+            if (sender != null && sender.isOnline()) {
+                sender.sendMessage("§c✖ Your teleport request to " +
+                    (target != null ? target.getName() : "player") + " has expired.");
+            }
+            if (target != null && target.isOnline()) {
+                target.sendMessage("§7Teleport request from " +
+                    (sender != null ? sender.getName() : "player") + " has expired.");
+            }
+        }
+    }
+
+    // --- Cooldown ---
+
+    public boolean isOnCooldown(Player player) {
+        if (player.hasPermission(BYPASS_COOLDOWN_PERM)) return false;
+        Long expiry = cooldowns.get(player.getUniqueId());
+        if (expiry == null) return false;
+        if (System.currentTimeMillis() >= expiry) {
+            cooldowns.remove(player.getUniqueId());
+            return false;
+        }
+        return true;
+    }
+
+    private long getRemainingCooldown(UUID playerUUID) {
+        Long expiry = cooldowns.get(playerUUID);
+        if (expiry == null) return 0;
+        long remaining = (expiry - System.currentTimeMillis()) / 1000;
+        return Math.max(0, remaining);
+    }
+
+    private void setCooldown(UUID playerUUID) {
+        cooldowns.put(playerUUID, System.currentTimeMillis() + (cooldownSeconds * 1000L));
+    }
+
+    // --- Warmup ---
+
+    /**
+     * Start a warmup countdown before teleporting.
+     * @param player the player being teleported
+     * @param onComplete callback to execute when warmup finishes
+     * @return true if warmup started, false if bypassed (instant teleport)
+     */
+    public boolean startWarmup(Player player, Runnable onComplete) {
+        if (player.hasPermission(BYPASS_WARMUP_PERM) || warmupSeconds <= 0) {
+            onComplete.run();
+            return false;
+        }
+
+        UUID uuid = player.getUniqueId();
+        Location startLoc = player.getLocation().clone();
+
+        // Cancel any existing warmup
+        cancelWarmup(uuid);
+
+        player.sendMessage("§e⚠ Teleporting in " + warmupSeconds + " seconds... Don't move!");
+
+        BukkitTask task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            activeWarmups.remove(uuid);
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null && p.isOnline()) {
+                onComplete.run();
+            }
+        }, warmupSeconds * 20L);
+
+        activeWarmups.put(uuid, new WarmupState(startLoc, task.getTaskId()));
+        return true;
+    }
+
+    /**
+     * Check if a player moved during warmup and cancel if so.
+     * Called from PlayerMoveEvent listener.
+     * @return true if warmup was cancelled
+     */
+    public boolean checkWarmupMovement(Player player) {
+        UUID uuid = player.getUniqueId();
+        WarmupState state = activeWarmups.get(uuid);
+        if (state == null) return false;
+
+        Location current = player.getLocation();
+        Location start = state.startLocation;
+
+        // Check block-level movement (ignore head rotation)
+        if (current.getBlockX() != start.getBlockX() ||
+            current.getBlockY() != start.getBlockY() ||
+            current.getBlockZ() != start.getBlockZ()) {
+
+            cancelWarmup(uuid);
+            player.sendMessage("§c✖ Teleport cancelled — you moved!");
+            return true;
+        }
+        return false;
+    }
+
+    public boolean hasActiveWarmup(UUID playerUUID) {
+        return activeWarmups.containsKey(playerUUID);
+    }
+
+    public void cancelWarmup(UUID playerUUID) {
+        WarmupState state = activeWarmups.remove(playerUUID);
+        if (state != null) {
+            Bukkit.getScheduler().cancelTask(state.taskId);
+        }
+    }
+
+    // --- Cleanup ---
+
+    /**
+     * Clean up all data for a disconnecting player.
+     */
+    public void handlePlayerQuit(UUID playerUUID) {
+        cancelRequest(playerUUID);
+        cancelRequestByTarget(playerUUID);
+        cancelWarmup(playerUUID);
+        cooldowns.remove(playerUUID);
+    }
+
+    /**
+     * Cancel all pending tasks. Call on plugin disable.
+     */
+    public void shutdown() {
+        for (TpaRequest req : outboundRequests.values()) {
+            cancelExpiryTask(req);
+        }
+        for (WarmupState state : activeWarmups.values()) {
+            Bukkit.getScheduler().cancelTask(state.taskId);
+        }
+        outboundRequests.clear();
+        inboundRequests.clear();
+        activeWarmups.clear();
+        cooldowns.clear();
+    }
+
+    private void cancelExpiryTask(TpaRequest request) {
+        if (request.getExpiryTaskId() != -1) {
+            Bukkit.getScheduler().cancelTask(request.getExpiryTaskId());
+        }
+    }
+
+    private static class WarmupState {
+        final Location startLocation;
+        final int taskId;
+
+        WarmupState(Location startLocation, int taskId) {
+            this.startLocation = startLocation;
+            this.taskId = taskId;
+        }
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/Permission/LuckPermsGroupResolver.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/Permission/LuckPermsGroupResolver.java
@@ -1,0 +1,115 @@
+package org.fourz.rvnktools.permission;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.QueryOptions;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Shared utility for resolving LuckPerms groups for a player.
+ * Eliminates duplicate group-resolution logic across LinkCommand,
+ * LuckPermsIntegrationListener, and other consumers.
+ *
+ * @since 1.5.1
+ */
+public final class LuckPermsGroupResolver {
+
+    private LuckPermsGroupResolver() { }
+
+    /**
+     * Result of a group resolution: primary group + all inherited groups.
+     */
+    public record GroupResult(String primaryGroup, List<String> allGroups) { }
+
+    /**
+     * Resolves groups for an online player (fast path, no async load).
+     *
+     * @param player the online player
+     * @return group result with primary first in allGroups
+     */
+    public static GroupResult resolveGroups(Player player) {
+        LuckPerms lp = LuckPermsManager.getLuckPerms();
+        User user = lp.getPlayerAdapter(Player.class).getUser(player);
+        return extractGroups(user);
+    }
+
+    /**
+     * Resolves groups for a LuckPerms User that is already loaded.
+     *
+     * @param user the LuckPerms user
+     * @return group result with primary first in allGroups
+     */
+    public static GroupResult resolveGroups(User user) {
+        return extractGroups(user);
+    }
+
+    /**
+     * Loads and resolves groups for any player by UUID (async).
+     * Works for both online and offline players.
+     *
+     * @param uuid the player UUID
+     * @return future containing the group result
+     */
+    public static CompletableFuture<GroupResult> resolveGroupsAsync(UUID uuid) {
+        LuckPerms lp = LuckPermsManager.getLuckPerms();
+        return lp.getUserManager().loadUser(uuid)
+                .thenApply(LuckPermsGroupResolver::extractGroups);
+    }
+
+    /**
+     * Checks a list of permissions for a player by UUID (async).
+     * Uses {@link QueryOptions#nonContextual()} so inherited group permissions
+     * resolve correctly for offline players.
+     *
+     * @param uuid            the player UUID
+     * @param permissionNodes permission strings to check
+     * @return future containing a map of permission node to boolean result
+     */
+    public static CompletableFuture<Map<String, Boolean>> checkPermissionsAsync(
+            UUID uuid, List<String> permissionNodes) {
+        LuckPerms lp = LuckPermsManager.getLuckPerms();
+        return lp.getUserManager().loadUser(uuid)
+                .thenApply(user -> checkPermissions(user, permissionNodes));
+    }
+
+    /**
+     * Checks a list of permissions for an already-loaded LuckPerms user.
+     * Uses {@link QueryOptions#nonContextual()} so inherited group permissions
+     * resolve correctly regardless of online/offline state.
+     *
+     * @param user            the LuckPerms user
+     * @param permissionNodes permission strings to check
+     * @return map of permission node to boolean result (iteration order preserved)
+     */
+    public static Map<String, Boolean> checkPermissions(User user, List<String> permissionNodes) {
+        CachedPermissionData permData = user.getCachedData()
+                .getPermissionData(QueryOptions.nonContextual());
+        Map<String, Boolean> results = new LinkedHashMap<>();
+        for (String node : permissionNodes) {
+            results.put(node, permData.checkPermission(node).asBoolean());
+        }
+        return results;
+    }
+
+    private static GroupResult extractGroups(User user) {
+        String primaryGroup = user.getPrimaryGroup();
+        List<String> allGroups = new ArrayList<>();
+        allGroups.add(primaryGroup);
+
+        user.getInheritedGroups(user.getQueryOptions()).stream()
+                .map(Group::getName)
+                .filter(name -> !name.equals(primaryGroup))
+                .forEach(allGroups::add);
+
+        return new GroupResult(primaryGroup, allGroups);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceConfig.java
@@ -187,6 +187,10 @@ public class AnnounceConfig {
             announceType.setListingFee(listingFee);
         }
         announceType.setPermission(permission);
+        String displayContext = (String) map.get("display_context");
+        if (displayContext != null) {
+            announceType.setDisplayContext(displayContext);
+        }
         return announceType;
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -34,6 +34,7 @@ public class AnnounceManager {
     private final Map<String, Announcement> announcements = new ConcurrentHashMap<>();
     private boolean usingPlaceholderAPI;
     private AnnouncementService announcementService;
+    private AnnouncementFeeCollector feeCollector;
 
     public AnnounceManager(RVNKCore plugin) {
         this.logger = LogManager.getInstance(plugin, getClass());
@@ -52,6 +53,35 @@ public class AnnounceManager {
 
         this.announceScheduler = new AnnounceScheduler(plugin, this);
         announceScheduler.scheduleAnnouncements();
+
+        // Initialize weekly fee collector if Vault economy is available
+        initializeFeeCollector();
+    }
+
+    private void initializeFeeCollector() {
+        try {
+            org.bukkit.plugin.RegisteredServiceProvider<net.milkbowl.vault.economy.Economy> rsp =
+                plugin.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
+            if (rsp == null) {
+                logger.info("Vault economy not found — fee collector disabled");
+                return;
+            }
+            net.milkbowl.vault.economy.Economy economy = rsp.getProvider();
+            this.feeCollector = new AnnouncementFeeCollector(announcementService, economy, logger);
+
+            // Run weekly: 20 ticks/sec * 60 * 60 * 24 * 7 = 12,096,000 ticks
+            // Initial delay: 5 minutes (6000 ticks) to let server stabilize
+            long weeklyTicks = 20L * 60 * 60 * 24 * 7;
+            feeCollector.runTaskTimerAsynchronously(plugin, 6000L, weeklyTicks);
+
+            // Register login listener for payment notifications
+            AnnouncementFeeLoginListener loginListener = new AnnouncementFeeLoginListener(feeCollector, logger);
+            plugin.getServer().getPluginManager().registerEvents(loginListener, plugin);
+
+            logger.info("AnnouncementFeeCollector initialized (weekly cycle, Vault economy)");
+        } catch (Exception e) {
+            logger.warning("Failed to initialize fee collector: " + e.getMessage());
+        }
     }
 
     private void resolveAnnouncementService() {
@@ -206,7 +236,24 @@ public class AnnounceManager {
                 return false;
             }
             player.sendMessage("Announcement added: " + id + " (" + type + ")");
-            return announceConfig.parseAnnouncement(id, type, text, player.getName());
+            boolean result = announceConfig.parseAnnouncement(id, type, text, player.getName());
+            // Set ownerUuid on the newly created announcement
+            if (result) {
+                Announcement ann = announcements.get(id.toLowerCase());
+                if (ann != null) {
+                    ann.setOwnerUuid(player.getUniqueId().toString());
+                    // Persist ownerUuid to DB
+                    if (announcementService != null) {
+                        try {
+                            AnnouncementDTO dto = convertToDTO(ann);
+                            announcementService.updateAnnouncement(dto).join();
+                        } catch (Exception e) {
+                            logger.warning("Failed to persist ownerUuid for announcement: " + id);
+                        }
+                    }
+                }
+            }
+            return result;
         }
 
         return announceConfig.parseAnnouncement(id, type, text);
@@ -342,6 +389,14 @@ public class AnnounceManager {
 
     public void shutdown() {
         announceScheduler.shutdown();
+        if (feeCollector != null) {
+            try {
+                feeCollector.cancel();
+                logger.info("AnnouncementFeeCollector cancelled");
+            } catch (Exception e) {
+                logger.debug("Fee collector already cancelled");
+            }
+        }
         logger.info("Saving preferences before shutdown...");
         announceConfig.shutdown();
         logger.info("AnnounceManager shutdown complete.");
@@ -524,6 +579,7 @@ public class AnnounceManager {
             updatedAnnouncement.setMessage(newMessage);
             updatedAnnouncement.setPermission(oldAnnouncement.getPermission());
             updatedAnnouncement.setOwner(oldAnnouncement.getOwner());
+            updatedAnnouncement.setOwnerUuid(oldAnnouncement.getOwnerUuid());
             updatedAnnouncement.setDate(oldAnnouncement.getDate());
             updatedAnnouncement.setTime(oldAnnouncement.getTime());
             updatedAnnouncement.setExpiration(oldAnnouncement.getExpiration());
@@ -573,6 +629,11 @@ public class AnnounceManager {
             ann.setExpiration(dto.getExpiresAt().toLocalDateTime());
         }
 
+        // Set ownerUuid from first-class column
+        if (dto.getOwnerUuid() != null) {
+            ann.setOwnerUuid(dto.getOwnerUuid());
+        }
+
         Map<String, Object> metadata = dto.getMetadata();
         if (metadata != null) {
             Object permission = metadata.get("permission");
@@ -606,6 +667,10 @@ public class AnnounceManager {
 
         if (ann.getExpiration() != null) {
             builder.expiresAt(Timestamp.valueOf(ann.getExpiration()));
+        }
+
+        if (ann.getOwnerUuid() != null) {
+            builder.ownerUuid(ann.getOwnerUuid());
         }
 
         if (ann.getPermission() != null) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceManager.java
@@ -278,6 +278,10 @@ public class AnnounceManager {
             return;
         }
 
+        if ("webonly".equals(type.getDisplayContext())) {
+            return; // webonly types are not broadcast in-game
+        }
+
         String prefix = type.getPrefix() != null ? type.getPrefix() : "";
         String suffix = type.getSuffix() != null ? type.getSuffix() : "";
         String message = prefix + announcement.getMessage() + suffix;
@@ -737,6 +741,7 @@ public class AnnounceManager {
                 .prefix(type.getPrefix())
                 .suffix(type.getSuffix())
                 .permission(type.getPermission())
+                .displayContext(type.getDisplayContext())
                 .listFee(listFee)
                 .weeklyFee(0)
                 .active(true)

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceType.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnounceType.java
@@ -6,6 +6,7 @@ public class AnnounceType {
     private String suffix;
     private String permission;
     private Double listingFee;
+    private String displayContext = "both";
     private boolean imported = false;
 
     // Getters and setters
@@ -47,6 +48,14 @@ public class AnnounceType {
 
     public void setListingFee(Double listingFee) {
         this.listingFee = listingFee;
+    }
+
+    public String getDisplayContext() {
+        return displayContext;
+    }
+
+    public void setDisplayContext(String displayContext) {
+        this.displayContext = displayContext;
     }
 
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/Announcement.java
@@ -13,6 +13,7 @@ public class Announcement {
     private Long recurrence;
     private String recurrenceString;
     private String owner;
+    private String ownerUuid;
     private String permission;
     private LocalDate date;
     private LocalTime time;
@@ -79,6 +80,12 @@ public class Announcement {
     }
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+    public String getOwnerUuid() {
+        return ownerUuid;
+    }
+    public void setOwnerUuid(String ownerUuid) {
+        this.ownerUuid = ownerUuid;
     }
     public String getPermission() {
         return permission;

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncementFeeCollector.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncementFeeCollector.java
@@ -1,0 +1,142 @@
+package org.fourz.rvnktools.announceManager;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.fourz.rvnkcore.api.model.AnnouncementDTO;
+import org.fourz.rvnkcore.api.model.AnnouncementTypeDTO;
+import org.fourz.rvnkcore.api.service.AnnouncementService;
+import org.fourz.rvnkcore.service.announcement.DefaultAnnouncementService;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Collects weekly fees for active announcements with weeklyFee > 0.
+ * Deactivates announcements when the owner's balance is depleted,
+ * setting deactivation_reason=payment_depleted in metadata.
+ *
+ * @since 1.5.0
+ */
+public class AnnouncementFeeCollector extends BukkitRunnable {
+
+    private final AnnouncementService announcementService;
+    private final Economy economy;
+    private final LogManager logger;
+
+    /** Tracks UUIDs whose announcements were deactivated for payment — cleared on next login */
+    private final ConcurrentHashMap<UUID, List<String>> pendingNotifications = new ConcurrentHashMap<>();
+
+    /** Type ID → weeklyFee cache, refreshed each cycle */
+    private final ConcurrentHashMap<String, Integer> typeFeeCache = new ConcurrentHashMap<>();
+
+    public AnnouncementFeeCollector(AnnouncementService announcementService, Economy economy, LogManager logger) {
+        this.announcementService = announcementService;
+        this.economy = economy;
+        this.logger = logger;
+    }
+
+    @Override
+    public void run() {
+        try {
+            collectFees();
+        } catch (Exception e) {
+            logger.error("AnnouncementFeeCollector cycle failed", e);
+        }
+    }
+
+    private void collectFees() {
+        // Refresh type fee cache
+        try {
+            List<AnnouncementTypeDTO> types = announcementService.getAnnouncementTypes().get(15, TimeUnit.SECONDS);
+            typeFeeCache.clear();
+            for (AnnouncementTypeDTO type : types) {
+                if (type.getWeeklyFee() != null && type.getWeeklyFee() > 0) {
+                    typeFeeCache.put(type.getId(), type.getWeeklyFee());
+                }
+            }
+        } catch (Exception e) {
+            logger.warning("Failed to refresh type fee cache: " + e.getMessage());
+            return;
+        }
+
+        if (typeFeeCache.isEmpty()) {
+            logger.debug("AnnouncementFeeCollector: no types with weekly fees, skipping cycle");
+            return;
+        }
+
+        try {
+            List<AnnouncementDTO> all = announcementService.getAllAnnouncements().get(15, TimeUnit.SECONDS);
+            int checked = 0;
+            int collected = 0;
+            int deactivated = 0;
+
+            for (AnnouncementDTO ann : all) {
+                if (!ann.isActive()) continue;
+                if (ann.getOwnerUuid() == null) continue;
+
+                Integer weeklyFee = typeFeeCache.get(ann.getType());
+                if (weeklyFee == null || weeklyFee <= 0) continue;
+
+                checked++;
+                UUID ownerUuid = UUID.fromString(ann.getOwnerUuid());
+                OfflinePlayer owner = Bukkit.getOfflinePlayer(ownerUuid);
+
+                if (economy.has(owner, weeklyFee)) {
+                    economy.withdrawPlayer(owner, weeklyFee);
+                    collected++;
+                    logger.debug("Collected " + weeklyFee + " fee for announcement " + ann.getId() +
+                        " from " + ann.getOwnerUuid());
+                } else {
+                    // Deactivate for payment
+                    deactivateForPayment(ann);
+                    deactivated++;
+
+                    // Track for login notification
+                    pendingNotifications.computeIfAbsent(ownerUuid, k -> new java.util.ArrayList<>())
+                        .add(ann.getId());
+                }
+            }
+
+            logger.info("AnnouncementFeeCollector: checked " + checked + " announcements, " +
+                "collected " + collected + " fees, deactivated " + deactivated + " for payment");
+
+        } catch (Exception e) {
+            logger.error("Fee collection cycle failed", e);
+        }
+    }
+
+    private void deactivateForPayment(AnnouncementDTO ann) {
+        try {
+            announcementService.deactivateAnnouncement(ann.getId()).get(15, TimeUnit.SECONDS);
+            announcementService.updateAnnouncementMetadata(ann.getId(), "deactivation_reason", "payment_depleted")
+                .get(15, TimeUnit.SECONDS);
+            logger.info("Deactivated announcement " + ann.getId() + " for payment (owner: " + ann.getOwnerUuid() + ")");
+        } catch (Exception e) {
+            logger.error("Failed to deactivate announcement " + ann.getId() + " for payment", e);
+        }
+    }
+
+    /**
+     * Gets and clears pending payment-deactivation notifications for a player.
+     *
+     * @param uuid The player UUID
+     * @return List of deactivated announcement IDs, or empty list
+     */
+    public List<String> getAndClearNotifications(UUID uuid) {
+        List<String> ids = pendingNotifications.remove(uuid);
+        return ids != null ? ids : List.of();
+    }
+
+    /**
+     * Checks if a player has pending payment deactivation notifications.
+     */
+    public boolean hasPendingNotifications(UUID uuid) {
+        return pendingNotifications.containsKey(uuid);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncementFeeLoginListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/announceManager/AnnouncementFeeLoginListener.java
@@ -1,0 +1,49 @@
+package org.fourz.rvnktools.announceManager;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.util.List;
+
+/**
+ * Notifies players on login if any of their announcements were deactivated
+ * due to insufficient funds for weekly fee payment.
+ *
+ * @since 1.5.0
+ */
+public class AnnouncementFeeLoginListener implements Listener {
+
+    private final AnnouncementFeeCollector feeCollector;
+    private final LogManager logger;
+
+    public AnnouncementFeeLoginListener(AnnouncementFeeCollector feeCollector, LogManager logger) {
+        this.feeCollector = feeCollector;
+        this.logger = logger;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (!feeCollector.hasPendingNotifications(player.getUniqueId())) {
+            return;
+        }
+
+        // Delay message slightly so it appears after join messages
+        player.getServer().getScheduler().runTaskLater(
+            player.getServer().getPluginManager().getPlugins()[0], // RVNKCore is always first
+            () -> {
+                List<String> deactivatedIds = feeCollector.getAndClearNotifications(player.getUniqueId());
+                if (deactivatedIds.isEmpty()) return;
+
+                player.sendMessage("§6[Announcements] §c" + deactivatedIds.size() +
+                    " of your announcement(s) were deactivated due to insufficient funds.");
+                player.sendMessage("§6[Announcements] §7IDs: " + String.join(", ", deactivatedIds));
+                player.sendMessage("§6[Announcements] §7Deposit funds and re-activate them to resume.");
+            },
+            60L // 3 seconds delay
+        );
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/CommandManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/CommandManager.java
@@ -11,10 +11,19 @@ import org.fourz.rvnktools.command.manager.commands.PingCommand;
 import org.fourz.rvnktools.command.manager.commands.PlayerServiceTestCommand;
 import org.fourz.rvnktools.command.manager.commands.PutHatCommand;
 import org.fourz.rvnktools.command.manager.commands.RVNKCoreCommand;
+import org.fourz.rvnktools.command.manager.commands.BackCommand;
 import org.fourz.rvnktools.command.manager.commands.TeleportCommand;
+import org.fourz.rvnktools.command.manager.commands.TpaCommand;
+import org.fourz.rvnktools.command.manager.commands.TpAcceptCommand;
+import org.fourz.rvnktools.command.manager.commands.TpDenyCommand;
 import org.fourz.rvnktools.command.manager.commands.TrainsCommand;
 import org.fourz.rvnktools.command.manager.commands.WorldSwapCommand;
 import org.fourz.rvnktools.command.manager.commands.WorldSwapSubCommand;
+import org.fourz.rvnkcore.service.teleport.BackLocationService;
+import org.fourz.rvnkcore.service.teleport.DefaultBackLocationService;
+import org.fourz.rvnkcore.service.teleport.TpaRequest;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+import org.fourz.rvnktools.listener.TpaListener;
 import org.fourz.rvnktools.link.LinkCommand;
 import org.fourz.rvnktools.logfilter.LogFilterCommand;
 import org.fourz.rvnkcore.util.log.LogManager;
@@ -99,6 +108,9 @@ public class CommandManager {
         // Register link command (magic link auth)
         registerLinkCommand();
 
+        // Register TPA commands (if enabled)
+        registerTpaCommands();
+
         // Register cycle commands
         cycleCommands.registerCommands();
 
@@ -122,6 +134,49 @@ public class CommandManager {
         } catch (Exception e) {
             logger.warning("Failed to register /link command: " + e.getMessage());
         }
+    }
+
+    /**
+     * Registers TPA commands if the feature is enabled in config.
+     * Creates TpaRequestService and BackLocationService, registers the listener,
+     * and registers all 5 commands: /tpa, /tpahere, /tpaccept, /tpdeny, /back.
+     */
+    private void registerTpaCommands() {
+        boolean enabled = plugin.getConfig().getBoolean("features.tpa-commands", true);
+        if (!enabled) {
+            logger.info("TPA commands disabled in config");
+            return;
+        }
+
+        // Create services
+        TpaRequestService tpaService = new TpaRequestService(plugin);
+        tpaService.setRequestExpireSeconds(plugin.getConfig().getInt("teleport.request-expire-seconds", 60));
+        tpaService.setWarmupSeconds(plugin.getConfig().getInt("teleport.warmup-seconds", 3));
+        tpaService.setCooldownSeconds(plugin.getConfig().getInt("teleport.cooldown-seconds", 10));
+
+        BackLocationService backService = new DefaultBackLocationService();
+
+        // Register services with ServiceRegistry
+        ServiceRegistry registry = plugin.getServiceRegistry();
+        registry.registerService(TpaRequestService.class, tpaService);
+        registry.registerService(BackLocationService.class, backService);
+
+        // Register listener for warmup movement cancellation + player quit cleanup
+        plugin.getServer().getPluginManager().registerEvents(
+            new TpaListener(tpaService, backService), plugin);
+
+        // Register commands
+        registerCommand(new TpaCommand(plugin, tpaService,
+            "tpa", "Request to teleport to another player", "/tpa <player>",
+            TpaRequest.Type.TPA));
+        registerCommand(new TpaCommand(plugin, tpaService,
+            "tpahere", "Request another player teleport to you", "/tpahere <player>",
+            TpaRequest.Type.TPAHERE));
+        registerCommand(new TpAcceptCommand(plugin, tpaService, backService));
+        registerCommand(new TpDenyCommand(plugin, tpaService));
+        registerCommand(new BackCommand(plugin, tpaService, backService));
+
+        logger.info("TPA commands registered: /tpa, /tpahere, /tpaccept, /tpdeny, /back");
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/BackCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/BackCommand.java
@@ -1,0 +1,122 @@
+package org.fourz.rvnktools.command.manager.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.service.ITeleportService;
+import org.fourz.rvnkcore.service.registry.ServiceRegistry;
+import org.fourz.rvnkcore.service.teleport.BackLocationService;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+import org.fourz.rvnkcore.util.ChatFormat;
+import org.fourz.rvnktools.command.manager.BaseCommand;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * /back — Teleport to your previous location (before last teleport).
+ * Supports back-and-forth: current location becomes new back location.
+ * Console: /back &lt;player&gt; to teleport a named player back.
+ */
+public class BackCommand extends BaseCommand {
+
+    private final TpaRequestService tpaService;
+    private final BackLocationService backService;
+
+    public BackCommand(RVNKCore plugin, TpaRequestService tpaService, BackLocationService backService) {
+        super(plugin, "back", "Teleport to your previous location", "/back");
+        this.tpaService = tpaService;
+        this.backService = backService;
+    }
+
+    @Override
+    protected boolean executeCommand(CommandSender sender, String[] args) {
+        Player player;
+
+        // Console support: /back <player>
+        if (!(sender instanceof Player)) {
+            if (args.length < 1) {
+                sender.sendMessage("Usage: /back <player>");
+                return true;
+            }
+            player = Bukkit.getPlayer(args[0]);
+            if (player == null || !player.isOnline()) {
+                sender.sendMessage("Player '" + args[0] + "' is not online.");
+                return true;
+            }
+        } else {
+            player = (Player) sender;
+        }
+
+        Optional<Location> optBack = backService.getBackLocation(player.getUniqueId());
+        if (optBack.isEmpty()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ No previous location to return to."));
+            return true;
+        }
+
+        Location backLoc = optBack.get();
+
+        // Check cooldown (uses same system as TPA)
+        if (sender instanceof Player && tpaService.isOnCooldown(player)) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ You must wait before using /back again."));
+            return true;
+        }
+
+        // Store current location as new back location (enables back-and-forth)
+        backService.setBackLocation(player.getUniqueId(), player.getLocation());
+
+        // Execute with warmup
+        tpaService.startWarmup(player, () -> {
+            ServiceRegistry registry = plugin.getServiceRegistry();
+            if (registry.hasService(ITeleportService.class)) {
+                ITeleportService teleportService = registry.getService(ITeleportService.class);
+                // Use teleportToPlayer approach for cross-world support
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    player.teleport(backLoc);
+                    player.sendMessage(ChatFormat.colorize("&a✓ Teleported to your previous location."));
+                });
+            } else {
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    player.teleport(backLoc);
+                    player.sendMessage(ChatFormat.colorize("&a✓ Teleported to your previous location."));
+                });
+            }
+        });
+
+        if (sender != player) {
+            sender.sendMessage("Teleporting " + player.getName() + " to their previous location.");
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) {
+            sendNoPermissionMessage(sender);
+            return true;
+        }
+        return executeCommand(sender, args);
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) return Collections.emptyList();
+        // Console: tab complete player names
+        if (!(sender instanceof Player) && args.length == 1) {
+            String partial = args[0].toLowerCase();
+            List<String> matches = new ArrayList<>();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    matches.add(p.getName());
+                }
+            }
+            return matches;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpAcceptCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpAcceptCommand.java
@@ -1,0 +1,119 @@
+package org.fourz.rvnktools.command.manager.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.service.ITeleportService;
+import org.fourz.rvnkcore.service.registry.ServiceRegistry;
+import org.fourz.rvnkcore.service.teleport.BackLocationService;
+import org.fourz.rvnkcore.service.teleport.TpaRequest;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+import org.fourz.rvnkcore.util.ChatFormat;
+import org.fourz.rvnktools.command.manager.BaseCommand;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * /tpaccept — Accept a pending teleport request.
+ */
+public class TpAcceptCommand extends BaseCommand {
+
+    private final TpaRequestService tpaService;
+    private final BackLocationService backService;
+
+    public TpAcceptCommand(RVNKCore plugin, TpaRequestService tpaService, BackLocationService backService) {
+        super(plugin, "tpaccept", "Accept a pending teleport request", "/tpaccept");
+        this.tpaService = tpaService;
+        this.backService = backService;
+    }
+
+    @Override
+    protected boolean executeCommand(CommandSender sender, String[] args) {
+        if (!validatePlayer(sender)) return true;
+
+        Player player = (Player) sender;
+        Optional<TpaRequest> optRequest = tpaService.acceptRequest(player.getUniqueId());
+
+        if (optRequest.isEmpty()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ You have no pending teleport requests."));
+            return true;
+        }
+
+        TpaRequest request = optRequest.get();
+        Player senderPlayer = Bukkit.getPlayer(request.getSender());
+        Player targetPlayer = Bukkit.getPlayer(request.getTarget());
+
+        if (senderPlayer == null || !senderPlayer.isOnline() ||
+            targetPlayer == null || !targetPlayer.isOnline()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ The other player is no longer online."));
+            return true;
+        }
+
+        // Determine who teleports where
+        Player teleporting;
+        Player destination;
+        if (request.getType() == TpaRequest.Type.TPA) {
+            // TPA: sender teleports to target (the acceptor)
+            teleporting = senderPlayer;
+            destination = targetPlayer;
+        } else {
+            // TPAHERE: target (the acceptor) teleports to sender
+            teleporting = targetPlayer;
+            destination = senderPlayer;
+        }
+
+        // Store back location before teleporting
+        backService.setBackLocation(teleporting.getUniqueId(), teleporting.getLocation());
+
+        // Execute teleport with warmup
+        tpaService.startWarmup(teleporting, () -> {
+            // Use ITeleportService for the actual teleport (gets RVNKWorlds handling if available)
+            ServiceRegistry registry = plugin.getServiceRegistry();
+            if (registry.hasService(ITeleportService.class)) {
+                ITeleportService teleportService = registry.getService(ITeleportService.class);
+                teleportService.teleportToPlayer(teleporting, destination).thenAccept(success -> {
+                    if (success) {
+                        teleporting.sendMessage(ChatFormat.colorize("&a✓ Teleported to &f" + destination.getName()));
+                        destination.sendMessage(ChatFormat.colorize("&a✓ &f" + teleporting.getName() + " &ateleported to you."));
+                    } else {
+                        teleporting.sendMessage(ChatFormat.colorize("&c✖ Teleport failed."));
+                    }
+                });
+            } else {
+                // Fallback: direct Bukkit teleport
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    teleporting.teleport(destination.getLocation());
+                    teleporting.sendMessage(ChatFormat.colorize("&a✓ Teleported to &f" + destination.getName()));
+                    destination.sendMessage(ChatFormat.colorize("&a✓ &f" + teleporting.getName() + " &ateleported to you."));
+                });
+            }
+        });
+
+        // Notify both players
+        if (tpaService.getWarmupSeconds() > 0 && !teleporting.hasPermission(TpaRequestService.BYPASS_WARMUP_PERM)) {
+            destination.sendMessage(ChatFormat.colorize("&a✓ Teleport request accepted. &f" +
+                teleporting.getName() + " &ais warming up..."));
+        } else {
+            player.sendMessage(ChatFormat.colorize("&a✓ Teleport request accepted."));
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) {
+            sendNoPermissionMessage(sender);
+            return true;
+        }
+        return executeCommand(sender, args);
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpDenyCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpDenyCommand.java
@@ -1,0 +1,65 @@
+package org.fourz.rvnktools.command.manager.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.service.teleport.TpaRequest;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+import org.fourz.rvnkcore.util.ChatFormat;
+import org.fourz.rvnktools.command.manager.BaseCommand;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * /tpdeny — Deny a pending teleport request.
+ */
+public class TpDenyCommand extends BaseCommand {
+
+    private final TpaRequestService tpaService;
+
+    public TpDenyCommand(RVNKCore plugin, TpaRequestService tpaService) {
+        super(plugin, "tpdeny", "Deny a pending teleport request", "/tpdeny");
+        this.tpaService = tpaService;
+    }
+
+    @Override
+    protected boolean executeCommand(CommandSender sender, String[] args) {
+        if (!validatePlayer(sender)) return true;
+
+        Player player = (Player) sender;
+        Optional<TpaRequest> optRequest = tpaService.denyRequest(player.getUniqueId());
+
+        if (optRequest.isEmpty()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ You have no pending teleport requests."));
+            return true;
+        }
+
+        TpaRequest request = optRequest.get();
+        Player requester = Bukkit.getPlayer(request.getSender());
+
+        sender.sendMessage(ChatFormat.colorize("&c✖ Teleport request denied."));
+
+        if (requester != null && requester.isOnline()) {
+            requester.sendMessage(ChatFormat.colorize("&c✖ &f" + player.getName() + " &cdenied your teleport request."));
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) {
+            sendNoPermissionMessage(sender);
+            return true;
+        }
+        return executeCommand(sender, args);
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpaCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TpaCommand.java
@@ -1,0 +1,105 @@
+package org.fourz.rvnktools.command.manager.commands;
+
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.service.teleport.TpaRequest;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+import org.fourz.rvnkcore.util.ChatFormat;
+import org.fourz.rvnktools.command.manager.BaseCommand;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * /tpa &lt;player&gt; — Request to teleport to another player.
+ * Cross-world supported; uses ITeleportService (gets RVNKWorlds handling if available).
+ */
+public class TpaCommand extends BaseCommand {
+
+    private final TpaRequestService tpaService;
+    private final TpaRequest.Type requestType;
+
+    /**
+     * @param requestType TPA (sender goes to target) or TPAHERE (target comes to sender)
+     */
+    public TpaCommand(RVNKCore plugin, TpaRequestService tpaService,
+                      String name, String description, String usage,
+                      TpaRequest.Type requestType) {
+        super(plugin, name, description, usage);
+        this.tpaService = tpaService;
+        this.requestType = requestType;
+    }
+
+    @Override
+    protected boolean executeCommand(CommandSender sender, String[] args) {
+        if (!validatePlayer(sender)) return true;
+        if (!validateArgs(sender, args, 1, "§c▶ Usage: §e/" + getName() + " <player>")) return true;
+
+        Player player = (Player) sender;
+        Player target = Bukkit.getPlayer(args[0]);
+
+        if (target == null || !target.isOnline()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ Player '" + args[0] + "' is not online."));
+            return true;
+        }
+
+        Optional<String> error = tpaService.sendRequest(player, target, requestType);
+        if (error.isPresent()) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ " + error.get()));
+            return true;
+        }
+
+        // Notify sender
+        sender.sendMessage(ChatFormat.colorize("&a✓ Teleport request sent to &f" + target.getName()));
+
+        // Notify target with clickable accept/deny
+        String label = requestType == TpaRequest.Type.TPA
+            ? player.getName() + " wants to teleport to you."
+            : player.getName() + " wants you to teleport to them.";
+
+        target.sendMessage(ChatFormat.colorize("&e⚠ " + label));
+
+        TextComponent accept = new TextComponent(ChatFormat.colorize("&a&l[Accept]"));
+        accept.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tpaccept"));
+
+        TextComponent space = new TextComponent("  ");
+
+        TextComponent deny = new TextComponent(ChatFormat.colorize("&c&l[Deny]"));
+        deny.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tpdeny"));
+
+        target.spigot().sendMessage(accept, space, deny);
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) return Collections.emptyList();
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            List<String> matches = new ArrayList<>();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial) && !p.equals(sender)) {
+                    matches.add(p.getName());
+                }
+            }
+            return matches;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!hasPermission(sender)) {
+            sendNoPermissionMessage(sender);
+            return true;
+        }
+        return executeCommand(sender, args);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/link/LinkCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/link/LinkCommand.java
@@ -1,7 +1,5 @@
 package org.fourz.rvnktools.link;
 
-import net.luckperms.api.LuckPerms;
-import net.luckperms.api.model.user.User;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
@@ -12,9 +10,8 @@ import org.fourz.rvnkcore.RVNKCore;
 import org.fourz.rvnkcore.api.auth.AuthTokenStore;
 import org.fourz.rvnkcore.util.ChatFormat;
 import org.fourz.rvnktools.command.manager.BaseCommand;
-import org.fourz.rvnktools.permission.LuckPermsManager;
+import org.fourz.rvnktools.permission.LuckPermsGroupResolver;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -147,19 +144,7 @@ public class LinkCommand extends BaseCommand {
      */
     private List<String> resolveGroups(Player player) {
         try {
-            LuckPerms lp = LuckPermsManager.getLuckPerms();
-            User user = lp.getPlayerAdapter(Player.class).getUser(player);
-            String primaryGroup = user.getPrimaryGroup();
-
-            List<String> groups = new ArrayList<>();
-            groups.add(primaryGroup);
-
-            user.getInheritedGroups(user.getQueryOptions()).stream()
-                    .map(g -> g.getName())
-                    .filter(name -> !name.equals(primaryGroup))
-                    .forEach(groups::add);
-
-            return groups;
+            return LuckPermsGroupResolver.resolveGroups(player).allGroups();
         } catch (Exception e) {
             logger.warning("Failed to resolve LuckPerms groups for " + player.getName() + ": " + e.getMessage());
             return List.of("default");
@@ -172,19 +157,7 @@ public class LinkCommand extends BaseCommand {
      */
     private List<String> resolveGroupsByUuid(UUID uuid, String playerName) {
         try {
-            LuckPerms lp = LuckPermsManager.getLuckPerms();
-            User user = lp.getUserManager().loadUser(uuid).join();
-            String primaryGroup = user.getPrimaryGroup();
-
-            List<String> groups = new ArrayList<>();
-            groups.add(primaryGroup);
-
-            user.getInheritedGroups(user.getQueryOptions()).stream()
-                    .map(g -> g.getName())
-                    .filter(name -> !name.equals(primaryGroup))
-                    .forEach(groups::add);
-
-            return groups;
+            return LuckPermsGroupResolver.resolveGroupsAsync(uuid).join().allGroups();
         } catch (Exception e) {
             logger.warning("Failed to resolve LuckPerms groups for " + playerName + ": " + e.getMessage());
             return List.of("default");

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/listener/LuckPermsIntegrationListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/listener/LuckPermsIntegrationListener.java
@@ -3,12 +3,12 @@ package org.fourz.rvnktools.listener;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.event.EventBus;
 import net.luckperms.api.event.EventSubscription;
-import net.luckperms.api.event.group.GroupDataRecalculateEvent;
 import net.luckperms.api.event.user.UserDataRecalculateEvent;
-import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
 import org.fourz.rvnkcore.RVNKCore;
 import org.fourz.rvnkcore.api.service.PlayerService;
+import org.fourz.rvnktools.permission.LuckPermsGroupResolver;
+import org.fourz.rvnktools.permission.LuckPermsGroupResolver.GroupResult;
 import org.fourz.rvnktools.permission.LuckPermsManager;
 import org.fourz.rvnkcore.util.log.LogManager;
 import org.bukkit.plugin.Plugin;
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * Listens to LuckPerms events and updates player data in RVNKCore.
@@ -60,14 +59,8 @@ public class LuckPermsIntegrationListener {
      * Registers event listeners with the LuckPerms event bus.
      */
     private void registerEventListeners() {
-        // Listen for user data recalculation events (includes group changes)
         subscriptions.add(
             eventBus.subscribe(UserDataRecalculateEvent.class, this::onUserDataRecalculate)
-        );
-
-        // Listen for group data recalculation events (for debugging/monitoring)
-        subscriptions.add(
-            eventBus.subscribe(GroupDataRecalculateEvent.class, this::onGroupDataRecalculate)
         );
 
         logger.debug("Registered LuckPerms event listeners");
@@ -96,18 +89,12 @@ public class LuckPermsIntegrationListener {
                         return CompletableFuture.completedFuture(null);
                     }
                     
-                    // Get updated groups from LuckPerms
-                    String primaryGroup = user.getPrimaryGroup();
-                    List<String> allGroups = user.getInheritedGroups(user.getQueryOptions())
-                        .stream()
-                        .map(Group::getName)
-                        .collect(Collectors.toList());
-                    
-                    logger.debug("Updating groups for " + user.getFriendlyName() + 
-                               ": primary=" + primaryGroup + ", all=" + allGroups);
-                    
-                    // Update in RVNKCore
-                    return playerService.updatePlayerGroups(playerId, primaryGroup, allGroups);
+                    GroupResult groups = LuckPermsGroupResolver.resolveGroups(user);
+
+                    logger.debug("Updating groups for " + user.getFriendlyName() +
+                               ": primary=" + groups.primaryGroup() + ", all=" + groups.allGroups());
+
+                    return playerService.updatePlayerGroups(playerId, groups.primaryGroup(), groups.allGroups());
                 })
                 .thenRun(() -> {
                     logger.debug("Successfully updated groups for " + user.getFriendlyName());
@@ -123,40 +110,18 @@ public class LuckPermsIntegrationListener {
     }
     
     /**
-     * Handles group data recalculation events for monitoring purposes.
-     * 
-     * @param event The group data recalculate event
-     */
-    private void onGroupDataRecalculate(GroupDataRecalculateEvent event) {
-        Group group = event.getGroup();
-        logger.debug("LuckPerms group data recalculated: " + group.getName());
-    }
-    
-    /**
      * Manually updates player groups for a specific player.
      * This can be called when needed to ensure synchronization.
-     * 
+     *
      * @param playerId The UUID of the player
      * @return CompletableFuture that completes when update is finished
      */
     public CompletableFuture<Void> updatePlayerGroups(UUID playerId) {
-        return luckPerms.getUserManager().loadUser(playerId)
-            .thenCompose(user -> {
-                if (user == null) {
-                    logger.warning("User not found in LuckPerms: " + playerId);
-                    return CompletableFuture.completedFuture(null);
-                }
-                
+        return LuckPermsGroupResolver.resolveGroupsAsync(playerId)
+            .thenCompose(groups -> {
                 try {
                     PlayerService playerService = rvnkCore.getService(PlayerService.class);
-                    
-                    String primaryGroup = user.getPrimaryGroup();
-                    List<String> allGroups = user.getInheritedGroups(user.getQueryOptions())
-                        .stream()
-                        .map(Group::getName)
-                        .collect(Collectors.toList());
-                    
-                    return playerService.updatePlayerGroups(playerId, primaryGroup, allGroups);
+                    return playerService.updatePlayerGroups(playerId, groups.primaryGroup(), groups.allGroups());
                 } catch (Exception e) {
                     CompletableFuture<Void> future = new CompletableFuture<>();
                     future.completeExceptionally(e);

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/listener/TpaListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/listener/TpaListener.java
@@ -1,0 +1,40 @@
+package org.fourz.rvnktools.listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.fourz.rvnkcore.service.teleport.BackLocationService;
+import org.fourz.rvnkcore.service.teleport.DefaultBackLocationService;
+import org.fourz.rvnkcore.service.teleport.TpaRequestService;
+
+/**
+ * Listener for TPA warmup cancellation on movement and cleanup on quit.
+ */
+public class TpaListener implements Listener {
+
+    private final TpaRequestService tpaService;
+    private final BackLocationService backService;
+
+    public TpaListener(TpaRequestService tpaService, BackLocationService backService) {
+        this.tpaService = tpaService;
+        this.backService = backService;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (tpaService.hasActiveWarmup(event.getPlayer().getUniqueId())) {
+            tpaService.checkWarmupMovement(event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        java.util.UUID uuid = event.getPlayer().getUniqueId();
+        tpaService.handlePlayerQuit(uuid);
+        if (backService instanceof DefaultBackLocationService) {
+            ((DefaultBackLocationService) backService).handlePlayerQuit(uuid);
+        }
+    }
+}

--- a/toolkitplugin/src/main/resources/announcements.yml
+++ b/toolkitplugin/src/main/resources/announcements.yml
@@ -3,16 +3,22 @@ announce_types:
   prefix: '&a[News] &7'
   suffix: '&7'
   permission: rvnktools.announce.type.news
+- id: event
+  prefix: '&9[Event] &7'
+  suffix: '&7'
+  permission: rvnktools.announce.type.event
 - id: help
   prefix: '&b[Help] &7'
   suffix: '&7'
   permission: rvnktools.announce.type.help
+  display_context: ingame
 - id: advert
   prefix: '&d[Advert] &f'
   suffix: '&7'
   list_fee: 4
   weekly_fee: 10
   permission: rvnktools.announce.type.advert
+  display_context: ingame
 - id: scheduled
   prefix: '&a[!!] &7'
   suffix: ' &a[!!]'
@@ -21,14 +27,27 @@ announce_types:
   prefix: '&c[Server] &f'
   suffix: '&7'
   permission: rvnktools.announce.type.server
+  display_context: ingame
 - id: guide
   prefix: '&e[Guide] &7'
   suffix: '&7'
   permission: rvnktools.announce.type.guide
+  display_context: ingame
 - id: motd
   prefix: '&b'
   suffix: '&r'
   permission: rvnktools.announce.type.motd
+  display_context: ingame
+- id: info
+  prefix: '&7[Info] &7'
+  suffix: '&7'
+  permission: rvnktools.announce.type.info
+  display_context: ingame
+- id: warning
+  prefix: '&e[Warning] &7'
+  suffix: '&7'
+  permission: rvnktools.announce.type.warning
+  display_context: ingame
 
 announcements:
 - id: events

--- a/toolkitplugin/src/main/resources/config.yml
+++ b/toolkitplugin/src/main/resources/config.yml
@@ -136,3 +136,13 @@ features:
   hat-command: true      # /hat command for cosmetic items
   link-command: true     # /link command for clickable links
   world-swap: true       # World switching with location tracking
+  tpa-commands: true     # /tpa, /tpahere, /tpaccept, /tpdeny, /back
+
+# Teleport Request Configuration
+teleport:
+  # TPA request expiry in seconds (how long target has to accept/deny)
+  request-expire-seconds: 60
+  # Warmup delay before teleport executes (seconds, 0 to disable)
+  warmup-seconds: 3
+  # Cooldown between TPA requests (seconds)
+  cooldown-seconds: 10

--- a/toolkitplugin/src/main/resources/plugin.yml
+++ b/toolkitplugin/src/main/resources/plugin.yml
@@ -94,6 +94,26 @@ commands:
     description: Manage TrainCarts settings and view help pages
     usage: /trains [enable|disable|modes|examples|links]
     aliases: [train-help]
+  tpa:
+    description: Request to teleport to another player
+    usage: /tpa <player>
+    permission: rvnktools.command.tpa
+  tpahere:
+    description: Request another player teleport to you
+    usage: /tpahere <player>
+    permission: rvnktools.command.tpahere
+  tpaccept:
+    description: Accept a pending teleport request
+    usage: /tpaccept
+    permission: rvnktools.command.tpaccept
+  tpdeny:
+    description: Deny a pending teleport request
+    usage: /tpdeny
+    permission: rvnktools.command.tpdeny
+  back:
+    description: Teleport to your previous location
+    usage: /back
+    permission: rvnktools.command.back
   link:
     description: Link your account to external services
     usage: /link <login|matrix|discord>
@@ -191,6 +211,27 @@ permissions:
   rvnktools.link:
     description: Allows linking account to external services
     default: true
+  rvnktools.command.tpa:
+    description: Allows sending teleport requests
+    default: true
+  rvnktools.command.tpahere:
+    description: Allows sending teleport-here requests
+    default: true
+  rvnktools.command.tpaccept:
+    description: Allows accepting teleport requests
+    default: true
+  rvnktools.command.tpdeny:
+    description: Allows denying teleport requests
+    default: true
+  rvnktools.command.back:
+    description: Allows teleporting to previous location
+    default: true
+  rvnktools.tpa.bypass.cooldown:
+    description: Bypass TPA cooldown timer
+    default: op
+  rvnktools.tpa.bypass.warmup:
+    description: Bypass TPA warmup timer
+    default: op
   rvnkcore.prefs:
     description: Manage notification preferences
     default: true


### PR DESCRIPTION
## Summary
Major RVNKCore update spanning announcements, auth, API, and cleanup:

### Announcements
- ownerUuid as first-class DB column with edit.own permission (#568, #569)
- Weekly fee scheduler with payment-deactivation (#570)
- displayContext passed through type migration to DB (#576)
- Preference and permission REST endpoints (#539, #540)
- Legacy data layer removed (DataStore, DataStoreManager, MySQL/SQLite/YAML connectors)
- Console support for help and status subcommands

### Auth
- `/link login` command and auth token API for magic link flow
- AuthTokenStore with one-time tokens and 15-minute TTL

### API
- Health endpoint with live player counts, session playtime, memory, version
- GET /v1/announcements/types endpoint (#485)
- GET /lore/categories endpoint (#391)
- Webhook notifier for WebUI cache revalidation on player join/quit
- BarterShops route pattern fix for input validation

### Cleanup
- 14 deprecated/dead files removed (zero callers)
- LogManager null-safety guards
- Version bump to 1.3.7-alpha

## Files Changed
67 files, +3155 / -4115 (net reduction)

## Test plan
- [x] `mvn clean package -DskipTests` builds successfully
- [x] Deployed and validated on RVNK Dev server
- [ ] Full test suite after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)