### PR TITLE
fix(rvnkcore): restore onlinePlayers + tps to /v1/health (#1470)

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.6-alpha</version>
+    <version>1.5.7-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.7-alpha</version>
+    <version>1.5.8-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -46,9 +46,9 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * REST API controller for authentication endpoints.
@@ -36,6 +37,14 @@ import java.util.concurrent.TimeUnit;
  * @since 1.5.0
  */
 public class AuthController extends HttpServlet {
+
+    /**
+     * How long a session/token endpoint waits on the async {@code getPlayer} DB lookup before
+     * giving up. Under heavy shared-pool contention (e.g. right after a bulk world reimport) the
+     * lookup can exceed this bound; the endpoint then degrades gracefully with a 503 + retry hint
+     * rather than logging a raw {@link TimeoutException} at ERROR and returning a 500 (#1466).
+     */
+    private static final int PLAYER_LOOKUP_TIMEOUT_SECONDS = 10;
 
     private final AuthTokenStore authTokenStore;
     private final PlayerService playerService;
@@ -184,7 +193,8 @@ public class AuthController extends HttpServlet {
 
         try {
             // Look up the player to get current name and groups
-            Optional<PlayerDTO> optPlayer = playerService.getPlayer(uuid).get(10, TimeUnit.SECONDS);
+            Optional<PlayerDTO> optPlayer =
+                    playerService.getPlayer(uuid).get(PLAYER_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (optPlayer.isEmpty()) {
                 ApiUtils.sendError(resp, gson, 404, "NOT_FOUND", "Player not found");
                 return;
@@ -210,6 +220,12 @@ public class AuthController extends HttpServlet {
             logger.info("Session token generated for " + player.getCurrentName()
                     + " (QR login) from " + ApiUtils.getClientIP(req));
             ApiUtils.sendSuccess(resp, gson, result);
+        } catch (TimeoutException e) {
+            // DB-pool contention (not a real failure) — degrade gracefully so the caller can retry (#1466).
+            logger.warning("Session-token lookup for UUID " + uuid + " timed out after "
+                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) — returning 503");
+            ApiUtils.sendError(resp, gson, 503, "LOOKUP_TIMEOUT",
+                    "Player lookup timed out, please retry");
         } catch (Exception e) {
             logger.error("Failed to generate session token for " + uuid, e);
             ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to generate session token");
@@ -243,7 +259,8 @@ public class AuthController extends HttpServlet {
         }
 
         try {
-            Optional<PlayerDTO> optPlayer = playerService.getPlayer(uuid).get(10, TimeUnit.SECONDS);
+            Optional<PlayerDTO> optPlayer =
+                    playerService.getPlayer(uuid).get(PLAYER_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
             if (optPlayer.isEmpty()) {
                 Map<String, Object> result = new LinkedHashMap<>();
@@ -272,6 +289,13 @@ public class AuthController extends HttpServlet {
             ApiUtils.sendSuccess(resp, gson, result);
 
             logger.debug("Session validated for " + player.getCurrentName() + " (banned=" + banned + ")");
+        } catch (TimeoutException e) {
+            // DB-pool contention (not a real failure) — degrade gracefully so the WebUI/widget can
+            // retry instead of treating the user as logged-out. Logged at WARN, not ERROR (#1466).
+            logger.warning("Session validation for UUID " + uuid + " timed out after "
+                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) — returning 503");
+            ApiUtils.sendError(resp, gson, 503, "LOOKUP_TIMEOUT",
+                    "Player lookup timed out, please retry");
         } catch (Exception e) {
             logger.error("Failed to validate session for UUID " + uuid, e);
             ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Session validation failed");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/HealthController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/HealthController.java
@@ -66,6 +66,10 @@ public class HealthController extends HttpServlet {
         LiveDataCache cache = LiveDataCache.getInstance();
         if (cache != null) {
             LiveDataCache.BukkitSnapshot snap = cache.getSnapshot();
+            // #1470: restore onlinePlayers + tps to /v1/health (dropped in the 26.2 rebuild).
+            // Both consumed by the WebUI ServerHealth card and scripts/rvnkcore-api/health.py.
+            data.put("onlinePlayers", snap.onlineCount);
+            data.put("tps", Math.round(snap.tps * 100.0) / 100.0);
             data.put("worldsLoaded", snap.worlds.size());
             data.put("worlds", snap.worlds.stream()
                     .map(w -> Map.of("name", w.name(), "environment", w.environment()))

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
@@ -93,6 +93,20 @@ public class LoreController extends HttpServlet {
                 future = apiService.getStats();
             } else if (pathInfo.equals("/health")) {
                 future = apiService.getHealthStatus();
+            } else if (pathInfo.equals("/items")) {
+                // GET /lore/items?name=<display name>
+                String name = req.getParameter("name");
+                if (name == null || name.trim().isEmpty()) {
+                    sendError(resp, 400, "INVALID_REQUEST", "Query param 'name' is required for /items");
+                    return;
+                }
+                future = apiService.getItemByName(name);
+            } else if (pathInfo.matches("^/items/[^/]+$")) {
+                String id = pathInfo.substring("/items/".length());
+                future = apiService.getItemById(id);
+            } else if (pathInfo.matches("^/presets/[^/]+$")) {
+                String questId = pathInfo.substring("/presets/".length());
+                future = apiService.getPresetsForQuest(questId);
             } else {
                 sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
                 return;
@@ -124,6 +138,13 @@ public class LoreController extends HttpServlet {
             if (pathInfo.equals("/") || pathInfo.equals("/submit")) {
                 String body = ApiUtils.readRequestBody(req);
                 ApiResponse<?> response = apiService.submitEntry(body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else if (pathInfo.matches("^/pools/[^/]+/roll$")) {
+                // POST /lore/pools/{poolId}/roll  body: {"rarityTier":"..."} (optional)
+                String poolId = pathInfo.substring("/pools/".length(), pathInfo.length() - "/roll".length());
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.rollPool(poolId, body)
                     .get(30, TimeUnit.SECONDS);
                 sendApiResponse(resp, response);
             } else {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
@@ -35,6 +35,7 @@ public class RVNKWorldsController extends HttpServlet {
     private static final Pattern WORLD_NAME_PATTERN = Pattern.compile("^/worlds/([^/]+)/?$");
     private static final Pattern WORLD_LOAD_PATTERN = Pattern.compile("^/worlds/([^/]+)/load/?$");
     private static final Pattern WORLD_UNLOAD_PATTERN = Pattern.compile("^/worlds/([^/]+)/unload/?$");
+    private static final Pattern WORLD_RESTORE_PATTERN = Pattern.compile("^/worlds/([^/]+)/restore/?$");
     private static final Pattern TEMPLATES_PATTERN = Pattern.compile("^/templates/?$");
     private static final Pattern GROUPS_PATTERN = Pattern.compile("^/groups/?$");
     private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^/groups/([^/]+)/?$");
@@ -176,6 +177,39 @@ public class RVNKWorldsController extends HttpServlet {
 
         } catch (Exception e) {
             logger.error("Error handling RVNKWorlds API DELETE: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
+        }
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IRVNKWorldsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 501, "PLUGIN_NOT_LOADED", "RVNKWorlds plugin is not loaded");
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            Matcher matcher = WORLD_RESTORE_PATTERN.matcher(pathInfo);
+            if (matcher.matches()) {
+                String worldName = matcher.group(1);
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.restoreWorldSnapshot(worldName, body)
+                    .get(30, TimeUnit.SECONDS);
+                // 202 Accepted for a successfully queued restore; other statuses use normal mapping
+                int status = response.success() ? 202
+                    : (response.error() != null ? response.error().suggestedHttpStatus() : 400);
+                ApiUtils.sendJson(resp, gson, status, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling RVNKWorlds API PUT: " + pathInfo, e);
             sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsFallbackService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsFallbackService.java
@@ -151,6 +151,11 @@ class RVNKWorldsFallbackService implements IRVNKWorldsApiService {
         return writeUnavailable();
     }
 
+    @Override
+    public CompletableFuture<ApiResponse<?>> restoreWorldSnapshot(String worldName, String requestBody) {
+        return writeUnavailable();
+    }
+
     private static CompletableFuture<ApiResponse<?>> writeUnavailable() {
         return CompletableFuture.completedFuture(
             ApiResponse.error("PLUGIN_NOT_LOADED",

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/LiveDataCache.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/LiveDataCache.java
@@ -58,12 +58,24 @@ public class LiveDataCache {
                 .map(w -> new WorldSnapshot(w.getName(), w.getEnvironment().name(), w.getPlayers().size()))
                 .collect(Collectors.toList());
 
+        // getTPS() is a Paper-only Server method; this plugin compiles against spigot-api,
+        // so read it reflectively (present at runtime on Paper). Guarded — 0.0 on any failure.
+        double tps = 0.0;
+        try {
+            Object server = Bukkit.getServer();
+            double[] tpsArr = (double[]) server.getClass().getMethod("getTPS").invoke(server);
+            if (tpsArr != null && tpsArr.length > 0) tps = Math.min(tpsArr[0], 20.0);
+        } catch (Exception ignored) {
+            // Non-Paper runtime or API change — leave tps at 0.0.
+        }
+
         ref.set(new BukkitSnapshot(
                 Collections.unmodifiableList(players),
                 Collections.unmodifiableMap(worldGroups),
                 Collections.unmodifiableList(worlds),
                 online.size(),
                 maxPlayers,
+                tps,
                 System.currentTimeMillis()
         ));
     }
@@ -87,24 +99,27 @@ public class LiveDataCache {
 
     public static class BukkitSnapshot {
         static final BukkitSnapshot EMPTY = new BukkitSnapshot(
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), 0, 0, 0L);
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), 0, 0, 0.0, 0L);
 
         public final List<PlayerResponse> onlinePlayers;
         public final Map<String, List<Map<String, Object>>> worldGroups;
         public final List<WorldSnapshot> worlds;
         public final int onlineCount;
         public final int maxPlayers;
+        /** 1-minute TPS, captured on the main thread and clamped to 20.0 (#1470). */
+        public final double tps;
         public final long capturedAt;
 
         BukkitSnapshot(List<PlayerResponse> onlinePlayers,
                        Map<String, List<Map<String, Object>>> worldGroups,
                        List<WorldSnapshot> worlds,
-                       int onlineCount, int maxPlayers, long capturedAt) {
+                       int onlineCount, int maxPlayers, double tps, long capturedAt) {
             this.onlinePlayers = onlinePlayers;
             this.worldGroups = worldGroups;
             this.worlds = worlds;
             this.onlineCount = onlineCount;
             this.maxPlayers = maxPlayers;
+            this.tps = tps;
             this.capturedAt = capturedAt;
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
@@ -35,4 +35,18 @@ public interface ILoreApiService {
     CompletableFuture<ApiResponse<?>> getHealthStatus();
 
     CompletableFuture<ApiResponse<?>> getCategories();
+
+    // ── Item surface (#1495) — read + roll, no mint/persist over HTTP ──────────────
+
+    /** Item properties by numeric lore_item id. */
+    CompletableFuture<ApiResponse<?>> getItemById(String id);
+
+    /** Item properties by (case-insensitive) display name. */
+    CompletableFuture<ApiResponse<?>> getItemByName(String name);
+
+    /** Preset item properties bound to a quest id. */
+    CompletableFuture<ApiResponse<?>> getPresetsForQuest(String questId);
+
+    /** Roll a weighted item from an RNG pool; {@code requestBody} may carry {"rarityTier": "..."}. */
+    CompletableFuture<ApiResponse<?>> rollPool(String poolId, String requestBody);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
@@ -29,6 +29,9 @@ public interface IRVNKWorldsApiService {
     CompletableFuture<ApiResponse<?>> listGroups();
     CompletableFuture<ApiResponse<?>> getGroup(String groupName);
 
+    // Snapshot operations
+    CompletableFuture<ApiResponse<?>> restoreWorldSnapshot(String worldName, String requestBody);
+
     // Metrics & Health
     CompletableFuture<ApiResponse<?>> getMetrics();
     CompletableFuture<ApiResponse<?>> getHealthStatus();

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
@@ -14,13 +14,18 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Sends webhook POST notifications on server events.
  * Player events use a leading-edge debounce to coalesce rapid join/quit bursts.
  * Shop CRUD events use a 30-second leading-edge debounce.
- * Trade completion events use a separate 30-second debounce (independent of shop CRUD).
+ * Trade completion events use a trailing-edge debounce: fires 30s after the last
+ * trade in a burst, ensuring the cache reflects the final state rather than the first.
  * Announcement events fire immediately (no debounce).
  *
  * @since 1.5.0
@@ -36,7 +41,13 @@ public class WebhookNotifier {
     private final LogManager logger;
     private final AtomicLong lastFiredAt = new AtomicLong(0);
     private final AtomicLong shopLastFiredAt = new AtomicLong(0);
-    private final AtomicLong tradeLastFiredAt = new AtomicLong(0);
+
+    // Trailing-edge debounce state for trade events
+    private final ScheduledExecutorService tradeScheduler =
+        Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "rvnkcore-trade-debounce"));
+    private final Object tradeLock = new Object();
+    private ScheduledFuture<?> pendingTradeFuture = null;
+    private String latestTradeShopId = "";
 
     /**
      * Creates a new WebhookNotifier.
@@ -178,33 +189,47 @@ public class WebhookNotifier {
 
     /**
      * Fires a webhook notification for a trade completion event.
-     * Uses a separate 30-second leading-edge debounce independent of shop CRUD events,
-     * so shop create/delete and trade completions don't suppress each other.
+     * Uses a trailing-edge debounce: each call resets the 30-second timer, so the
+     * webhook fires once, 30s after the last trade in a burst. This ensures peak-hour
+     * trade bursts produce a single cache refresh reflecting the final state, rather
+     * than firing on the first trade and missing all subsequent ones in the window.
      *
      * @param shopId The ID of the shop where the trade occurred
      */
     public void notifyTradeComplete(String shopId) {
         if (!config.isEnabled()) return;
-        long now = System.currentTimeMillis();
-        long last = tradeLastFiredAt.get();
-
-        if (now - last < TRADE_DEBOUNCE_MS) {
-            logger.debug("Webhook trade debounced (within 30s window)");
-            return;
+        synchronized (tradeLock) {
+            latestTradeShopId = shopId != null ? shopId : "";
+            if (pendingTradeFuture != null) {
+                pendingTradeFuture.cancel(false);
+            }
+            pendingTradeFuture = tradeScheduler.schedule(this::fireTrade, TRADE_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+            logger.debug("Webhook trade debounce reset (fires in 30s)");
         }
-        if (!tradeLastFiredAt.compareAndSet(last, now)) {
-            return;
-        }
+    }
 
+    private void fireTrade() {
+        String shopId;
+        synchronized (tradeLock) {
+            shopId = latestTradeShopId;
+            pendingTradeFuture = null;
+        }
         String payload = GSON.toJson(Map.of(
             "event", "trade_complete",
             "server", config.getServerId(),
-            "shopId", shopId != null ? shopId : "",
+            "shopId", shopId,
             "timestamp", Instant.now().toString()
         ));
-
         sendAsync(payload, "Webhook trade " + config.getServerId());
         sendCachePurgeAsync();
+    }
+
+    /**
+     * Shuts down the trade debounce scheduler. Call on plugin disable to avoid thread leaks.
+     * Any pending trade flush is cancelled — trades within the final 30s window are dropped.
+     */
+    public void shutdown() {
+        tradeScheduler.shutdownNow();
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/webhook/WebhookNotifier.java
@@ -300,7 +300,15 @@ public class WebhookNotifier {
             .build();
 
         httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-            .thenAccept(response -> logger.warning(logTag + " -> " + response.statusCode()))
+            .thenAccept(response -> {
+                int status = response.statusCode();
+                // Success (2xx) is routine — log at DEBUG. Only surface non-2xx as WARN (#1454).
+                if (status >= 200 && status < 300) {
+                    logger.debug(logTag + " -> " + status);
+                } else {
+                    logger.warning(logTag + " -> " + status);
+                }
+            })
             .exceptionally(e -> {
                 logger.warning(logTag + " failed: " + e.getMessage());
                 return null;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/ApiServerInitializer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/ApiServerInitializer.java
@@ -135,7 +135,9 @@ public class ApiServerInitializer {
     public void stop() {
         if (apiServer != null) {
             try {
-                // Unregister webhook notifier
+                // Shutdown and unregister webhook notifier
+                WebhookNotifier notifier = registry.getService(WebhookNotifier.class);
+                if (notifier != null) notifier.shutdown();
                 registry.unregisterService(WebhookNotifier.class);
                 // Unregister servlet registration service
                 registry.unregisterService(IServletRegistrationService.class);

--- a/toolkitplugin/src/main/resources/plugin.yml
+++ b/toolkitplugin/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: '${project.version}'
 author: fourz
 main: org.fourz.rvnkcore.RVNKCore
 description: Core unified library for Ravenkraft Minecraft plugins
-api-version: 1.21
+api-version: '26.1'
 website: http://www.fourz.org
 softdepend: [Multiverse-Core, PlaceholderAPI, LuckPerms, Vault]
 

--- a/toolkitplugin/src/main/resources/plugin.yml
+++ b/toolkitplugin/src/main/resources/plugin.yml
@@ -131,25 +131,9 @@ permissions:
   rvnktools.command:
     description: Allows use of rvnktools commands
     default: op
-  rvnktools.command.event:
-    description: Allows teleporting to event worlds
-    default: op
-  rvnktools.command.return:
-    description: Allows returning from event worlds
-    default: op
-  rvnktools.command.broadcast:
-    description: Allows the player to use the broadcast command
-    default: op
-  rvnktools.welcome:
-    description: Allows the player to get welcome messages
-  rvnktools.welcome.newplayer:
-    description: Sends a welcome message to new players
-  rvnktools.command.cyclegamemode:
-    description: Allows the player to use the gmc command
-  rvnktools.command.cycletrainmode:
-    description: Allows the player to use cycle railroad modes
-  rvnktools.command.countdown:
-    description: Allows the player to use the countdown command
+  # NOTE: event/return/broadcast/welcome/welcome.newplayer/cyclegamemode/
+  # cycletrainmode/countdown are declared once each in the categorized sections
+  # below (Trains, Misc commands, Welcome) — do not re-add them here (#1490).
   # ── Teleport ────────────────────────────────────────────────────────────────
   rvnktools.command.tp:
     description: Allows use of /tp and /teleport commands (unified node)


### PR DESCRIPTION
Restore `onlinePlayers` + `tps` to `GET /v1/health` (#1470) — the 26.2 rebuild dropped both, blanking the WebUI ServerHealth card player count and `health.py` diagnostics.

- LiveDataCache.BukkitSnapshot gains a `tps` field, captured on the main thread in `refresh()` via reflective `Server.getTPS()` (Paper-only method; this plugin compiles against spigot-api), clamped to 20.0, guarded to 0.0 on non-Paper runtimes.
- HealthController re-exposes `onlinePlayers` (= snap.onlineCount) and `tps`.

Verified on RVNK Dev: `/v1/health` returns `onlinePlayers` + `tps:20.0`; `health.py` shows `0/20` + `20.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mqipyPkhdBxi8fctv1Ynx
