### PR TITLE
feat(rvnkcore): announcements, auth/magic-link, teleport, push subs, BarterShops groups API

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.4.6-alpha</version>
+    <version>1.4.8-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.4.5-alpha</version>
+    <version>1.4.6-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
@@ -57,7 +57,7 @@ public class ApiConfig {
         this.apiKey = config.getString("api.auth.key", "changeme");
         this.corsEnabled = config.getBoolean("api.cors.enabled", true);
         this.corsAllowedOrigins = config.getString("api.cors.allowed-origins", "*");
-        this.corsAllowedMethods = config.getString("api.cors.allowed-methods", "GET,POST,PUT,DELETE,OPTIONS");
+        this.corsAllowedMethods = config.getString("api.cors.allowed-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
         this.maxThreads = config.getInt("api.server.max-threads", 50);
         this.idleTimeout = config.getInt("api.server.idle-timeout", 30000);
         this.httpsEnabled = config.getBoolean("api.https.enabled", false);
@@ -122,7 +122,7 @@ public class ApiConfig {
         this.apiKey = apiSection.getString("auth.key", "changeme");
         this.corsEnabled = apiSection.getBoolean("cors.enabled", true);
         this.corsAllowedOrigins = apiSection.getString("cors.allowed-origins", "*");
-        this.corsAllowedMethods = apiSection.getString("cors.allowed-methods", "GET,POST,PUT,DELETE,OPTIONS");
+        this.corsAllowedMethods = apiSection.getString("cors.allowed-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
         this.maxThreads = apiSection.getInt("server.max-threads", 50);
         this.idleTimeout = apiSection.getInt("server.idle-timeout", 30000);
         this.httpsEnabled = apiSection.getBoolean("https.enabled", false);

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
@@ -13,10 +13,12 @@ import org.fourz.rvnkcore.RVNKCore;
 import org.fourz.rvnkcore.service.registry.ServiceRegistry;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * REST API controller for BarterShops endpoints.
@@ -31,10 +33,12 @@ public class BarterShopsController extends HttpServlet {
     private final Gson gson;
     private final LogManager logger;
 
-    private static final Pattern SHOP_BY_ID_PATTERN = Pattern.compile("^/shops/([^/]+)$");
-    private static final Pattern TRADE_BY_ID_PATTERN = Pattern.compile("^/trades/([^/]+)$");
-    private static final Pattern STATS_SHOPS_PATTERN = Pattern.compile("^/stats/shops/?(.*)$");
-    private static final Pattern GROUP_BY_ID_PATTERN = Pattern.compile("^/groups/(\\d+)$");
+    private static final Pattern SHOP_BY_ID_PATTERN       = Pattern.compile("^/shops/([^/]+)$");
+    private static final Pattern TRADE_BY_ID_PATTERN       = Pattern.compile("^/trades/([^/]+)$");
+    private static final Pattern STATS_SHOPS_PATTERN       = Pattern.compile("^/stats/shops/?(.*)$");
+    private static final Pattern GROUP_BY_ID_PATTERN       = Pattern.compile("^/groups/(\\d+)$");
+    private static final Pattern GROUP_COOWNERS_PATTERN    = Pattern.compile("^/groups/(\\d+)/coowners$");
+    private static final Pattern GROUP_COOWNER_UUID_PATTERN = Pattern.compile("^/groups/(\\d+)/coowners/([^/]+)$");
 
     public BarterShopsController(IBarterShopsApiService ignored, Gson gson, LogManager logger) {
         this.gson = gson;
@@ -116,6 +120,88 @@ public class BarterShopsController extends HttpServlet {
 
         } catch (Exception e) {
             logger.error("Error handling BarterShops API request: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "Server error: " + e.getMessage());
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IBarterShopsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 503, "SERVICE_UNAVAILABLE", "BarterShops plugin is not loaded");
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            if (GROUP_COOWNERS_PATTERN.matcher(pathInfo).matches()) {
+                Matcher m = GROUP_COOWNERS_PATTERN.matcher(pathInfo);
+                m.matches();
+                String groupId = m.group(1);
+
+                String body = req.getReader().lines().collect(Collectors.joining());
+                @SuppressWarnings("unchecked")
+                Map<String, String> bodyMap = gson.fromJson(body, Map.class);
+                if (bodyMap == null) {
+                    sendError(resp, 400, "INVALID_REQUEST", "Request body is required");
+                    return;
+                }
+                String requesterUuid = bodyMap.get("requesterUuid");
+                String coOwnerUuid = bodyMap.get("coOwnerUuid");
+                if (requesterUuid == null || coOwnerUuid == null) {
+                    sendError(resp, 400, "INVALID_REQUEST", "requesterUuid and coOwnerUuid are required");
+                    return;
+                }
+
+                ApiResponse<?> response = apiService.addGroupCoOwner(groupId, requesterUuid, coOwnerUuid)
+                        .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling BarterShops POST request: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "Server error: " + e.getMessage());
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IBarterShopsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 503, "SERVICE_UNAVAILABLE", "BarterShops plugin is not loaded");
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            if (GROUP_COOWNER_UUID_PATTERN.matcher(pathInfo).matches()) {
+                Matcher m = GROUP_COOWNER_UUID_PATTERN.matcher(pathInfo);
+                m.matches();
+                String groupId = m.group(1);
+                String coOwnerUuid = m.group(2);
+                String requesterUuid = req.getParameter("requesterUuid");
+                if (requesterUuid == null || requesterUuid.isEmpty()) {
+                    sendError(resp, 400, "INVALID_REQUEST", "requesterUuid query parameter is required");
+                    return;
+                }
+
+                ApiResponse<?> response = apiService.removeGroupCoOwner(groupId, coOwnerUuid, requesterUuid)
+                        .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling BarterShops DELETE request: " + pathInfo, e);
             sendError(resp, 500, "INTERNAL_ERROR", "Server error: " + e.getMessage());
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
@@ -170,6 +170,60 @@ public class BarterShopsController extends HttpServlet {
     }
 
     @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp)
+            throws jakarta.servlet.ServletException, IOException {
+        if ("PATCH".equalsIgnoreCase(req.getMethod())) {
+            handlePatch(req, resp);
+        } else {
+            super.service(req, resp);
+        }
+    }
+
+    private void handlePatch(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IBarterShopsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 503, "SERVICE_UNAVAILABLE", "BarterShops plugin is not loaded");
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            if (GROUP_BY_ID_PATTERN.matcher(pathInfo).matches()) {
+                Matcher m = GROUP_BY_ID_PATTERN.matcher(pathInfo);
+                m.matches();
+                String groupId = m.group(1);
+
+                String body = req.getReader().lines().collect(Collectors.joining());
+                @SuppressWarnings("unchecked")
+                Map<String, String> bodyMap = gson.fromJson(body, Map.class);
+                if (bodyMap == null) {
+                    sendError(resp, 400, "INVALID_REQUEST", "Request body is required");
+                    return;
+                }
+                String requesterUuid = bodyMap.get("requesterUuid");
+                String groupName = bodyMap.get("groupName");
+                if (requesterUuid == null || groupName == null || groupName.isBlank()) {
+                    sendError(resp, 400, "INVALID_REQUEST", "requesterUuid and groupName are required");
+                    return;
+                }
+
+                ApiResponse<?> response = apiService.renameGroup(groupId, requesterUuid, groupName.trim())
+                        .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling BarterShops PATCH request: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "Server error: " + e.getMessage());
+        }
+    }
+
+    @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
@@ -72,4 +72,22 @@ public interface IBarterShopsApiService {
      * GET /api/bartershops/groups/{id} — get group by ID with shops and co-owners.
      */
     CompletableFuture<ApiResponse<?>> getGroupById(String groupId);
+
+    /**
+     * POST /api/bartershops/groups/{id}/coowners — add a co-owner to a group.
+     *
+     * @param groupId       group to modify
+     * @param requesterUuid UUID of the player making the request (must be group owner)
+     * @param coOwnerUuid   UUID of the player to add as co-owner
+     */
+    CompletableFuture<ApiResponse<?>> addGroupCoOwner(String groupId, String requesterUuid, String coOwnerUuid);
+
+    /**
+     * DELETE /api/bartershops/groups/{id}/coowners/{coOwnerUuid} — remove a co-owner from a group.
+     *
+     * @param groupId       group to modify
+     * @param coOwnerUuid   UUID of the co-owner to remove
+     * @param requesterUuid UUID of the player making the request (must be group owner)
+     */
+    CompletableFuture<ApiResponse<?>> removeGroupCoOwner(String groupId, String coOwnerUuid, String requesterUuid);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
@@ -90,4 +90,13 @@ public interface IBarterShopsApiService {
      * @param requesterUuid UUID of the player making the request (must be group owner)
      */
     CompletableFuture<ApiResponse<?>> removeGroupCoOwner(String groupId, String coOwnerUuid, String requesterUuid);
+
+    /**
+     * PATCH /api/bartershops/groups/{id} — rename a shop group.
+     *
+     * @param groupId       group to rename
+     * @param requesterUuid UUID of the player making the request (must be group owner)
+     * @param groupName     new name for the group
+     */
+    CompletableFuture<ApiResponse<?>> renameGroup(String groupId, String requesterUuid, String groupName);
 }

--- a/toolkitplugin/src/main/resources/config.yml
+++ b/toolkitplugin/src/main/resources/config.yml
@@ -56,7 +56,7 @@ api:
   cors:
     enabled: true
     allowed-origins: "*"
-    allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+    allowed-methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
   auth:
     key: "changeme"
   server:


### PR DESCRIPTION
## Summary

- **Announcements**: owner UUID, edit.own permission, fee scheduler (#568–570), event+info types, WebUI alignment (#576), preference + permission REST endpoints (#539–540), console support, type migration fix
- **Auth / magic link**: `/link login` command, auth token API, session validation endpoint, QR session-token generation (#577, #581)
- **Push subscriptions**: CRUD, ban webhook, notification endpoints (#577–580)
- **Teleport**: `/tpa`, `/tpahere`, `/tpaccept`, `/tpdeny`, `/back` commands (#47, #49)
- **BarterShops API**: shop group endpoints wired through controller, co-owner add/remove, PATCH renameGroup (#599)
- **CORS**: add PATCH to allowed-methods default
- **LuckPerms**: extract LuckPermsGroupResolver, fix offline permission resolution (#548)
- **Webhook**: cache revalidation notifier on player join/quit
- **Health endpoint**: live player counts, session playtime, memory/version info (#481)
- **Lore**: GET /lore/categories (#391)
- **Cleanup**: 14 deprecated/dead files removed, LogManager null-safety guards
- **Version**: 1.4.8-alpha

## Test plan
- [x] `/link login` generates auth token, session validation works
- [x] Announcement CRUD with type/owner/fee
- [x] `/tpa` flow — request, accept, deny, back
- [x] BarterShops co-owner and renameGroup endpoints
- [x] PATCH requests pass CORS preflight
- [x] Health endpoint returns player counts + memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)