### PR TITLE
RVNKCore 1.5.19-alpha — Migration 8 (holiday_key) + gitignore fix that unblocks clean-clone builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,19 @@ toolkitplugin/dependency-reduced-pom.xml
 rvnktools.jar
 .vscode/bak
 shared-backup/
+# Bare 'docs' matches at ANY depth, which silently swallowed the Java package
+# org/fourz/rvnkcore/api/docs/ — source files that ServletFactory imports (#1597).
+# The result was a repo that could not build from a clean clone while building fine
+# on any machine that happened to have the untracked files on disk.
+# Intent is the metamake doc trees; source is negated below.
 docs
 !toolkitplugin/docs/
 !toolkitplugin/docs/**
+# Never ignore source. A directory must be re-included before anything inside it can
+# be — git does not descend into an excluded directory, so a file-level negation alone
+# would not work here.
+!toolkitplugin/src/**/docs/
+!toolkitplugin/src/**/docs/**
 toolkitplugin/target/rvnktools-1.3.0-alpha.jar
 toolkitplugin/target/original-rvnkcore-1.3.0-alpha.jar
 nul

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.17-alpha</version>
+    <version>1.5.18-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.15-alpha</version>
+    <version>1.5.16-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.12-alpha</version>
+    <version>1.5.15-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.18-alpha</version>
+    <version>1.5.19-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.9-alpha</version>
+    <version>1.5.10-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.16-alpha</version>
+    <version>1.5.17-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.11-alpha</version>
+    <version>1.5.12-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.10-alpha</version>
+    <version>1.5.11-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.8-alpha</version>
+    <version>1.5.9-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
@@ -32,6 +32,8 @@ public class ApiConfig {
     private final int connectionTimeout;
     private final boolean useForwardedHeaders;
     private final String[] allowedIPs;
+    private final boolean rateLimitEnabled;
+    private final int rateLimitRequestsPerMinute;
     private final String[] sanHostnames;
     private final Level apiLogLevel;
     private final Level globalLogLevel;
@@ -78,6 +80,11 @@ public class ApiConfig {
         // Parse allowed IPs
         String allowedIPsStr = config.getString("api.security.allowed-ips", "");
         this.allowedIPs = allowedIPsStr.isEmpty() ? new String[0] : allowedIPsStr.split(",");
+
+        // Per-IP request throttling (#1043). Configurable rather than hardcoded so the
+        // limit can be tuned per environment without a rebuild.
+        this.rateLimitEnabled = config.getBoolean("api.security.rate-limit.enabled", true);
+        this.rateLimitRequestsPerMinute = config.getInt("api.security.rate-limit.requests-per-minute", 600);
 
         // Parse SAN hostnames for TLS cert generation (includes api.host if not localhost)
         this.sanHostnames = parseSanHostnames(host, config.getString("api.https.san-hostnames", ""));
@@ -145,6 +152,11 @@ public class ApiConfig {
         String allowedIPsStr = apiSection.getString("security.allowed-ips", "");
         this.allowedIPs = allowedIPsStr.isEmpty() ? new String[0] : allowedIPsStr.split(",");
 
+        // Per-IP request throttling (#1043). Configurable rather than hardcoded so the
+        // limit can be tuned per environment without a rebuild.
+        this.rateLimitEnabled = apiSection.getBoolean("security.rate-limit.enabled", true);
+        this.rateLimitRequestsPerMinute = apiSection.getInt("security.rate-limit.requests-per-minute", 600);
+
         // Parse SAN hostnames for TLS cert generation (includes api.host if not localhost)
         this.sanHostnames = parseSanHostnames(host, apiSection.getString("https.san-hostnames", ""));
 
@@ -180,6 +192,8 @@ public class ApiConfig {
     public int getConnectionTimeout() { return connectionTimeout; }
     public boolean isUseForwardedHeaders() { return useForwardedHeaders; }
     public String[] getAllowedIPs() { return allowedIPs; }
+    public boolean isRateLimitEnabled() { return rateLimitEnabled; }
+    public int getRateLimitRequestsPerMinute() { return rateLimitRequestsPerMinute; }
     public String[] getSanHostnames() { return sanHostnames; }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
@@ -140,6 +140,12 @@ public class LoreController extends HttpServlet {
                 ApiResponse<?> response = apiService.submitEntry(body)
                     .get(30, TimeUnit.SECONDS);
                 sendApiResponse(resp, response);
+            } else if (pathInfo.equals("/items")) {
+                // POST /lore/items — mint a single lore item (#1517)
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.createItem(body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
             } else if (pathInfo.matches("^/pools/[^/]+/roll$")) {
                 // POST /lore/pools/{poolId}/roll  body: {"rarityTier":"..."} (optional)
                 String poolId = pathInfo.substring("/pools/".length(), pathInfo.length() - "/roll".length());

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
@@ -101,6 +101,10 @@ public class LoreController extends HttpServlet {
                     return;
                 }
                 future = apiService.getItemByName(name);
+            } else if (pathInfo.matches("^/items/[^/]+/versions$")) {
+                // GET /lore/items/{id}/versions (#1528)
+                String id = pathInfo.substring("/items/".length(), pathInfo.length() - "/versions".length());
+                future = apiService.getItemVersions(id);
             } else if (pathInfo.matches("^/items/[^/]+$")) {
                 String id = pathInfo.substring("/items/".length());
                 future = apiService.getItemById(id);
@@ -153,11 +157,72 @@ public class LoreController extends HttpServlet {
                 ApiResponse<?> response = apiService.rollPool(poolId, body)
                     .get(30, TimeUnit.SECONDS);
                 sendApiResponse(resp, response);
+            } else if (pathInfo.matches("^/items/[^/]+/rollback$")) {
+                // POST /lore/items/{id}/rollback  body: {"version":N} (#1528)
+                String id = pathInfo.substring("/items/".length(), pathInfo.length() - "/rollback".length());
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.rollbackItem(id, body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
             } else {
                 sendError(resp, 404, "NOT_FOUND", "Unknown POST endpoint: " + pathInfo);
             }
         } catch (Exception e) {
             logger.error("Error handling Lore API POST: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
+        }
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        ILoreApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 501, "PLUGIN_NOT_LOADED", "RVNKLore plugin is not loaded");
+            return;
+        }
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+        try {
+            if (pathInfo.matches("^/items/[^/]+$")) {
+                // PUT /lore/items/{id} — versioned update (#1528)
+                String id = pathInfo.substring("/items/".length());
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.updateItem(id, body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Unknown PUT endpoint: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling Lore API PUT: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        ILoreApiService apiService = getApiService();
+        if (apiService == null) {
+            sendError(resp, 501, "PLUGIN_NOT_LOADED", "RVNKLore plugin is not loaded");
+            return;
+        }
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+        try {
+            if (pathInfo.matches("^/items/[^/]+$")) {
+                // DELETE /lore/items/{id}?hard=true|false (#1528) — soft-archive by default
+                String id = pathInfo.substring("/items/".length());
+                boolean hard = "true".equalsIgnoreCase(req.getParameter("hard"));
+                ApiResponse<?> response = apiService.deleteItem(id, hard)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Unknown DELETE endpoint: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling Lore API DELETE: " + pathInfo, e);
             sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.fourz.rvnkcore.api.model.WebUIAccessLogDTO;
+import org.fourz.rvnkcore.api.model.response.ApiResponse;
 import org.fourz.rvnkcore.api.util.ApiUtils;
 import org.fourz.rvnkcore.database.repository.WebUIAccessRepository;
 import org.fourz.rvnkcore.util.log.LogManager;
@@ -140,7 +141,7 @@ public class WebUIAccessController extends HttpServlet {
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("id", id);
             logger.debug("Recorded webui access log id=" + id + " (" + dto.getActionType() + ")");
-            ApiUtils.sendJson(resp, gson, 201, result);
+            ApiUtils.sendJson(resp, gson, 201, ApiResponse.success(result));
         } catch (Exception e) {
             logger.error("Failed to record webui access log", e);
             ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to record access log");
@@ -168,7 +169,7 @@ public class WebUIAccessController extends HttpServlet {
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("data", qr.getData());
             result.put("total", qr.getTotal());
-            ApiUtils.sendJson(resp, gson, 200, result);
+            ApiUtils.sendJson(resp, gson, 200, ApiResponse.success(result));
         } catch (Exception e) {
             logger.error("Failed to query webui access logs", e);
             ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to query access logs");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
@@ -153,9 +153,14 @@ public class WebUIAccessController extends HttpServlet {
         // Previously this did .get(DB_TIMEOUT_SECONDS) on a Jetty request thread. On Event
         // that budget (10s) equalled the HikariCP connection-acquisition timeout, leaving no
         // headroom for the INSERT itself, so every write threw TimeoutException. Worse, each
-        // failure parked a Jetty worker for the full 10s against api.server.max-threads=50 —
-        // so a slow pool could exhaust the API thread pool and take down every endpoint over
-        // a non-critical logging call.
+        // failure parked a Jetty worker for the full 10s — so a slow pool could exhaust the
+        // API thread pool and take down every endpoint over a non-critical logging call.
+        //
+        // NB: this previously cited api.server.max-threads=50 as the pool being exhausted.
+        // That config key is read into ApiConfig but never applied to Jetty — CoreServer
+        // constructs a bare `new Server()`, so the server actually runs Jetty's default
+        // 200-thread pool and the configured 50 is inert (#1558). The exhaustion risk is
+        // real but the headroom is ~4x larger than that number implies.
         //
         // The caller does not read the response body (RVNKWebUI's src/lib/access-log.ts is
         // itself documented fire-and-forget), so 202 Accepted is the honest status: the

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
@@ -36,7 +36,18 @@ import java.util.concurrent.TimeUnit;
 public class WebUIAccessController extends HttpServlet {
 
     /** How long to wait on the async DB operation before degrading to a 500/503. */
-    private static final int DB_TIMEOUT_SECONDS = 10;
+    /**
+     * Budget for the blocking GET query (#1545).
+     *
+     * <p>Must exceed the HikariCP connection-acquisition timeout, otherwise the wait for a
+     * pooled connection can consume the entire budget before the query even starts. That is
+     * exactly what broke the POST path: this was 10s while Event's {@code connectionTimeoutMs}
+     * is also 10000, leaving zero headroom. Dev's pool allows up to 30s, so the budget has to
+     * clear that too.
+     *
+     * <p>The POST path no longer uses this — it dispatches without blocking.
+     */
+    private static final int DB_TIMEOUT_SECONDS = 45;
 
     /** Valid {@code action_type} values; anything else is rejected with 400. */
     private static final Set<String> VALID_ACTION_TYPES = Set.of("LOGIN", "PAGE_VISIT", "ADMIN_ACTION");
@@ -136,16 +147,41 @@ public class WebUIAccessController extends HttpServlet {
                 .actionType(actionType)
                 .build();
 
-        try {
-            Long id = repository.insert(dto).get(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            Map<String, Object> result = new LinkedHashMap<>();
-            result.put("id", id);
-            logger.debug("Recorded webui access log id=" + id + " (" + dto.getActionType() + ")");
-            ApiUtils.sendJson(resp, gson, 201, ApiResponse.success(result));
-        } catch (Exception e) {
-            logger.error("Failed to record webui access log", e);
-            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to record access log");
-        }
+        // Access logging is fire-and-forget telemetry, so the write is dispatched without
+        // blocking the request thread (#1545).
+        //
+        // Previously this did .get(DB_TIMEOUT_SECONDS) on a Jetty request thread. On Event
+        // that budget (10s) equalled the HikariCP connection-acquisition timeout, leaving no
+        // headroom for the INSERT itself, so every write threw TimeoutException. Worse, each
+        // failure parked a Jetty worker for the full 10s against api.server.max-threads=50 —
+        // so a slow pool could exhaust the API thread pool and take down every endpoint over
+        // a non-critical logging call.
+        //
+        // The caller does not read the response body (RVNKWebUI's src/lib/access-log.ts is
+        // itself documented fire-and-forget), so 202 Accepted is the honest status: the
+        // request was accepted, durability is not being confirmed.
+        repository.insert(dto).whenComplete((id, error) -> {
+            if (error != null) {
+                logger.error("Failed to record webui access log ("
+                        + dto.getActionType() + " " + dto.getPagePath() + ")", unwrapCause(error));
+            } else {
+                logger.debug("Recorded webui access log id=" + id + " (" + dto.getActionType() + ")");
+            }
+        });
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("accepted", true);
+        ApiUtils.sendJson(resp, gson, 202, ApiResponse.success(result));
+    }
+
+    /**
+     * Unwraps the {@link java.util.concurrent.CompletionException} wrapper the async pipeline
+     * adds, so the log shows the real failure rather than the wrapper.
+     */
+    private Throwable unwrapCause(Throwable error) {
+        return (error instanceof java.util.concurrent.CompletionException && error.getCause() != null)
+                ? error.getCause()
+                : error;
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WebUIAccessController.java
@@ -1,0 +1,188 @@
+package org.fourz.rvnkcore.api.controller;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.fourz.rvnkcore.api.model.WebUIAccessLogDTO;
+import org.fourz.rvnkcore.api.util.ApiUtils;
+import org.fourz.rvnkcore.database.repository.WebUIAccessRepository;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * REST API controller for WebUI access logging.
+ * Mounted at {@code /v1/webui/*}.
+ *
+ * <h3>Endpoints</h3>
+ * <ul>
+ *   <li>{@code POST /v1/webui/access} — Record a WebUI access-log entry. Returns 201 {@code {"id": <id>}}.</li>
+ *   <li>{@code GET  /v1/webui/access} — Query access-log entries. Returns {@code {"data":[...],"total":N}}.</li>
+ * </ul>
+ *
+ * <p>The country code is resolved upstream by fourzorg-api (ip-api lookup) and passed in
+ * pre-resolved; this controller performs no geo lookup of its own.</p>
+ *
+ * @since 1.5.9
+ */
+public class WebUIAccessController extends HttpServlet {
+
+    /** How long to wait on the async DB operation before degrading to a 500/503. */
+    private static final int DB_TIMEOUT_SECONDS = 10;
+
+    /** Valid {@code action_type} values; anything else is rejected with 400. */
+    private static final Set<String> VALID_ACTION_TYPES = Set.of("LOGIN", "PAGE_VISIT", "ADMIN_ACTION");
+    private static final String DEFAULT_ACTION_TYPE = "PAGE_VISIT";
+
+    private final WebUIAccessRepository repository;
+    private final Gson gson;
+    private final LogManager logger;
+
+    public WebUIAccessController(WebUIAccessRepository repository, Gson gson, LogManager logger) {
+        this.repository = repository;
+        this.gson = gson;
+        this.logger = logger;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo != null && pathInfo.equals("/access")) {
+                handleRecordAccess(req, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown webui endpoint: POST " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling webui POST request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo != null && pathInfo.equals("/access")) {
+                handleQueryAccess(req, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown webui endpoint: GET " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling webui GET request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    /**
+     * POST /v1/webui/access — Record an access-log entry.
+     * Body: {@code {"ign":?, "uuid":?, "ip_address":"...", "country_code":?, "page_path":"...", "action_type":?}}
+     * {@code ip_address} and {@code page_path} are required; {@code action_type} defaults to PAGE_VISIT.
+     */
+    private void handleRecordAccess(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String body = ApiUtils.readRequestBody(req);
+
+        JsonObject json;
+        try {
+            json = gson.fromJson(body, JsonObject.class);
+        } catch (JsonSyntaxException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Invalid JSON body");
+            return;
+        }
+        if (json == null) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Empty request body");
+            return;
+        }
+
+        String ipAddress = getJsonString(json, "ip_address");
+        String pagePath = getJsonString(json, "page_path");
+        if (ipAddress.isBlank()) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Missing required field: ip_address");
+            return;
+        }
+        if (pagePath.isBlank()) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "Missing required field: page_path");
+            return;
+        }
+
+        String actionType = getJsonString(json, "action_type");
+        if (actionType.isBlank()) {
+            actionType = DEFAULT_ACTION_TYPE;
+        }
+        if (!VALID_ACTION_TYPES.contains(actionType)) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST",
+                    "Invalid action_type: must be one of LOGIN, PAGE_VISIT, ADMIN_ACTION");
+            return;
+        }
+
+        WebUIAccessLogDTO dto = WebUIAccessLogDTO.builder()
+                .ign(nullIfBlank(getJsonString(json, "ign")))
+                .uuid(nullIfBlank(getJsonString(json, "uuid")))
+                .ipAddress(ipAddress)
+                .countryCode(nullIfBlank(getJsonString(json, "country_code")))
+                .pagePath(pagePath)
+                .actionType(actionType)
+                .build();
+
+        try {
+            Long id = repository.insert(dto).get(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("id", id);
+            logger.debug("Recorded webui access log id=" + id + " (" + dto.getActionType() + ")");
+            ApiUtils.sendJson(resp, gson, 201, result);
+        } catch (Exception e) {
+            logger.error("Failed to record webui access log", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to record access log");
+        }
+    }
+
+    /**
+     * GET /v1/webui/access — Query access-log entries.
+     * Query params: {@code ign, country, from, to, limit, action_type}.
+     * Response: {@code {"data":[...],"total":N}}.
+     */
+    private void handleQueryAccess(HttpServletRequest req, HttpServletResponse resp) {
+        String ign = req.getParameter("ign");
+        String country = req.getParameter("country");
+        String from = req.getParameter("from");
+        String to = req.getParameter("to");
+        String actionType = req.getParameter("action_type");
+        int limit = ApiUtils.getIntParam(req, "limit", 100);
+
+        try {
+            WebUIAccessRepository.QueryResult qr =
+                    repository.query(ign, country, actionType, from, to, limit)
+                            .get(DB_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("data", qr.getData());
+            result.put("total", qr.getTotal());
+            ApiUtils.sendJson(resp, gson, 200, result);
+        } catch (Exception e) {
+            logger.error("Failed to query webui access logs", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Failed to query access logs");
+        }
+    }
+
+    private static String getJsonString(JsonObject json, String key) {
+        if (json.has(key) && !json.get(key).isJsonNull()) {
+            return json.get(key).getAsString();
+        }
+        return "";
+    }
+
+    private static String nullIfBlank(String value) {
+        return (value == null || value.isBlank()) ? null : value;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/docs/OpenApiHandler.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/docs/OpenApiHandler.java
@@ -1,0 +1,32 @@
+package org.fourz.rvnkcore.api.docs;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Serves the OpenAPI documentation UI and spec JSON.
+ *
+ * Endpoints:
+ *   GET /api/docs/spec.json  — raw OpenAPI 3.0 specification
+ *   GET /api/docs/ui         — Swagger UI (HTML)
+ */
+public class OpenApiHandler extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String path = req.getPathInfo();
+        if (path == null) path = "/";
+
+        if (path.equals("/spec.json") || path.equals("/spec")) {
+            resp.setContentType("application/json;charset=UTF-8");
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.getWriter().write("{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"RVNKCore API\",\"version\":\"1.0\"}}");
+        } else {
+            resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            resp.getWriter().write("Not found");
+        }
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/WebUIAccessLogDTO.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/model/WebUIAccessLogDTO.java
@@ -1,0 +1,75 @@
+package org.fourz.rvnkcore.api.model;
+
+import java.sql.Timestamp;
+
+/**
+ * Data transfer object for a WebUI access-log entry.
+ * Table: {@code rvnk_webui_access_log}
+ *
+ * <p>Records a single WebUI page visit / login / admin action. The country code is
+ * resolved upstream by fourzorg-api (ip-api lookup); RVNKCore stores it as-is.</p>
+ *
+ * @since 1.5.9
+ */
+public class WebUIAccessLogDTO {
+
+    private Long id;
+    private String ign;
+    private String uuid;
+    private String ipAddress;
+    private String countryCode;
+    private String pagePath;
+    private String actionType;
+    private Timestamp createdAt;
+
+    public WebUIAccessLogDTO() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getIgn() { return ign; }
+    public void setIgn(String ign) { this.ign = ign; }
+
+    public String getUuid() { return uuid; }
+    public void setUuid(String uuid) { this.uuid = uuid; }
+
+    public String getIpAddress() { return ipAddress; }
+    public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
+
+    public String getCountryCode() { return countryCode; }
+    public void setCountryCode(String countryCode) { this.countryCode = countryCode; }
+
+    public String getPagePath() { return pagePath; }
+    public void setPagePath(String pagePath) { this.pagePath = pagePath; }
+
+    public String getActionType() { return actionType; }
+    public void setActionType(String actionType) { this.actionType = actionType; }
+
+    public Timestamp getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Timestamp createdAt) { this.createdAt = createdAt; }
+
+    /**
+     * @return a new fluent builder for {@link WebUIAccessLogDTO}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent builder for {@link WebUIAccessLogDTO}.
+     */
+    public static final class Builder {
+        private final WebUIAccessLogDTO dto = new WebUIAccessLogDTO();
+
+        public Builder id(Long id) { dto.id = id; return this; }
+        public Builder ign(String ign) { dto.ign = ign; return this; }
+        public Builder uuid(String uuid) { dto.uuid = uuid; return this; }
+        public Builder ipAddress(String ipAddress) { dto.ipAddress = ipAddress; return this; }
+        public Builder countryCode(String countryCode) { dto.countryCode = countryCode; return this; }
+        public Builder pagePath(String pagePath) { dto.pagePath = pagePath; return this; }
+        public Builder actionType(String actionType) { dto.actionType = actionType; return this; }
+        public Builder createdAt(Timestamp createdAt) { dto.createdAt = createdAt; return this; }
+
+        public WebUIAccessLogDTO build() { return dto; }
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
@@ -49,13 +49,20 @@ public class AuthFilter implements Filter {
      * Sharing one limiter across instances fixes all three.
      */
     /**
-     * Marks a request as already rate-limit-checked. A single HTTP request can traverse more
-     * than one AuthFilter instance (ServletFactory registers one for the fixed paths and
-     * ServletRegistrationServiceImpl registers another per servlet path), and without this
-     * guard each pass would consume another token from the shared bucket — halving the
-     * effective limit on any double-filtered path. One request must cost exactly one token.
+     * Marks a request as already processed by an AuthFilter (#1547).
+     *
+     * <p>A single request can traverse more than one AuthFilter instance: ServletFactory
+     * blanket-registers one on {@code /v1/*}, while ServletRegistrationServiceImpl adds
+     * another for each dynamically registered path. Paths registered under {@code /v1/}
+     * — currently {@code /v1/events/*}, {@code /v1/announcements/*} and
+     * {@code /v1/support/*} — are therefore covered twice.
+     *
+     * <p>Every instance is built from the same {@link ApiConfig}, so a second pass would
+     * re-run the IP whitelist check and the constant-time key comparison, log the request
+     * again, and consume a second token from the shared rate-limit bucket. Short-circuiting
+     * on this attribute guarantees exactly one authentication and one token per request.
      */
-    private static final String RATE_LIMIT_CHECKED_ATTR = "org.fourz.rvnkcore.rateLimitChecked";
+    private static final String AUTH_APPLIED_ATTR = "org.fourz.rvnkcore.authFilterApplied";
 
     private static final Object RATE_LIMITER_LOCK = new Object();
     private static RateLimiter sharedRateLimiter;
@@ -122,7 +129,15 @@ public class AuthFilter implements Filter {
         
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
-        
+
+        // Already authenticated by an earlier AuthFilter in this chain (#1547) — every
+        // instance shares the same config, so a second pass is pure duplicated work.
+        if (httpRequest.getAttribute(AUTH_APPLIED_ATTR) != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+        httpRequest.setAttribute(AUTH_APPLIED_ATTR, Boolean.TRUE);
+
         String clientIP = ApiUtils.getClientIP(httpRequest);
         String method = httpRequest.getMethod();
         String requestURI = httpRequest.getRequestURI();
@@ -139,13 +154,10 @@ public class AuthFilter implements Filter {
         // Per-IP throttling (#1043). Deliberately runs BEFORE the whitelist and API-key
         // checks so an unauthenticated flood — including API-key brute-forcing — is
         // throttled too. The health endpoint returns above and is never throttled.
-        if (rateLimiter != null && httpRequest.getAttribute(RATE_LIMIT_CHECKED_ATTR) == null) {
-            httpRequest.setAttribute(RATE_LIMIT_CHECKED_ATTR, Boolean.TRUE);
-            if (!rateLimiter.isAllowed(clientIP)) {
-                warnRateLimited(clientIP, method, requestURI);
-                sendRateLimited(httpResponse);
-                return;
-            }
+        if (rateLimiter != null && !rateLimiter.isAllowed(clientIP)) {
+            warnRateLimited(clientIP, method, requestURI);
+            sendRateLimited(httpResponse);
+            return;
         }
 
         // Check IP whitelist if enabled

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.fourz.rvnkcore.api.config.ApiConfig;
 import org.fourz.rvnkcore.api.model.response.ApiResponse;
+import org.fourz.rvnkcore.api.ratelimit.RateLimiter;
 import org.fourz.rvnkcore.api.util.ApiUtils;
 import org.fourz.rvnkcore.util.log.LogManager;
 import org.bukkit.plugin.Plugin;
@@ -25,6 +26,8 @@ public class AuthFilter implements Filter {
     private final LogManager logger;
     private final boolean ipWhitelistEnabled;
     private final Gson gson;
+    /** Per-IP throttle (#1043); null when disabled via config. */
+    private final RateLimiter rateLimiter;
 
     /**
      * Creates an AuthFilter with API key authentication.
@@ -48,6 +51,16 @@ public class AuthFilter implements Filter {
         } else {
             logger.info("IP whitelist disabled - allowing all IPs");
         }
+
+        // Per-IP throttling (#1043)
+        if (config.isRateLimitEnabled()) {
+            int perMinute = config.getRateLimitRequestsPerMinute();
+            this.rateLimiter = RateLimiter.forRequestsPerMinute(perMinute);
+            logger.info("API rate limiting enabled - " + perMinute + " requests/minute per IP");
+        } else {
+            this.rateLimiter = null;
+            logger.info("API rate limiting disabled");
+        }
     }
 
     @Override
@@ -67,6 +80,15 @@ public class AuthFilter implements Filter {
         // Health endpoint is public — allow unauthenticated probes (Caddy, uptime monitors)
         if (requestURI.endsWith("/v1/health") || requestURI.contains("/v1/health/")) {
             chain.doFilter(request, response);
+            return;
+        }
+
+        // Per-IP throttling (#1043). Deliberately runs BEFORE the whitelist and API-key
+        // checks so an unauthenticated flood — including API-key brute-forcing — is
+        // throttled too. The health endpoint returns above and is never throttled.
+        if (rateLimiter != null && !rateLimiter.isAllowed(clientIP)) {
+            logger.warning("API rate limit exceeded for IP: " + clientIP + " on " + method + " " + requestURI);
+            sendRateLimited(httpResponse);
             return;
         }
 
@@ -102,6 +124,18 @@ public class AuthFilter implements Filter {
         
         // Authentication successful, continue with request
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Sends a 429 using the canonical ApiResponse envelope (#1043).
+     */
+    private void sendRateLimited(HttpServletResponse response) throws IOException {
+        response.setStatus(429);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setHeader("Retry-After", "60");
+        response.getWriter().write(gson.toJson(
+                ApiResponse.error("RATE_LIMITED", "Too many requests.")));
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthFilter.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Authentication filter for RVNKCore API endpoints.
@@ -28,6 +29,39 @@ public class AuthFilter implements Filter {
     private final Gson gson;
     /** Per-IP throttle (#1043); null when disabled via config. */
     private final RateLimiter rateLimiter;
+
+    /** Minimum gap between rate-limit warnings for the same IP. */
+    private static final long RATE_LIMIT_WARN_INTERVAL_MS = 60_000L;
+    /** Cap on tracked IPs before stale warn-state is pruned. */
+    private static final int RATE_LIMIT_WARN_MAX_TRACKED = 10_000;
+
+    /*
+     * Rate-limit state is deliberately STATIC and shared across every AuthFilter instance.
+     *
+     * AuthFilter is constructed in two places: once by ServletFactory for the fixed API
+     * paths, and again by ServletRegistrationServiceImpl for *each* dynamically registered
+     * servlet path. Per-instance state would therefore mean:
+     *   - the limit is not global — a caller spread across N registered paths would get
+     *     N x the configured allowance;
+     *   - warn state fragments, so a single flood logs once per filter instance;
+     *   - every instance leaks a RateLimiter-Cleanup daemon thread, since the filter has
+     *     no lifecycle hook that shuts its limiter down.
+     * Sharing one limiter across instances fixes all three.
+     */
+    /**
+     * Marks a request as already rate-limit-checked. A single HTTP request can traverse more
+     * than one AuthFilter instance (ServletFactory registers one for the fixed paths and
+     * ServletRegistrationServiceImpl registers another per servlet path), and without this
+     * guard each pass would consume another token from the shared bucket — halving the
+     * effective limit on any double-filtered path. One request must cost exactly one token.
+     */
+    private static final String RATE_LIMIT_CHECKED_ATTR = "org.fourz.rvnkcore.rateLimitChecked";
+
+    private static final Object RATE_LIMITER_LOCK = new Object();
+    private static RateLimiter sharedRateLimiter;
+    private static int sharedRateLimitPerMinute;
+    /** Per-IP warn state: {lastWarnMs, suppressedSinceWarn, suppressedToReport}. */
+    private static final ConcurrentHashMap<String, long[]> rateLimitWarnState = new ConcurrentHashMap<>();
 
     /**
      * Creates an AuthFilter with API key authentication.
@@ -52,14 +86,33 @@ public class AuthFilter implements Filter {
             logger.info("IP whitelist disabled - allowing all IPs");
         }
 
-        // Per-IP throttling (#1043)
+        // Per-IP throttling (#1043) — shared across all AuthFilter instances.
         if (config.isRateLimitEnabled()) {
             int perMinute = config.getRateLimitRequestsPerMinute();
-            this.rateLimiter = RateLimiter.forRequestsPerMinute(perMinute);
-            logger.info("API rate limiting enabled - " + perMinute + " requests/minute per IP");
+            this.rateLimiter = acquireSharedRateLimiter(perMinute);
+            logger.info("API rate limiting enabled - " + perMinute + " requests/minute per IP (shared)");
         } else {
             this.rateLimiter = null;
             logger.info("API rate limiting disabled");
+        }
+    }
+
+    /**
+     * Returns the process-wide {@link RateLimiter}, creating it on first use and replacing
+     * it only when the configured limit changes (e.g. across a config reload). The previous
+     * limiter is shut down on replacement so its cleanup thread does not leak.
+     */
+    private static RateLimiter acquireSharedRateLimiter(int perMinute) {
+        synchronized (RATE_LIMITER_LOCK) {
+            if (sharedRateLimiter == null || sharedRateLimitPerMinute != perMinute) {
+                if (sharedRateLimiter != null) {
+                    sharedRateLimiter.shutdown();
+                    rateLimitWarnState.clear();
+                }
+                sharedRateLimiter = RateLimiter.forRequestsPerMinute(perMinute);
+                sharedRateLimitPerMinute = perMinute;
+            }
+            return sharedRateLimiter;
         }
     }
 
@@ -86,10 +139,13 @@ public class AuthFilter implements Filter {
         // Per-IP throttling (#1043). Deliberately runs BEFORE the whitelist and API-key
         // checks so an unauthenticated flood — including API-key brute-forcing — is
         // throttled too. The health endpoint returns above and is never throttled.
-        if (rateLimiter != null && !rateLimiter.isAllowed(clientIP)) {
-            logger.warning("API rate limit exceeded for IP: " + clientIP + " on " + method + " " + requestURI);
-            sendRateLimited(httpResponse);
-            return;
+        if (rateLimiter != null && httpRequest.getAttribute(RATE_LIMIT_CHECKED_ATTR) == null) {
+            httpRequest.setAttribute(RATE_LIMIT_CHECKED_ATTR, Boolean.TRUE);
+            if (!rateLimiter.isAllowed(clientIP)) {
+                warnRateLimited(clientIP, method, requestURI);
+                sendRateLimited(httpResponse);
+                return;
+            }
         }
 
         // Check IP whitelist if enabled
@@ -124,6 +180,47 @@ public class AuthFilter implements Filter {
         
         // Authentication successful, continue with request
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Logs a rate-limit rejection at most once per IP per minute, reporting how many
+     * further rejections were swallowed in the meantime (#1043 follow-up).
+     *
+     * <p>Warning per rejection made the log itself an amplifier: a verification flood of
+     * 1200 requests produced ~548 WARN lines in six seconds. Under a real attack that
+     * buries every other line in the log — the denial-of-service succeeds against the
+     * operator's visibility even though the API held.
+     */
+    private void warnRateLimited(String clientIP, String method, String requestURI) {
+        long now = System.currentTimeMillis();
+
+        // Bound memory against rotating/spoofed source IPs.
+        if (rateLimitWarnState.size() > RATE_LIMIT_WARN_MAX_TRACKED) {
+            rateLimitWarnState.entrySet()
+                    .removeIf(e -> now - e.getValue()[0] > RATE_LIMIT_WARN_INTERVAL_MS);
+        }
+
+        long[] state = rateLimitWarnState.compute(clientIP, (ip, prev) -> {
+            if (prev == null) {
+                return new long[]{now, 0L, 0L};
+            }
+            if (now - prev[0] >= RATE_LIMIT_WARN_INTERVAL_MS) {
+                // Window reopened — emit, and report what was suppressed while it was closed.
+                return new long[]{now, 0L, prev[1]};
+            }
+            // Still inside the window — count it and stay quiet.
+            return new long[]{prev[0], prev[1] + 1L, -1L};
+        });
+
+        if (state[2] < 0) {
+            return;
+        }
+
+        String suppressed = state[2] > 0
+                ? " (" + state[2] + " further rejections suppressed in the previous minute)"
+                : "";
+        logger.warning("API rate limit exceeded for IP: " + clientIP
+                + " on " + method + " " + requestURI + suppressed);
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthPathPatterns.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthPathPatterns.java
@@ -1,0 +1,62 @@
+package org.fourz.rvnkcore.api.security;
+
+import java.util.List;
+
+/**
+ * The URL patterns that receive a blanket {@link AuthFilter} mapping at server startup.
+ *
+ * <p>Two independent code paths attach {@code AuthFilter}: {@code ServletFactory} registers
+ * this blanket list once, and {@code ServletRegistrationServiceImpl} adds a per-path filter
+ * for every dynamically registered path declaring {@code requireAuth}. Their coverage
+ * intersects — any dynamic path under {@code /v1/} is filtered twice (#1551).</p>
+ *
+ * <p>#1547 made that duplication harmless at runtime via a request-scoped guard in
+ * {@code AuthFilter}, but the overlap itself was invisible: nothing reported that a path was
+ * already covered. It cost real debugging time when the rate limiter appeared to enforce half
+ * its configured value on the three affected paths. Centralising the patterns here lets the
+ * registration service detect the overlap and say so.</p>
+ *
+ * <p><strong>The blanket mapping is the safe default and must stay.</strong> Removing it in
+ * favour of per-path registration alone would leave any path that is never explicitly
+ * registered <em>silently unauthenticated</em> — trading a logging problem for a security
+ * hole.</p>
+ */
+public final class AuthPathPatterns {
+
+    /** Patterns blanket-mapped to the shared AuthFilter by {@code ServletFactory}. */
+    public static final List<String> BLANKET_PATTERNS = List.of(
+            "/v1/*",
+            "/bartershops/*",
+            "/lore/*",
+            "/rvnkworlds/*",
+            "/docs/*"
+    );
+
+    private AuthPathPatterns() {
+        // constants holder
+    }
+
+    /**
+     * Whether a servlet path spec already receives auth from a blanket mapping.
+     *
+     * @param pathSpec a servlet path spec, e.g. {@code /v1/events/*}
+     * @return the covering blanket pattern, or {@code null} if none covers it
+     */
+    public static String coveringPattern(String pathSpec) {
+        if (pathSpec == null || pathSpec.isEmpty()) {
+            return null;
+        }
+        for (String pattern : BLANKET_PATTERNS) {
+            // Only prefix patterns ("/v1/*") can cover a nested path; an exact-match mapping
+            // covers nothing but itself, which the servlet container already dedupes.
+            if (!pattern.endsWith("/*")) {
+                continue;
+            }
+            String prefix = pattern.substring(0, pattern.length() - 1); // "/v1/*" -> "/v1/"
+            if (pathSpec.startsWith(prefix)) {
+                return pattern;
+            }
+        }
+        return null;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
@@ -15,6 +15,7 @@ import org.fourz.rvnkcore.api.controller.LoreController;
 import org.fourz.rvnkcore.api.controller.NotificationController;
 import org.fourz.rvnkcore.api.controller.RVNKWorldsController;
 import org.fourz.rvnkcore.api.controller.PlayerController;
+import org.fourz.rvnkcore.api.controller.WebUIAccessController;
 import org.fourz.rvnkcore.api.controller.WhitelistController;
 import org.fourz.rvnkcore.api.controller.WorldController;
 import org.fourz.rvnkcore.api.docs.OpenApiHandler;
@@ -23,6 +24,9 @@ import org.fourz.rvnkcore.api.service.PlayerService;
 import org.fourz.rvnkcore.api.service.PlayerWorldService;
 import org.fourz.rvnkcore.api.service.PushSubscriptionService;
 import org.fourz.rvnkcore.api.service.WorldService;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.database.connection.ConnectionProvider;
+import org.fourz.rvnkcore.database.repository.WebUIAccessRepository;
 import org.fourz.rvnkcore.util.log.LogManager;
 import org.bukkit.plugin.Plugin;
 import java.util.EnumSet;
@@ -140,6 +144,9 @@ public class ServletFactory {
         // Whitelist management
         registerWhitelistController(context);
 
+        // WebUI access logging
+        registerWebUIAccessController(context);
+
         // Plugin controllers — registered if their API service is available in ServiceRegistry
         registerBarterShopsController(context);
         registerLoreController(context);
@@ -183,6 +190,34 @@ public class ServletFactory {
         NotificationController controller = new NotificationController(null, gson, notifLogger);
         context.addServlet(new ServletHolder(controller), "/v1/notifications/*");
         logger.debug("Notification API controller registered at /v1/notifications/*");
+    }
+
+    /**
+     * Registers the WebUIAccessController for WebUI access logging at {@code /v1/webui/*}.
+     *
+     * <p>The controller is constructed with a {@link WebUIAccessRepository} backed by the shared
+     * {@link ConnectionProvider}. The provider is registered in the ServiceRegistry by
+     * {@code CoreServiceFactory} before the API server starts, so it is resolvable here via
+     * {@link RVNKCore#getServiceSafe(Class)} (null-safe; bypasses the {@code coreInitialized}
+     * flag which is still false during API startup). Mirrors how {@code CoreServiceFactory}
+     * builds sibling repositories: {@code new XxxRepository(connectionProvider, plugin)}.</p>
+     */
+    private void registerWebUIAccessController(ServletContextHandler context) {
+        try {
+            ConnectionProvider connectionProvider = RVNKCore.getServiceSafe(ConnectionProvider.class);
+            if (connectionProvider == null) {
+                logger.warning("WebUIAccess API controller not registered: ConnectionProvider unavailable");
+                return;
+            }
+            LogManager controllerLogger = LogManager.getInstance(plugin, WebUIAccessController.class);
+            WebUIAccessRepository repository = new WebUIAccessRepository(connectionProvider, plugin);
+            WebUIAccessController controller = new WebUIAccessController(repository, gson, controllerLogger);
+            context.addServlet(new ServletHolder(controller), "/v1/webui/*");
+            logger.debug("WebUIAccess API controller registered at /v1/webui/*");
+        } catch (Throwable e) {
+            logger.warning("WebUIAccess API controller not registered: "
+                    + e.getClass().getName() + ": " + e.getMessage());
+        }
     }
 
     private void registerWhitelistController(ServletContextHandler context) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
@@ -106,13 +106,14 @@ public class ServletFactory {
             registerCorsFilter(context);
         }
 
-        // Add authentication filter for all API endpoints (single shared instance)
+        // Add authentication filter for all API endpoints (single shared instance).
+        // Patterns live in AuthPathPatterns so ServletRegistrationServiceImpl can detect when a
+        // dynamically registered path is already covered here and warn instead of silently
+        // double-registering (#1551).
         FilterHolder authHolder = new FilterHolder(new AuthFilter(config, plugin, gson));
-        context.addFilter(authHolder, "/v1/*", null);
-        context.addFilter(authHolder, "/bartershops/*", null);
-        context.addFilter(authHolder, "/lore/*", null);
-        context.addFilter(authHolder, "/rvnkworlds/*", null);
-        context.addFilter(authHolder, "/docs/*", null);
+        for (String pattern : org.fourz.rvnkcore.api.security.AuthPathPatterns.BLANKET_PATTERNS) {
+            context.addFilter(authHolder, pattern, null);
+        }
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
@@ -49,4 +49,13 @@ public interface ILoreApiService {
 
     /** Roll a weighted item from an RNG pool; {@code requestBody} may carry {"rarityTier": "..."}. */
     CompletableFuture<ApiResponse<?>> rollPool(String poolId, String requestBody);
+
+    /**
+     * Mint a single lore item from a JSON body (#1517) — the write verb for the item surface.
+     * Body: {material, name, itemType?, rarity?, lore?[], pages?[], enchantments?{ns:lvl},
+     * enchantmentTier?, glow?, customModelData?, description?, createdBy?}. Creates a lore_entry
+     * (type ITEM) + lore_item, returning the created item in the same shape as {@link #getItemById}.
+     * Auth-gated by the existing AuthFilter on POST, same as {@link #submitEntry}/{@link #rollPool}.
+     */
+    CompletableFuture<ApiResponse<?>> createItem(String requestBody);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
@@ -58,4 +58,18 @@ public interface ILoreApiService {
      * Auth-gated by the existing AuthFilter on POST, same as {@link #submitEntry}/{@link #rollPool}.
      */
     CompletableFuture<ApiResponse<?>> createItem(String requestBody);
+
+    // ── Versioned item write surface (#1528) ─────────────────────────────────────
+
+    /** Update an item as a new version (PUT /lore/items/{id}); re-materializes the current instance. */
+    CompletableFuture<ApiResponse<?>> updateItem(String id, String requestBody);
+
+    /** Delete an item (DELETE /lore/items/{id}); {@code hard=false} soft-archives, {@code true} purges. */
+    CompletableFuture<ApiResponse<?>> deleteItem(String id, boolean hard);
+
+    /** Version history for an item (GET /lore/items/{id}/versions). */
+    CompletableFuture<ApiResponse<?>> getItemVersions(String id);
+
+    /** Roll an item back to a prior version (POST /lore/items/{id}/rollback, body {"version":N}). */
+    CompletableFuture<ApiResponse<?>> rollbackItem(String id, String requestBody);
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
@@ -45,6 +45,16 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
     
     // Reference to the servlet context (set when server starts)
     private volatile ServletContextHandler servletContext;
+
+    /**
+     * One AuthFilter reused across every authenticated registration (#1547).
+     *
+     * <p>Previously a new instance was built per path, which multiplied the filter's
+     * internal state — most visibly the rate limiter, whose cleanup thread then leaked
+     * once per registration. Every instance is constructed from the same {@link ApiConfig},
+     * so a single shared instance is equivalent and cheaper.
+     */
+    private volatile AuthFilter sharedAuthFilter;
     
     // Server running state
     private volatile boolean serverRunning = false;
@@ -199,8 +209,26 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
     }
 
     /**
+     * Returns the shared {@link AuthFilter}, creating it on first authenticated
+     * registration (#1547).
+     */
+    private AuthFilter authFilter() {
+        AuthFilter filter = sharedAuthFilter;
+        if (filter == null) {
+            synchronized (this) {
+                filter = sharedAuthFilter;
+                if (filter == null) {
+                    filter = new AuthFilter(config, plugin, gson);
+                    sharedAuthFilter = filter;
+                }
+            }
+        }
+        return filter;
+    }
+
+    /**
      * Applies a single servlet registration to the context.
-     * When requireAuth is true, an AuthFilter is added for the servlet's path.
+     * When requireAuth is true, the shared AuthFilter is added for the servlet's path.
      */
     private boolean applyRegistration(String pathSpec, ServletRegistration registration) {
         try {
@@ -210,8 +238,7 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
             servletContext.addServlet(holder, pathSpec);
 
             if (registration.requireAuth()) {
-                AuthFilter authFilter = new AuthFilter(config, plugin, gson);
-                FilterHolder filterHolder = new FilterHolder(authFilter);
+                FilterHolder filterHolder = new FilterHolder(authFilter());
                 filterHolder.setName("auth_" + registration.displayName() + "_" + pathSpec.hashCode());
                 servletContext.addFilter(filterHolder, pathSpec,
                         EnumSet.of(DispatcherType.REQUEST, DispatcherType.ASYNC));

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
@@ -238,6 +238,18 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
             servletContext.addServlet(holder, pathSpec);
 
             if (registration.requireAuth()) {
+                // The blanket mapping in ServletFactory already covers everything under /v1/ and
+                // friends, so this registration is redundant for those paths. It is harmless —
+                // #1547's request-scoped guard means one authentication and one rate-limit token
+                // per request either way — but the overlap was previously invisible and cost real
+                // debugging time. Say so rather than registering silently (#1551).
+                String covering = org.fourz.rvnkcore.api.security.AuthPathPatterns.coveringPattern(pathSpec);
+                if (covering != null) {
+                    logger.warning("Auth filter for " + pathSpec + " is redundant: already covered by"
+                            + " the blanket mapping " + covering + " (#1551). Registering anyway —"
+                            + " harmless, but the duplicate mapping is intentional to document.");
+                }
+
                 FilterHolder filterHolder = new FilterHolder(authFilter());
                 filterHolder.setName("auth_" + registration.displayName() + "_" + pathSpec.hashCode());
                 servletContext.addFilter(filterHolder, pathSpec,

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/config/ConfigLoader.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/config/ConfigLoader.java
@@ -365,7 +365,10 @@ public class ConfigLoader {
                 .username(coreConfig.getString("database.mysql.username", ""))
                 .password(coreConfig.getString("database.mysql.password", ""))
                 .useSSL(coreConfig.getBoolean("database.mysql.useSSL", true))
-                .connectionParameters(coreConfig.getString("database.mysql.connectionParameters", ""))
+                // Safety parameters (socketTimeout/connectTimeout/tcpKeepAlive) are merged in
+                // at code level so a fresh deployment cannot come up without them (#1546).
+                .connectionParameters(DatabaseConfig.withRequiredMySqlParams(
+                        coreConfig.getString("database.mysql.connectionParameters", "")))
                 // Connection Pool Configuration
                 .maxConnections(coreConfig.getInt("database.mysql.pool.maxConnections", 20))
                 .minIdleConnections(coreConfig.getInt("database.mysql.pool.minIdleConnections", 5))

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/config/DatabaseConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/config/DatabaseConfig.java
@@ -83,6 +83,59 @@ public class DatabaseConfig {
     public String getPassword() { return password; }
     public boolean isUseSSL() { return useSSL; }
     public String getConnectionParameters() { return connectionParameters; }
+
+    /**
+     * JDBC parameters that must always be present on a MySQL connection, in order (#1546).
+     * <p>RVNKCore's MySQL is cross-host on every environment. Without {@code socketTimeout}
+     * the driver blocks forever on a read from a dropped or stalled connection, HikariCP
+     * cannot reclaim it, and the pool degrades until exhaustion — leak detection logs the
+     * leak but does not recover it.
+     */
+    private static final String[][] REQUIRED_MYSQL_PARAMS = {
+            {"socketTimeout", "30000"},
+            {"connectTimeout", "10000"},
+            {"tcpKeepAlive", "true"},
+    };
+
+    /**
+     * Merges the required MySQL safety parameters into a configured parameter string,
+     * preserving any value the operator has already set explicitly (#1546).
+     *
+     * <p>Applied as a code-level default so a fresh deployment is safe without manual
+     * config editing. Every environment previously had to be patched by hand, which is
+     * how RVNK Dev ended up running for months without a socket timeout.
+     *
+     * @param configured the raw {@code connectionParameters} value; may be null or empty
+     * @return the parameter string with any missing required parameters appended
+     */
+    public static String withRequiredMySqlParams(String configured) {
+        String params = (configured == null) ? "" : configured.trim();
+        StringBuilder merged = new StringBuilder(params);
+        for (String[] param : REQUIRED_MYSQL_PARAMS) {
+            if (!hasParam(params, param[0])) {
+                if (merged.length() > 0) {
+                    merged.append('&');
+                }
+                merged.append(param[0]).append('=').append(param[1]);
+            }
+        }
+        return merged.toString();
+    }
+
+    /** True when {@code key=} appears as a parameter name (not inside another value). */
+    private static boolean hasParam(String params, String key) {
+        if (params.isEmpty()) {
+            return false;
+        }
+        for (String pair : params.split("&")) {
+            int eq = pair.indexOf('=');
+            String name = (eq >= 0) ? pair.substring(0, eq) : pair;
+            if (name.trim().equalsIgnoreCase(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
     public int getMaxConnections() { return maxConnections; }
     public int getMinIdleConnections() { return minIdleConnections; }
     public long getConnectionTimeoutMs() { return connectionTimeoutMs; }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/BaseRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/BaseRepository.java
@@ -115,7 +115,10 @@ public abstract class BaseRepository<T, ID> {
                     try {
                         T entity = mapResultSet(rs);
                         results.add(entity);
-                        logger.debug("Mapped row " + rowCount + " for table " + tableName);
+                        // No per-row success log: volume scales with result-set size and
+                        // synchronous log I/O backpressures the DB worker thread (#1548).
+                        // The summary below reports the count; the catch below names the
+                        // offending row number when a mapping actually fails.
                     } catch (SQLException mapEx) {
                         logger.error("Failed to map result set row " + rowCount + " for table: " + tableName, mapEx);
                         throw mapEx;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/WebUIAccessRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/WebUIAccessRepository.java
@@ -1,0 +1,191 @@
+package org.fourz.rvnkcore.database.repository;
+
+import org.bukkit.plugin.Plugin;
+import org.fourz.rvnkcore.api.exception.DatabaseException;
+import org.fourz.rvnkcore.api.model.WebUIAccessLogDTO;
+import org.fourz.rvnkcore.database.connection.ConnectionProvider;
+import org.fourz.rvnkcore.database.query.BasicSQLQueryBuilder;
+import org.fourz.rvnkcore.database.schema.DatabaseSetup;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository for WebUI access-log storage.
+ * Table: {@code rvnk_webui_access_log}
+ *
+ * <p>Append-and-query only: rows are inserted per WebUI page visit / login / admin action
+ * and read back through {@link #query}. There are no update or delete paths.</p>
+ *
+ * <p>All operations are async via {@link CompletableFuture}.</p>
+ *
+ * @since 1.5.9
+ */
+public class WebUIAccessRepository {
+
+    /** Hard cap on rows a single query may return. */
+    private static final int MAX_LIMIT = 1000;
+    /** Default row limit when the caller does not specify one. */
+    private static final int DEFAULT_LIMIT = 100;
+
+    private final ConnectionProvider connectionProvider;
+    private final LogManager logger;
+    private final String tableName;
+
+    public WebUIAccessRepository(ConnectionProvider connectionProvider, Plugin plugin) {
+        this.connectionProvider = connectionProvider;
+        this.logger = LogManager.getInstance(plugin, getClass());
+
+        // Apply the configured table prefix via DatabaseSetup's helper (matches sibling repos).
+        DatabaseSetup dbSetup = new DatabaseSetup(connectionProvider, plugin);
+        this.tableName = dbSetup.table(DatabaseSetup.TABLE_WEBUI_ACCESS_LOG);
+    }
+
+    /**
+     * Inserts a new access-log row and returns its generated primary key.
+     *
+     * @param dto the log entry (created_at defaults to the DB clock)
+     * @return CompletableFuture of the generated id, or {@code null} if no key was returned
+     */
+    public CompletableFuture<Long> insert(WebUIAccessLogDTO dto) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "INSERT INTO " + tableName
+                    + " (ign, uuid, ip_address, country_code, page_path, action_type)"
+                    + " VALUES (?, ?, ?, ?, ?, ?)";
+            try (Connection conn = connectionProvider.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                stmt.setString(1, dto.getIgn());
+                stmt.setString(2, dto.getUuid());
+                stmt.setString(3, dto.getIpAddress());
+                stmt.setString(4, dto.getCountryCode());
+                stmt.setString(5, dto.getPagePath());
+                stmt.setString(6, dto.getActionType());
+                stmt.executeUpdate();
+
+                try (ResultSet keys = stmt.getGeneratedKeys()) {
+                    if (keys.next()) {
+                        return keys.getLong(1);
+                    }
+                }
+                return null;
+            } catch (SQLException e) {
+                logger.error("Failed to insert webui access log", e);
+                throw new DatabaseException("WebUI access log insert failed", e);
+            }
+        });
+    }
+
+    /**
+     * Queries access-log rows with optional filters, ordered by {@code created_at DESC}.
+     *
+     * @param ign         optional exact IGN filter (null/blank = ignored)
+     * @param countryCode optional exact country-code filter (null/blank = ignored)
+     * @param actionType  optional exact action-type filter (null/blank = ignored)
+     * @param from        optional inclusive lower bound on created_at (ISO datetime string)
+     * @param to          optional inclusive upper bound on created_at (ISO datetime string)
+     * @param limit       max rows (clamped to 1..{@value #MAX_LIMIT}; {@value #DEFAULT_LIMIT} if <= 0)
+     * @return CompletableFuture of a {@link QueryResult} holding the page and the total match count
+     */
+    public CompletableFuture<QueryResult> query(String ign, String countryCode, String actionType,
+                                                String from, String to, int limit) {
+        final int safeLimit = clampLimit(limit);
+        return CompletableFuture.supplyAsync(() -> {
+            List<String> conditions = new ArrayList<>();
+            List<Object> params = new ArrayList<>();
+            if (ign != null && !ign.isBlank()) { conditions.add("ign = ?"); params.add(ign); }
+            if (countryCode != null && !countryCode.isBlank()) { conditions.add("country_code = ?"); params.add(countryCode); }
+            if (actionType != null && !actionType.isBlank()) { conditions.add("action_type = ?"); params.add(actionType); }
+            if (from != null && !from.isBlank()) { conditions.add("created_at >= ?"); params.add(from); }
+            if (to != null && !to.isBlank()) { conditions.add("created_at <= ?"); params.add(to); }
+            String whereClause = conditions.isEmpty() ? null : String.join(" AND ", conditions);
+
+            // #1471: BasicSQLQueryBuilder is stateful and single-use — instantiate a FRESH one here
+            // (per-lambda), never as a shared field. A second fresh instance is used for the count.
+            BasicSQLQueryBuilder dataBuilder = new BasicSQLQueryBuilder();
+            dataBuilder.select("*").from(tableName);
+            if (whereClause != null) {
+                dataBuilder.where(whereClause);
+            }
+            dataBuilder.orderBy("created_at", false).limit(safeLimit);
+            String dataSql = dataBuilder.build();
+
+            BasicSQLQueryBuilder countBuilder = new BasicSQLQueryBuilder();
+            countBuilder.select("COUNT(*)").from(tableName);
+            if (whereClause != null) {
+                countBuilder.where(whereClause);
+            }
+            String countSql = countBuilder.build();
+
+            List<WebUIAccessLogDTO> data = new ArrayList<>();
+            long total = 0L;
+            try (Connection conn = connectionProvider.getConnection()) {
+                try (PreparedStatement stmt = conn.prepareStatement(dataSql)) {
+                    for (int i = 0; i < params.size(); i++) {
+                        stmt.setObject(i + 1, params.get(i));
+                    }
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        while (rs.next()) {
+                            data.add(mapResultSet(rs));
+                        }
+                    }
+                }
+                try (PreparedStatement stmt = conn.prepareStatement(countSql)) {
+                    for (int i = 0; i < params.size(); i++) {
+                        stmt.setObject(i + 1, params.get(i));
+                    }
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        if (rs.next()) {
+                            total = rs.getLong(1);
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to query webui access logs", e);
+                throw new DatabaseException("WebUI access log query failed", e);
+            }
+            return new QueryResult(data, total);
+        });
+    }
+
+    private WebUIAccessLogDTO mapResultSet(ResultSet rs) throws SQLException {
+        WebUIAccessLogDTO dto = new WebUIAccessLogDTO();
+        dto.setId(rs.getLong("id"));
+        dto.setIgn(rs.getString("ign"));
+        dto.setUuid(rs.getString("uuid"));
+        dto.setIpAddress(rs.getString("ip_address"));
+        dto.setCountryCode(rs.getString("country_code"));
+        dto.setPagePath(rs.getString("page_path"));
+        dto.setActionType(rs.getString("action_type"));
+        dto.setCreatedAt(rs.getTimestamp("created_at"));
+        return dto;
+    }
+
+    private static int clampLimit(int limit) {
+        int effective = limit <= 0 ? DEFAULT_LIMIT : limit;
+        return Math.max(1, Math.min(effective, MAX_LIMIT));
+    }
+
+    /**
+     * Result of a {@link #query} call: the page of rows plus the total match count
+     * (ignoring the limit).
+     */
+    public static final class QueryResult {
+        private final List<WebUIAccessLogDTO> data;
+        private final long total;
+
+        public QueryResult(List<WebUIAccessLogDTO> data, long total) {
+            this.data = data;
+            this.total = total;
+        }
+
+        public List<WebUIAccessLogDTO> getData() { return data; }
+        public long getTotal() { return total; }
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
@@ -789,6 +789,69 @@ public class DatabaseSetup {
             }
         }
 
+        // Migration 8: Add holiday_key column to announcements table, and register the
+        // 'holiday' announcement type (#1575 Phase 1).
+        //
+        // NOTE for anyone extending this: the guard below is `columnExists`, which is correct for
+        // ADD COLUMN and WRONG for widening one. A migration that tries to widen an existing
+        // column is a silent no-op here, because columnExists already returns true. This feature
+        // only ever needs ADD COLUMN, which is part of why it was chosen over widening
+        // recurrence_date (#1561).
+        if (!columnExists(connection, announcementsTable, "holiday_key")) {
+            logger.info("Adding 'holiday_key' column to " + announcementsTable);
+            try (var stmt = connection.createStatement()) {
+                if ("MySQL".equalsIgnoreCase(databaseType)) {
+                    stmt.execute("ALTER TABLE " + announcementsTable
+                        + " ADD COLUMN holiday_key VARCHAR(32) NULL");
+                } else {
+                    stmt.execute("ALTER TABLE " + announcementsTable
+                        + " ADD COLUMN holiday_key TEXT NULL");
+                }
+                logger.info("Successfully added 'holiday_key' column");
+            } catch (SQLException e) {
+                logger.warning("Failed to add holiday_key column: " + e.getMessage());
+            }
+
+            // Index for findByHolidayKey, which backs the duplicate-preset check on create.
+            try (var stmt = connection.createStatement()) {
+                String prefix = getTablePrefix().isEmpty() ? "" : getTablePrefix();
+                stmt.execute("CREATE INDEX IF NOT EXISTS idx_" + prefix
+                    + "announcements_holiday_key ON " + announcementsTable + "(holiday_key)");
+                logger.info("Created index on holiday_key");
+            } catch (SQLException e) {
+                logger.warning("Failed to create holiday_key index: " + e.getMessage());
+            }
+        }
+
+        // Register the 'holiday' type. GET /v1/announcements/types reads this TABLE, not an enum,
+        // so without this row Holiday never appears as a choice in game or on the web and the
+        // whole feature is invisible. Guarded on row presence rather than columnExists, and kept
+        // outside the column guard above so a partially-applied migration still self-heals.
+        String holidayTypesTable = table(TABLE_ANNOUNCEMENT_TYPES);
+        try (var check = connection.prepareStatement(
+                "SELECT 1 FROM " + holidayTypesTable + " WHERE id = ?")) {
+            check.setString(1, "holiday");
+            try (var rs = check.executeQuery()) {
+                if (!rs.next()) {
+                    try (var insert = connection.prepareStatement(
+                            "INSERT INTO " + holidayTypesTable
+                            + " (id, name, prefix, permission, active, display_context) "
+                            + "VALUES (?, ?, ?, ?, ?, ?)")) {
+                        insert.setString(1, "holiday");
+                        insert.setString(2, "Holiday");
+                        insert.setString(3, "&6[Holiday]&r ");
+                        insert.setString(4, "rvnktools.announce.holiday");
+                        insert.setBoolean(5, true);
+                        insert.setString(6, "both");
+                        insert.executeUpdate();
+                        logger.info("Registered 'holiday' announcement type");
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            logger.warning("Failed to register 'holiday' announcement type: " + e.getMessage());
+        }
+
         logger.debug("Database migrations completed");
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/schema/DatabaseSetup.java
@@ -37,6 +37,7 @@ public class DatabaseSetup {
     public static final String TABLE_ANNOUNCEMENT_TYPES = "rvnk_announcement_types";
     public static final String TABLE_SCHEMA_VERSION = "rvnk_schema_version";
     public static final String TABLE_PUSH_SUBSCRIPTIONS = "rvnk_push_subscriptions";
+    public static final String TABLE_WEBUI_ACCESS_LOG = "rvnk_webui_access_log";
 
     public DatabaseSetup(ConnectionProvider connectionProvider, Plugin plugin) {
         this.connectionProvider = connectionProvider;
@@ -189,6 +190,7 @@ public class DatabaseSetup {
         String notificationChannelsTable = table(TABLE_PLAYER_NOTIFICATION_CHANNELS);
         String preferenceDefaultsTable = table(TABLE_PREFERENCE_DEFAULTS);
         String pushSubscriptionsTable = table(TABLE_PUSH_SUBSCRIPTIONS);
+        String webuiAccessLogTable = table(TABLE_WEBUI_ACCESS_LOG);
 
         String createPlayersTable;
         String createPlayerWorldDataTable;
@@ -200,6 +202,7 @@ public class DatabaseSetup {
         String createNotificationChannelsTable;
         String createPreferenceDefaultsTable;
         String createPushSubscriptionsTable;
+        String createWebuiAccessLogTable;
 
         if ("MySQL".equalsIgnoreCase(databaseType)) {
             // MySQL-specific table definitions with proper column types
@@ -363,6 +366,20 @@ public class DatabaseSetup {
                 "INDEX idx_push_player (player_id), " +
                 "UNIQUE INDEX idx_push_endpoint (endpoint(255))" +
                 ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+            createWebuiAccessLogTable = "CREATE TABLE IF NOT EXISTS " + webuiAccessLogTable + " (" +
+                "id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, " +
+                "ign VARCHAR(16) NULL, " +
+                "uuid CHAR(36) NULL, " +
+                "ip_address VARCHAR(45) NOT NULL, " +
+                "country_code CHAR(2) NULL, " +
+                "page_path VARCHAR(255) NOT NULL, " +
+                "action_type VARCHAR(16) NOT NULL DEFAULT 'PAGE_VISIT', " +
+                "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
+                "INDEX idx_webui_access_ign (ign), " +
+                "INDEX idx_webui_access_created_at (created_at), " +
+                "INDEX idx_webui_access_country (country_code)" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
         } else {
             // SQLite table definitions
             createPlayersTable = "CREATE TABLE IF NOT EXISTS " + playersTable + " (" +
@@ -516,6 +533,17 @@ public class DatabaseSetup {
                 "auth_key TEXT NOT NULL, " +
                 "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP" +
                 ")";
+
+            createWebuiAccessLogTable = "CREATE TABLE IF NOT EXISTS " + webuiAccessLogTable + " (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "ign TEXT, " +
+                "uuid TEXT, " +
+                "ip_address TEXT NOT NULL, " +
+                "country_code TEXT, " +
+                "page_path TEXT NOT NULL, " +
+                "action_type TEXT NOT NULL DEFAULT 'PAGE_VISIT', " +
+                "created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP" +
+                ")";
         }
 
         try (var stmt = connection.createStatement()) {
@@ -539,6 +567,8 @@ public class DatabaseSetup {
             stmt.execute(createPreferenceDefaultsTable);
             logger.debug("Creating " + pushSubscriptionsTable + " table...");
             stmt.execute(createPushSubscriptionsTable);
+            logger.debug("Creating " + webuiAccessLogTable + " table...");
+            stmt.execute(createWebuiAccessLogTable);
             logger.debug("All tables created successfully");
         }
     }
@@ -555,6 +585,7 @@ public class DatabaseSetup {
         String notificationTypesTable = table(TABLE_PLAYER_NOTIFICATION_TYPES);
         String notificationChannelsTable = table(TABLE_PLAYER_NOTIFICATION_CHANNELS);
         String preferenceDefaultsTable = table(TABLE_PREFERENCE_DEFAULTS);
+        String webuiAccessLogTable = table(TABLE_WEBUI_ACCESS_LOG);
         String prefix = getTablePrefix().isEmpty() ? "" : getTablePrefix();
 
         String[] indexes;
@@ -615,7 +646,11 @@ public class DatabaseSetup {
                 "CREATE INDEX IF NOT EXISTS idx_" + prefix + "notif_types_plugin_type ON " + notificationTypesTable + "(plugin_id, notification_type)",
                 "CREATE INDEX IF NOT EXISTS idx_" + prefix + "channels_player ON " + notificationChannelsTable + "(player_id)",
                 "CREATE INDEX IF NOT EXISTS idx_" + prefix + "channels_plugin_type ON " + notificationChannelsTable + "(plugin_id, notification_type)",
-                "CREATE INDEX IF NOT EXISTS idx_" + prefix + "defaults_plugin ON " + preferenceDefaultsTable + "(plugin_id)"
+                "CREATE INDEX IF NOT EXISTS idx_" + prefix + "defaults_plugin ON " + preferenceDefaultsTable + "(plugin_id)",
+                // WebUI access log indexes (SQLite only — MySQL uses inline indexes)
+                "CREATE INDEX IF NOT EXISTS idx_" + prefix + "webui_access_ign ON " + webuiAccessLogTable + "(ign)",
+                "CREATE INDEX IF NOT EXISTS idx_" + prefix + "webui_access_created_at ON " + webuiAccessLogTable + "(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_" + prefix + "webui_access_country ON " + webuiAccessLogTable + "(country_code)"
             };
         }
 

--- a/toolkitplugin/src/main/resources/config.yml
+++ b/toolkitplugin/src/main/resources/config.yml
@@ -30,7 +30,11 @@ database:
     username: root
     password: ""
     useSSL: true
-    connectionParameters: allowPublicKeyRetrieval=true
+    # socketTimeout/connectTimeout/tcpKeepAlive are merged in automatically if omitted
+    # (#1546) — RVNKCore's MySQL is typically cross-host, and without a socket timeout a
+    # stalled connection blocks forever and leaks from the pool. Override only if you
+    # know you need different values.
+    connectionParameters: allowPublicKeyRetrieval=true&socketTimeout=30000&connectTimeout=10000&tcpKeepAlive=true
     pool:
       maxConnections: 20
       minIdleConnections: 5


### PR DESCRIPTION
## RVNKCore 1.5.19-alpha — deployed and verified on Dev + Event

### Migration 8 — holiday preset schema (#1577)
Adds `holiday_key VARCHAR(32)` + index, and seeds the `holiday` row into the announcement types table. **That row matters as much as the column** — `GET /v1/announcements/types` reads the table, not an enum, so without it Holiday is invisible everywhere. Guarded on row presence and kept *outside* the column guard so a partial migration self-heals.

### #1597 — repo could not build from a clean clone
`.gitignore` had a bare `docs` pattern, which matches at **any depth** and silently excluded the Java package `org/fourz/rvnkcore/api/docs/`. `ServletFactory` is tracked and imports `OpenApiHandler` at `:21`, so a tracked file had a hard compile dependency on an untracked one — building fine only on machines that happened to have the file on disk, while already shipping in the jar on both servers.

Fixed by negating the source tree rather than anchoring to `/docs`: there is no root-level `docs/` directory, so anchoring would have changed what `metamake` ignores instead of fixing the bug.

### Also included
- #1546 MySQL `socketTimeout` / `connectTimeout` / `tcpKeepAlive` forced into connection params
- #1548 per-row repository logging dropped
- #1551 redundant auth-filter registration now warns at startup, naming the issue
- #1558 corrected reasoning in the access-log comment

### Verified
Both servers report `RVNKCore version 1.5.19-alpha`. Migration 8 confirmed live: `holiday_key` present, `holiday` type served by `/v1/announcements/types`.

### Known follow-up, not in this PR
The committed `OpenApiHandler` is a **32-line stub** returning a hardcoded three-field document. A fuller implementation exists on another machine and has never been tracked. Committed as-is so history has a baseline and reconciliation is a reviewable diff — tracked by #1589.
