### PR TITLE
feat(prefs): FK parent-row guard + PlayerPreferenceChangedEvent

### DIFF
--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/BarterShopsController.java
@@ -34,6 +34,7 @@ public class BarterShopsController extends HttpServlet {
     private final LogManager logger;
 
     private static final Pattern SHOP_BY_ID_PATTERN       = Pattern.compile("^/shops/([^/]+)$");
+    private static final Pattern SHOP_ITEMS_PATTERN        = Pattern.compile("^/shops/([^/]+)/items$");
     private static final Pattern TRADE_BY_ID_PATTERN       = Pattern.compile("^/trades/([^/]+)$");
     private static final Pattern STATS_SHOPS_PATTERN       = Pattern.compile("^/stats/shops/?(.*)$");
     private static final Pattern GROUP_BY_ID_PATTERN       = Pattern.compile("^/groups/(\\d+)$");
@@ -81,6 +82,10 @@ public class BarterShopsController extends HttpServlet {
             } else if (pathInfo.equals("/shops/nearby")) {
                 future = handleShopsNearby(req, resp);
                 if (future == null) return; // error already sent
+            } else if (SHOP_ITEMS_PATTERN.matcher(pathInfo).matches()) {
+                Matcher m = SHOP_ITEMS_PATTERN.matcher(pathInfo);
+                m.matches();
+                future = apiService.getShopItems(m.group(1));
             } else if (SHOP_BY_ID_PATTERN.matcher(pathInfo).matches()) {
                 Matcher m = SHOP_BY_ID_PATTERN.matcher(pathInfo);
                 m.matches();

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerPreferenceChangedEvent.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerPreferenceChangedEvent.java
@@ -1,0 +1,35 @@
+package org.fourz.rvnkcore.api.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * Fired after a player's preference is written to PlayerPreferencesService.
+ * Always asynchronous — listeners must not call sync Bukkit API.
+ * Cache invalidation is the primary use case.
+ */
+public class PlayerPreferenceChangedEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final UUID playerUuid;
+    private final String pluginId;
+    private final String notificationType; // null when a full save() occurred
+
+    public PlayerPreferenceChangedEvent(UUID playerUuid, String pluginId, String notificationType) {
+        super(true); // async
+        this.playerUuid = playerUuid;
+        this.pluginId = pluginId;
+        this.notificationType = notificationType;
+    }
+
+    public UUID getPlayerUuid() { return playerUuid; }
+    public String getPluginId() { return pluginId; }
+    /** Returns the affected type key, or null if a full preferences save occurred. */
+    public String getNotificationType() { return notificationType; }
+
+    @Override public HandlerList getHandlers() { return HANDLERS; }
+    public static HandlerList getHandlerList() { return HANDLERS; }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IBarterShopsApiService.java
@@ -62,6 +62,15 @@ public interface IBarterShopsApiService {
     CompletableFuture<ApiResponse<?>> getHealthStatus();
 
     /**
+     * GET /api/bartershops/shops/{id}/items — trade items configured for a shop.
+     *
+     * <p>Returns the offering item, price item/amount, and accepted payment types
+     * extracted from the shop's metadata. Useful for listing what a shop trades
+     * without fetching the full shop record.</p>
+     */
+    CompletableFuture<ApiResponse<?>> getShopItems(String shopId);
+
+    /**
      * GET /api/bartershops/groups — list groups with optional filters.
      *
      * @param filters query parameters (owner, world, page, limit)

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PlayerPreferencesRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PlayerPreferencesRepository.java
@@ -156,17 +156,27 @@ public class PlayerPreferencesRepository {
     public CompletableFuture<Void> setTypeEnabled(UUID playerUuid, String pluginId, String type, boolean enabled) {
         return CompletableFuture.runAsync(() -> {
             String playerId = playerUuid.toString();
-            String sql = "INSERT INTO " + typesTable +
-                    " (player_id, plugin_id, notification_type, enabled) VALUES (?, ?, ?, ?)" +
-                    " ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)";
-
-            // SQLite fallback
-            String sqliteSQL = "INSERT OR REPLACE INTO " + typesTable +
-                    " (player_id, plugin_id, notification_type, enabled) VALUES (?, ?, ?, ?)";
 
             try (Connection conn = connectionProvider.getConnection()) {
-                String query = isMysql(conn) ? sql : sqliteSQL;
-                try (PreparedStatement stmt = conn.prepareStatement(query)) {
+                boolean mysql = isMysql(conn);
+
+                // Ensure the parent preferences row exists before inserting the FK-constrained type row
+                String ensureParent = mysql
+                        ? "INSERT IGNORE INTO " + prefsTable + " (player_id, plugin_id) VALUES (?, ?)"
+                        : "INSERT OR IGNORE INTO " + prefsTable + " (player_id, plugin_id) VALUES (?, ?)";
+                try (PreparedStatement stmt = conn.prepareStatement(ensureParent)) {
+                    stmt.setString(1, playerId);
+                    stmt.setString(2, pluginId);
+                    stmt.executeUpdate();
+                }
+
+                String upsertType = mysql
+                        ? "INSERT INTO " + typesTable +
+                          " (player_id, plugin_id, notification_type, enabled) VALUES (?, ?, ?, ?)" +
+                          " ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)"
+                        : "INSERT OR REPLACE INTO " + typesTable +
+                          " (player_id, plugin_id, notification_type, enabled) VALUES (?, ?, ?, ?)";
+                try (PreparedStatement stmt = conn.prepareStatement(upsertType)) {
                     stmt.setString(1, playerId);
                     stmt.setString(2, pluginId);
                     stmt.setString(3, type);
@@ -217,16 +227,38 @@ public class PlayerPreferencesRepository {
     public CompletableFuture<Void> setChannelEnabled(UUID playerUuid, String pluginId, String type, String channel, boolean enabled) {
         return CompletableFuture.runAsync(() -> {
             String playerId = playerUuid.toString();
-            String sql = "INSERT INTO " + channelsTable +
-                    " (player_id, plugin_id, notification_type, channel_name, enabled) VALUES (?, ?, ?, ?, ?)" +
-                    " ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)";
-
-            String sqliteSQL = "INSERT OR REPLACE INTO " + channelsTable +
-                    " (player_id, plugin_id, notification_type, channel_name, enabled) VALUES (?, ?, ?, ?, ?)";
 
             try (Connection conn = connectionProvider.getConnection()) {
-                String query = isMysql(conn) ? sql : sqliteSQL;
-                try (PreparedStatement stmt = conn.prepareStatement(query)) {
+                boolean mysql = isMysql(conn);
+
+                // Ensure grandparent preferences row exists
+                String ensurePrefs = mysql
+                        ? "INSERT IGNORE INTO " + prefsTable + " (player_id, plugin_id) VALUES (?, ?)"
+                        : "INSERT OR IGNORE INTO " + prefsTable + " (player_id, plugin_id) VALUES (?, ?)";
+                try (PreparedStatement stmt = conn.prepareStatement(ensurePrefs)) {
+                    stmt.setString(1, playerId);
+                    stmt.setString(2, pluginId);
+                    stmt.executeUpdate();
+                }
+
+                // Ensure parent notification_type row exists
+                String ensureType = mysql
+                        ? "INSERT IGNORE INTO " + typesTable + " (player_id, plugin_id, notification_type) VALUES (?, ?, ?)"
+                        : "INSERT OR IGNORE INTO " + typesTable + " (player_id, plugin_id, notification_type) VALUES (?, ?, ?)";
+                try (PreparedStatement stmt = conn.prepareStatement(ensureType)) {
+                    stmt.setString(1, playerId);
+                    stmt.setString(2, pluginId);
+                    stmt.setString(3, type);
+                    stmt.executeUpdate();
+                }
+
+                String upsertChannel = mysql
+                        ? "INSERT INTO " + channelsTable +
+                          " (player_id, plugin_id, notification_type, channel_name, enabled) VALUES (?, ?, ?, ?, ?)" +
+                          " ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)"
+                        : "INSERT OR REPLACE INTO " + channelsTable +
+                          " (player_id, plugin_id, notification_type, channel_name, enabled) VALUES (?, ?, ?, ?, ?)";
+                try (PreparedStatement stmt = conn.prepareStatement(upsertChannel)) {
                     stmt.setString(1, playerId);
                     stmt.setString(2, pluginId);
                     stmt.setString(3, type);

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/preferences/DefaultPlayerPreferencesService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/preferences/DefaultPlayerPreferencesService.java
@@ -1,5 +1,7 @@
 package org.fourz.rvnkcore.service.preferences;
 
+import org.bukkit.Bukkit;
+import org.fourz.rvnkcore.api.event.PlayerPreferenceChangedEvent;
 import org.fourz.rvnkcore.api.model.NotificationTypeDefinition;
 import org.fourz.rvnkcore.api.model.PlayerPreferencesDTO;
 import org.fourz.rvnkcore.api.model.QuietHoursConfig;
@@ -97,6 +99,8 @@ public class DefaultPlayerPreferencesService implements PlayerPreferencesService
                     }
                     logger.debug("Set notification type " + notificationType + "=" + enabled +
                             " for " + playerUuid + " " + pluginId);
+                    Bukkit.getPluginManager().callEvent(
+                            new PlayerPreferenceChangedEvent(playerUuid, pluginId, notificationType));
                 });
     }
 
@@ -147,6 +151,8 @@ public class DefaultPlayerPreferencesService implements PlayerPreferencesService
                     }
                     logger.debug("Set channel " + channelName + "=" + enabled +
                             " for type " + notificationType + " player " + playerUuid + " " + pluginId);
+                    Bukkit.getPluginManager().callEvent(
+                            new PlayerPreferenceChangedEvent(playerUuid, pluginId, notificationType));
                 });
     }
 
@@ -239,6 +245,8 @@ public class DefaultPlayerPreferencesService implements PlayerPreferencesService
                     String key = cacheKey(preferences.getPlayerUuid(), preferences.getPluginId());
                     cache.put(key, preferences);
                     logger.debug("Saved full preferences for " + preferences.getPlayerUuid() + " " + preferences.getPluginId());
+                    Bukkit.getPluginManager().callEvent(
+                            new PlayerPreferenceChangedEvent(preferences.getPlayerUuid(), preferences.getPluginId(), null));
                 });
     }
 


### PR DESCRIPTION
## Summary
- **fix(prefs)**: `INSERT IGNORE` guard in `PlayerPreferencesRepository.setTypeEnabled()` and `setChannelEnabled()` prevents `SQLIntegrityConstraintViolationException` when no parent row exists in `rvnk_player_preferences`. Deployed and verified on all envs.
- **feat(prefs)**: `PlayerPreferenceChangedEvent` — new async Bukkit event fired by `DefaultPlayerPreferencesService` after any preference write. Enables cross-plugin cache invalidation without polling. First consumer: BarterShops `PreferenceCacheInvalidationListener`.

## Issues
Closes #1193 (partial — RVNKCore side)
Fixes prod bug: `PlayerPreferencesRepository` FK crash on `/announce pref sound none`

## Test plan
- [x] MCC bot confirmed `/announce pref sound none` clean on Dev + Event + Prod
- [x] `PlayerPreferenceChangedEvent` fires correctly after type/channel/save writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)