### PR TITLE
feat(rvnkcore): /portal command, PortalService management API, and portal SPI (#1857)

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.63-alpha</version>
+    <version>1.5.64-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.65-alpha</version>
+    <version>1.5.66-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.64-alpha</version>
+    <version>1.5.65-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IPortalCommandExtension.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IPortalCommandExtension.java
@@ -1,0 +1,127 @@
+package org.fourz.rvnkcore.api.service;
+
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Extension point that lets another plugin contribute subcommands and listing output to
+ * RVNKCore's {@code /portal} command (#1861).
+ *
+ * <p><b>Why this exists.</b> RVNKCore owns cross-server portals ({@code [server]} sign on a
+ * {@code DIAMOND_BLOCK} frame, targeting another <i>server</i>). RVNKWorlds owns world portals
+ * ({@code [portal]} sign on a {@code LAPIS_BLOCK} frame, targeting another <i>portal</i>). Both
+ * can exist in the same world, often within a few blocks of each other, and an admin has no single
+ * place to ask "what portals are here, of any kind?" — see #1752, closed for exactly this
+ * confusion.</p>
+ *
+ * <p><b>Why it is an SPI and not a command.</b> RVNKWorlds cannot simply declare {@code portal} in
+ * its own {@code plugin.yml} and take over. Commands are resolved through
+ * {@code plugin.getCommand(name)} and must be declared statically; Bukkit's command map awards the
+ * bare label to whichever plugin registers first, and because RVNKWorlds declares
+ * {@code depend: [RVNKCore]} the core always enables first. A second declaration would silently
+ * yield only {@code rvnkworlds:portal}. So RVNKCore keeps the registration permanently and the
+ * override is <i>behavioural</i>: implementations are resolved per invocation, which also means a
+ * plugin can be loaded or unloaded mid-session without leaving {@code /portal} broken.</p>
+ *
+ * <p><b>Direction of travel.</b> RVNKCore never reads the implementor's portal data. The
+ * implementor renders its own portals and RVNKCore never handles a foreign type, so there is no
+ * shared DTO to keep in sync and no second source of truth. Management of <i>cross-server</i>
+ * portals stays in {@code PortalService}, which implementors call directly via
+ * {@code RVNKCore.getServiceSafe(PortalService.class)} rather than reimplementing.</p>
+ *
+ * <p><b>Registration.</b> Register with the RVNKCore {@code ServiceRegistry} on enable and
+ * unregister on disable, alongside the plugin's other core services:</p>
+ *
+ * <pre>{@code
+ * serviceRegistry.registerService(IPortalCommandExtension.class, new MyPortalExtension(this));
+ * }</pre>
+ *
+ * <p><b>Forward compatibility.</b> Every optional method has a default so that adding to this
+ * interface does not break an implementor compiled against an older RVNKCore. Only
+ * {@link #providerName()}, {@link #subcommands()} and
+ * {@link #handle(CommandSender, String, String[])} must be implemented. Implementors are still
+ * expected to be redeployed alongside RVNKCore when the contract changes meaningfully.</p>
+ *
+ * @since 1.5.64
+ */
+public interface IPortalCommandExtension {
+
+    /**
+     * Short name of the plugin providing this extension, e.g. {@code "RVNKWorlds"}.
+     *
+     * <p>Shown by {@code /portal types} and used in diagnostics so an operator can tell which
+     * plugin is answering a given subcommand.</p>
+     *
+     * @return the provider name; never null or blank
+     */
+    String providerName();
+
+    /**
+     * Subcommand names this extension claims, lowercase, without a leading slash.
+     *
+     * <p>RVNKCore's own subcommands always win a collision — a clash is logged as a startup
+     * warning and the claimed name is ignored rather than shadowing core behaviour.</p>
+     *
+     * @return claimed subcommand names; may be empty, never null
+     */
+    List<String> subcommands();
+
+    /**
+     * Executes one of this extension's claimed subcommands.
+     *
+     * <p>Only ever called with a name returned by {@link #subcommands()} that did not collide with
+     * a core subcommand. The extension is responsible for its own permission checks, argument
+     * validation and user messaging, exactly as it would be inside its own command.</p>
+     *
+     * @param sender     who ran the command; may be the console
+     * @param subcommand the claimed subcommand name, already lowercased
+     * @param args       arguments following the subcommand
+     * @return true when handled (including handled-with-an-error-message); false to make
+     *         {@code /portal} fall through to its usage output
+     */
+    boolean handle(CommandSender sender, String subcommand, String[] args);
+
+    /**
+     * Supplies tab completions for one of this extension's claimed subcommands.
+     *
+     * @param sender     who is completing
+     * @param subcommand the claimed subcommand name, already lowercased
+     * @param args       arguments following the subcommand; the last element is the partial token
+     * @return completions, or an empty list
+     */
+    default List<String> tabComplete(CommandSender sender, String subcommand, String[] args) {
+        return List.of();
+    }
+
+    /**
+     * Writes this extension's portals into the output of {@code /portal list}.
+     *
+     * <p>RVNKCore prints the section header (so the {@code WORLD} vs {@code SERVER} labelling stays
+     * consistent regardless of implementor) and then calls this to fill in the rows. The returned
+     * future lets RVNKCore sequence sections rather than interleaving them — complete it only once
+     * the rows have actually been sent, and never block the calling thread waiting for a database.</p>
+     *
+     * @param sender      who to write to
+     * @param worldFilter world name to restrict the listing to, or null for every world
+     * @return a future completing when the rows have been sent; never null
+     */
+    default CompletableFuture<Void> appendListing(CommandSender sender, String worldFilter) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * One-line description of how this extension's portals are recognised in-world — sign header
+     * and accepted frame materials.
+     *
+     * <p>Surfaced by {@code /portal types}. This is the direct answer to the "lapis worlds vs
+     * diamond servers" confusion in #1752: an operator can ask which marker belongs to which
+     * system instead of inferring it.</p>
+     *
+     * @return a human-readable description, or null to omit this extension from {@code types}
+     */
+    default String describe() {
+        return null;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
@@ -1,0 +1,437 @@
+package org.fourz.rvnkcore.command;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.model.PortalDTO;
+import org.fourz.rvnkcore.api.service.IPortalCommandExtension;
+import org.fourz.rvnkcore.service.portal.PortalService;
+import org.fourz.rvnkcore.service.transfer.TransferService;
+import org.fourz.rvnktools.command.manager.BaseCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Administration command for cross-server portals, and the single cross-system view of every
+ * portal on the server (#1859).
+ *
+ * <p>Before this existed, portals could only be managed by standing next to them: creation and
+ * removal were driven entirely by the registration sign, so a portal whose sign had been destroyed
+ * was both invisible and impossible to remove. {@code PortalRepository.listAll()} was implemented
+ * and unreachable.</p>
+ *
+ * <p><b>Ownership.</b> RVNKCore owns this command outright. RVNKWorlds cannot take it over by
+ * declaring {@code portal} in its own {@code plugin.yml} — Bukkit awards the bare label to
+ * whichever plugin registers first and {@code depend: [RVNKCore]} guarantees that is the core, so
+ * a second declaration would silently yield only {@code rvnkworlds:portal}. Instead, other plugins
+ * contribute through {@link IPortalCommandExtension}, resolved <b>per invocation</b> so a plugin
+ * can be loaded or unloaded mid-session without leaving this command broken.</p>
+ *
+ * <p>Console is supported on every subcommand except {@code tp}, which needs a player to move.</p>
+ *
+ * @since 1.5.64
+ */
+public class PortalCommand extends BaseCommand {
+
+    private static final List<String> CORE_SUBCOMMANDS =
+            List.of("list", "info", "delete", "tp", "repair", "reload", "types");
+
+    public PortalCommand(RVNKCore plugin) {
+        super(plugin, "portal",
+                "Cross-server portal administration",
+                "/portal <list|info|delete|tp|repair|reload|types> [args]",
+                "rvnkcore.portal.admin");
+    }
+
+    @Override
+    protected boolean executeCommand(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            showUsage(sender);
+            return true;
+        }
+
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        String[] rest = tail(args);
+
+        switch (sub) {
+            case "list":
+                return handleList(sender, rest);
+            case "info":
+                return handleInfo(sender, rest);
+            case "delete":
+                return handleDelete(sender, rest);
+            case "tp":
+                return handleTp(sender, rest);
+            case "repair":
+                return handleRepair(sender, rest);
+            case "reload":
+                return handleReload(sender);
+            case "types":
+                return handleTypes(sender);
+            default:
+                // Not a core subcommand — offer it to the extension before failing.
+                IPortalCommandExtension extension = extension();
+                if (extension != null && claims(extension, sub)) {
+                    return extension.handle(sender, sub, rest);
+                }
+                showUsage(sender);
+                return true;
+        }
+    }
+
+    // ── Core subcommands ────────────────────────────────────────────────────────
+
+    /**
+     * Lists portals. Cross-server portals come from {@link PortalService}'s in-memory index (safe
+     * on the main thread, and still correct during a database outage); world portals are appended
+     * by the extension when one is registered.
+     */
+    private boolean handleList(CommandSender sender, String[] args) {
+        PortalService service = portalService();
+        if (service == null) {
+            sender.sendMessage(ChatColor.RED + "Portal service is not available.");
+            return true;
+        }
+
+        String worldFilter = null;
+        String typeFilter = null;
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equalsIgnoreCase("--type") && i + 1 < args.length) {
+                typeFilter = args[++i].toLowerCase(Locale.ROOT);
+            } else if (!args[i].startsWith("--")) {
+                worldFilter = args[i];
+            }
+        }
+
+        boolean wantServer = typeFilter == null || typeFilter.equals("server");
+        boolean wantWorld = typeFilter == null || typeFilter.equals("world");
+        if (typeFilter != null && !wantServer && !wantWorld) {
+            sender.sendMessage(ChatColor.RED + "Unknown type '" + typeFilter + "' (expected: server, world).");
+            return true;
+        }
+
+        if (wantServer) {
+            List<PortalDTO> portals = service.listPortalsInWorld(worldFilter);
+            sender.sendMessage(ChatColor.GOLD + "Cross-server portals" + ChatColor.GRAY
+                    + " (" + portals.size() + (worldFilter != null ? " in " + worldFilter : "") + ")");
+            if (portals.isEmpty()) {
+                sender.sendMessage(ChatColor.GRAY + "  none");
+            }
+            for (PortalDTO portal : portals) {
+                PortalService.Verification state = service.verify(portal.getPortalId());
+                sender.sendMessage("  " + ChatColor.DARK_GRAY + "SERVER " + ChatColor.WHITE
+                        + shortId(portal.getPortalId()) + ChatColor.GRAY + "  "
+                        + portal.getWorld() + " " + portal.getX() + "," + portal.getY() + "," + portal.getZ()
+                        + ChatColor.WHITE + "  -> " + portal.getTargetServer()
+                        + "  " + colourFor(state) + state.name().toLowerCase(Locale.ROOT));
+            }
+        }
+
+        if (wantWorld) {
+            IPortalCommandExtension extension = extension();
+            // "no extension" and "no world portals" are different facts. Rendering them the same way
+            // is how an operator concludes there are no world portals when the plugin simply is not
+            // loaded — the #1752 confusion, one level up.
+            if (extension == null) {
+                sender.sendMessage(ChatColor.GOLD + "World portals" + ChatColor.GRAY
+                        + " — unavailable: no portal provider is loaded (RVNKWorlds absent).");
+            } else {
+                sender.sendMessage(ChatColor.GOLD + "World portals" + ChatColor.GRAY
+                        + " (via " + extension.providerName() + ")");
+                extension.appendListing(sender, worldFilter);
+            }
+        }
+        return true;
+    }
+
+    private boolean handleInfo(CommandSender sender, String[] args) {
+        PortalService service = portalService();
+        if (service == null || args.length < 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /portal info <id>");
+            return true;
+        }
+
+        Optional<PortalDTO> found = service.resolvePortal(args[0]);
+        if (found.isEmpty()) {
+            // Could be a world-portal id; say so rather than asserting it does not exist.
+            IPortalCommandExtension extension = extension();
+            sender.sendMessage(ChatColor.RED + "No cross-server portal matches '" + args[0]
+                    + "' (unknown id, or an ambiguous prefix).");
+            if (extension != null) {
+                sender.sendMessage(ChatColor.GRAY + "  It may be a world portal — try "
+                        + ChatColor.WHITE + "/world portal info " + args[0]);
+            }
+            return true;
+        }
+
+        PortalDTO portal = found.get();
+        PortalService.Verification state = service.verify(portal.getPortalId());
+        sender.sendMessage(ChatColor.GOLD + "Portal " + ChatColor.WHITE + portal.getPortalId());
+        sender.sendMessage(ChatColor.GRAY + "  type       " + ChatColor.WHITE + "SERVER (cross-server)");
+        sender.sendMessage(ChatColor.GRAY + "  location   " + ChatColor.WHITE + portal.getWorld()
+                + " " + portal.getX() + "," + portal.getY() + "," + portal.getZ());
+        sender.sendMessage(ChatColor.GRAY + "  target     " + ChatColor.WHITE + portal.getTargetServer());
+        sender.sendMessage(ChatColor.GRAY + "  blocks     " + ChatColor.WHITE
+                + (portal.getPortalBlocks() == null ? 0 : portal.getPortalBlocks().size()));
+        sender.sendMessage(ChatColor.GRAY + "  owner      " + ChatColor.WHITE
+                + (portal.getOwnerUuid() != null ? portal.getOwnerUuid() : "unknown"));
+        sender.sendMessage(ChatColor.GRAY + "  state      " + colourFor(state) + state.name().toLowerCase(Locale.ROOT));
+        if (state == PortalService.Verification.UNVERIFIED) {
+            sender.sendMessage(ChatColor.GRAY + "             world or chunk not loaded — not checked, not broken");
+        } else if (state == PortalService.Verification.ORPHANED) {
+            sender.sendMessage(ChatColor.GRAY + "             trigger block or stamped sign missing; "
+                    + "repair with /portal repair, or remove with /portal delete");
+        }
+        return true;
+    }
+
+    /**
+     * Removes a portal by id. This is the path that makes an orphaned row recoverable at all — the
+     * only other caller of the delete is the sign-break handler, which cannot fire when the sign is
+     * already gone.
+     */
+    private boolean handleDelete(CommandSender sender, String[] args) {
+        PortalService service = portalService();
+        if (service == null || args.length < 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /portal delete <id>");
+            return true;
+        }
+        if (!sender.hasPermission("rvnkcore.portal.delete")) {
+            sender.sendMessage(ChatColor.RED + "You don't have permission to remove portals.");
+            return true;
+        }
+
+        Optional<PortalDTO> found = service.resolvePortal(args[0]);
+        if (found.isEmpty()) {
+            sender.sendMessage(ChatColor.RED + "No cross-server portal matches '" + args[0]
+                    + "' (unknown id, or an ambiguous prefix).");
+            return true;
+        }
+
+        PortalDTO portal = found.get();
+        String id = portal.getPortalId();
+        boolean removed = service.deletePortalById(id);
+        if (removed) {
+            sender.sendMessage(ChatColor.GREEN + "Portal removed: " + ChatColor.WHITE + shortId(id)
+                    + ChatColor.GRAY + " (" + portal.getWorld() + " " + portal.getX() + ","
+                    + portal.getY() + "," + portal.getZ() + " -> " + portal.getTargetServer() + ")");
+            logger.info("Portal " + id + " deleted via /portal by " + sender.getName());
+        } else {
+            sender.sendMessage(ChatColor.RED + "Portal " + shortId(id) + " could not be removed.");
+        }
+        return true;
+    }
+
+    private boolean handleTp(CommandSender sender, String[] args) {
+        PortalService service = portalService();
+        if (service == null || args.length < 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /portal tp <id>");
+            return true;
+        }
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This subcommand must be run by a player.");
+            return true;
+        }
+
+        Optional<PortalDTO> found = service.resolvePortal(args[0]);
+        if (found.isEmpty()) {
+            sender.sendMessage(ChatColor.RED + "No cross-server portal matches '" + args[0] + "'.");
+            return true;
+        }
+
+        PortalDTO portal = found.get();
+        World world = Bukkit.getWorld(portal.getWorld());
+        if (world == null) {
+            sender.sendMessage(ChatColor.RED + "World '" + portal.getWorld() + "' is not loaded.");
+            return true;
+        }
+        // +1 on Y so the player lands on the anchor rather than inside it.
+        player.teleport(new Location(world, portal.getX() + 0.5, portal.getY() + 1, portal.getZ() + 0.5));
+        player.sendMessage(ChatColor.GREEN + "Teleported to portal " + ChatColor.WHITE + shortId(portal.getPortalId()));
+        return true;
+    }
+
+    private boolean handleRepair(CommandSender sender, String[] args) {
+        PortalService service = portalService();
+        if (service == null || args.length < 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /portal repair <id>");
+            return true;
+        }
+
+        Optional<PortalDTO> found = service.resolvePortal(args[0]);
+        if (found.isEmpty()) {
+            sender.sendMessage(ChatColor.RED + "No cross-server portal matches '" + args[0] + "'.");
+            return true;
+        }
+
+        PortalService.PortalResult result =
+                service.repairSign(found.get().getPortalId(), plugin.getService(TransferService.class));
+        sender.sendMessage((result.isSuccess() ? ChatColor.GREEN : ChatColor.RED) + result.message());
+        return true;
+    }
+
+    private boolean handleReload(CommandSender sender) {
+        PortalService service = portalService();
+        if (service == null) {
+            sender.sendMessage(ChatColor.RED + "Portal service is not available.");
+            return true;
+        }
+        // loadIndex() hits the database, so keep it off the main thread; the index itself is on
+        // concurrent maps. The reply hops back to main rather than messaging from the async thread.
+        sender.sendMessage(ChatColor.GRAY + "Reloading portal index...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            service.loadIndex();
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    sender.sendMessage(ChatColor.GREEN + "Portal index reloaded: "
+                            + ChatColor.WHITE + service.getPortalCount() + ChatColor.GREEN + " portal(s)."));
+        });
+        return true;
+    }
+
+    /**
+     * Reports how each portal system is recognised in-world. This is the direct answer to #1752 —
+     * "lapis worlds vs diamond servers" — so an operator can look it up instead of inferring it.
+     */
+    private boolean handleTypes(CommandSender sender) {
+        PortalService service = portalService();
+        sender.sendMessage(ChatColor.GOLD + "Portal systems on this server");
+        if (service != null) {
+            sender.sendMessage(ChatColor.WHITE + "  SERVER " + ChatColor.GRAY + "(RVNKCore) — "
+                    + service.getConfig().getSignHeader() + " sign on a "
+                    + service.getConfig().getTriggerBlock() + " frame; sends you to another server. "
+                    + "Manage with /portal.");
+        }
+        IPortalCommandExtension extension = extension();
+        if (extension == null) {
+            sender.sendMessage(ChatColor.WHITE + "  WORLD  " + ChatColor.GRAY
+                    + "— no provider loaded (RVNKWorlds absent).");
+        } else {
+            String described = extension.describe();
+            sender.sendMessage(ChatColor.WHITE + "  WORLD  " + ChatColor.GRAY + "(" + extension.providerName()
+                    + ") — " + (described != null ? described : "no description provided"));
+        }
+        return true;
+    }
+
+    // ── Tab completion ──────────────────────────────────────────────────────────
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        List<String> out = new ArrayList<>();
+        IPortalCommandExtension extension = extension();
+
+        if (args.length <= 1) {
+            String partial = args.length == 1 ? args[0].toLowerCase(Locale.ROOT) : "";
+            for (String sub : CORE_SUBCOMMANDS) {
+                if (sub.startsWith(partial)) out.add(sub);
+            }
+            if (extension != null) {
+                for (String sub : extension.subcommands()) {
+                    if (sub != null && sub.toLowerCase(Locale.ROOT).startsWith(partial)
+                            && !CORE_SUBCOMMANDS.contains(sub.toLowerCase(Locale.ROOT))) {
+                        out.add(sub);
+                    }
+                }
+            }
+            return out;
+        }
+
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        String[] rest = tail(args);
+
+        if (extension != null && !CORE_SUBCOMMANDS.contains(sub) && claims(extension, sub)) {
+            List<String> fromExtension = extension.tabComplete(sender, sub, rest);
+            return fromExtension != null ? fromExtension : out;
+        }
+
+        PortalService service = portalService();
+        if (service == null) return out;
+
+        if (args.length == 2 && List.of("info", "delete", "tp", "repair").contains(sub)) {
+            String partial = args[1].toLowerCase(Locale.ROOT);
+            for (PortalDTO portal : service.listPortals()) {
+                String id = shortId(portal.getPortalId());
+                if (id.toLowerCase(Locale.ROOT).startsWith(partial)) out.add(id);
+            }
+        } else if (args.length == 2 && sub.equals("list")) {
+            String partial = args[1].toLowerCase(Locale.ROOT);
+            for (World world : Bukkit.getWorlds()) {
+                if (world.getName().toLowerCase(Locale.ROOT).startsWith(partial)) out.add(world.getName());
+            }
+        }
+        return out;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private void showUsage(CommandSender sender) {
+        sender.sendMessage(ChatColor.GRAY + "Usage: " + ChatColor.WHITE + getUsage());
+        sender.sendMessage(ChatColor.GRAY + "  list [world] [--type server|world]  " + ChatColor.DARK_GRAY + "every portal");
+        sender.sendMessage(ChatColor.GRAY + "  info <id>                           " + ChatColor.DARK_GRAY + "details + world state");
+        sender.sendMessage(ChatColor.GRAY + "  delete <id>                         " + ChatColor.DARK_GRAY + "remove, even with no sign");
+        sender.sendMessage(ChatColor.GRAY + "  tp <id>                             " + ChatColor.DARK_GRAY + "teleport to it");
+        sender.sendMessage(ChatColor.GRAY + "  repair <id>                         " + ChatColor.DARK_GRAY + "rewrite + re-stamp its sign");
+        sender.sendMessage(ChatColor.GRAY + "  reload                              " + ChatColor.DARK_GRAY + "reload the index from the DB");
+        sender.sendMessage(ChatColor.GRAY + "  types                               " + ChatColor.DARK_GRAY + "which sign belongs to which system");
+
+        IPortalCommandExtension extension = extension();
+        if (extension != null && !extension.subcommands().isEmpty()) {
+            sender.sendMessage(ChatColor.GRAY + "  via " + extension.providerName() + ": "
+                    + ChatColor.DARK_GRAY + String.join(", ", extension.subcommands()));
+        }
+    }
+
+    /**
+     * Resolves the portal-command extension. Deliberately looked up on every call rather than
+     * cached, so a provider plugin loading or unloading mid-session is picked up immediately and a
+     * stale reference can never outlive it.
+     */
+    private IPortalCommandExtension extension() {
+        return RVNKCore.getServiceSafe(IPortalCommandExtension.class);
+    }
+
+    private PortalService portalService() {
+        return RVNKCore.getServiceSafe(PortalService.class);
+    }
+
+    /** Core subcommands always win a name clash; an extension cannot shadow built-in behaviour. */
+    private boolean claims(IPortalCommandExtension extension, String sub) {
+        if (CORE_SUBCOMMANDS.contains(sub)) {
+            return false;
+        }
+        List<String> claimed = extension.subcommands();
+        if (claimed == null) return false;
+        for (String candidate : claimed) {
+            if (candidate != null && candidate.equalsIgnoreCase(sub)) return true;
+        }
+        return false;
+    }
+
+    private ChatColor colourFor(PortalService.Verification state) {
+        return switch (state) {
+            case VERIFIED -> ChatColor.GREEN;
+            case UNVERIFIED -> ChatColor.YELLOW;
+            case ORPHANED -> ChatColor.RED;
+            case UNKNOWN -> ChatColor.DARK_GRAY;
+        };
+    }
+
+    private String shortId(String portalId) {
+        if (portalId == null) return "";
+        return portalId.length() >= 8 ? portalId.substring(0, 8) : portalId;
+    }
+
+    private String[] tail(String[] args) {
+        if (args.length <= 1) return new String[0];
+        String[] rest = new String[args.length - 1];
+        System.arraycopy(args, 1, rest, 0, rest.length);
+        return rest;
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
@@ -88,12 +88,21 @@ public class PortalSignListener implements Listener {
             String existingId = existingSign.getPersistentDataContainer()
                     .get(portalIdKey, PersistentDataType.STRING);
             if (existingId != null) {
-                portalService.getPortalById(existingId).ifPresent(p -> {
+                Optional<PortalDTO> existing = portalService.getPortalById(existingId);
+                if (existing.isPresent()) {
                     String[] lines = buildDisplayLines(
-                            RVNKCore.getServiceSafe(TransferService.class), p.getTargetServer(), existingId);
+                            RVNKCore.getServiceSafe(TransferService.class),
+                            existing.get().getTargetServer(), existingId);
                     for (int i = 0; i < 4; i++) event.setLine(i, lines[i]);
-                });
-                return;
+                    return;
+                }
+                // Stamp survives but the portal is gone (deleted, rolled back, DB resync). Returning
+                // here would leave the sign inert forever: never re-registerable, never editable.
+                // Drop the stale stamp and fall through so this edit is treated as a fresh sign.
+                existingSign.getPersistentDataContainer().remove(portalIdKey);
+                existingSign.update();
+                logger.debug("Cleared stale portal stamp " + existingId + " from sign at "
+                        + event.getBlock().getLocation() + " — portal no longer registered");
             }
         }
 
@@ -207,6 +216,15 @@ public class PortalSignListener implements Listener {
         PortalConfig config = portalService.getConfig();
 
         Player player = event.getPlayer();
+
+        // A stamp pointing at a portal that no longer exists protects nothing. Blocking the break
+        // would strand an un-removable sign in the world for anyone without delete permission.
+        if (portalService.getPortalById(portalId).isEmpty()) {
+            logger.debug("Sign at " + block.getLocation() + " carried stale portal stamp " + portalId
+                    + " — allowing break, portal is not registered");
+            return;
+        }
+
         if (config != null && !player.hasPermission(config.getPermissionDelete())) {
             event.setCancelled(true);
             player.sendMessage("§cYou don't have permission to remove cross-server portals.");
@@ -214,8 +232,8 @@ public class PortalSignListener implements Listener {
         }
 
         // Remove by the id stamped on the sign: clears all index entries and returns the interior
-        // NETHER_PORTAL blocks to AIR.
-        boolean removed = portalService.deletePortalById(portalId);
+        // NETHER_PORTAL blocks to AIR. The sign is already being destroyed, so skip clearing it.
+        boolean removed = portalService.deletePortalById(portalId, false);
 
         if (removed) {
             player.sendMessage("§aCross-server portal removed.");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
@@ -4,11 +4,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.WallSign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -22,6 +19,7 @@ import org.fourz.rvnkcore.api.config.TransferConfig;
 import org.fourz.rvnkcore.api.model.PortalDTO;
 import org.fourz.rvnkcore.service.portal.PortalFrameBuilder;
 import org.fourz.rvnkcore.service.portal.PortalService;
+import org.fourz.rvnkcore.service.portal.PortalSignWriter;
 import org.fourz.rvnkcore.service.transfer.TransferService;
 import org.fourz.rvnkcore.util.log.LogManager;
 
@@ -49,7 +47,7 @@ import java.util.Optional;
 public class PortalSignListener implements Listener {
 
     /** PersistentDataContainer key storing the portal id on the sign block. */
-    private static final String PORTAL_ID_KEY = "portal_id";
+    private static final String PORTAL_ID_KEY = PortalSignWriter.PORTAL_ID_KEY;
 
     private final RVNKCore plugin;
     private final LogManager logger;
@@ -233,16 +231,7 @@ public class PortalSignListener implements Listener {
      * @return the mounting block, or null when the block is not a sign
      */
     private Block resolveMountBlock(Block signBlock) {
-        BlockData data = signBlock.getBlockData();
-        if (data instanceof WallSign wallSign) {
-            // A wall sign faces outward; the block it is attached to sits behind it.
-            return signBlock.getRelative(wallSign.getFacing().getOppositeFace());
-        }
-        if (data instanceof org.bukkit.block.data.type.Sign) {
-            // A standing sign is mounted on the block directly below it.
-            return signBlock.getRelative(BlockFace.DOWN);
-        }
-        return null;
+        return PortalSignWriter.resolveMountBlock(signBlock);
     }
 
     /**
@@ -255,20 +244,7 @@ public class PortalSignListener implements Listener {
      * @return four legacy-coded sign lines
      */
     private String[] buildDisplayLines(TransferService transferService, String targetServer, String portalId) {
-        TransferConfig.Target tgt = transferService != null
-                ? transferService.getConfig().resolveTarget(targetServer) : null;
-        String display = (tgt != null && tgt.display() != null && !tgt.display().isEmpty())
-                ? tgt.display() : targetServer;
-        String world = (tgt != null && tgt.world() != null && !tgt.world().isEmpty())
-                ? tgt.world() : "";
-        String shortId = (portalId != null && portalId.length() >= 8)
-                ? portalId.substring(0, 8) : (portalId != null ? portalId : "");
-        return new String[]{
-                "§9[server]",
-                "§a" + display,
-                world.isEmpty() ? "" : "§7" + world,
-                "§8" + shortId
-        };
+        return PortalSignWriter.buildDisplayLines(transferService, targetServer, portalId);
     }
 
     /**
@@ -278,13 +254,9 @@ public class PortalSignListener implements Listener {
      * @param portalId  The portal id to store
      */
     private void stampSign(Block signBlock, String portalId) {
-        BlockState state = signBlock.getState();
-        if (!(state instanceof Sign sign)) {
+        if (!PortalSignWriter.stamp(signBlock, portalIdKey, portalId)) {
             logger.warning("Portal sign PDC stamp skipped: block at " + signBlock.getLocation()
                     + " is no longer a sign");
-            return;
         }
-        sign.getPersistentDataContainer().set(portalIdKey, PersistentDataType.STRING, portalId);
-        sign.update();
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
@@ -354,6 +354,13 @@ public class RVNKToolsInitializer {
                 ServerTransferCommand transferCommand = new ServerTransferCommand(plugin);
                 commandManager.registerCommand(transferCommand);
                 logger.info("ServerTransferCommand registered");
+
+                // Cross-server portal administration (/portal). Registered unconditionally: RVNKCore
+                // owns the command and other plugins extend it via IPortalCommandExtension (#1859).
+                org.fourz.rvnkcore.command.PortalCommand portalCommand =
+                        new org.fourz.rvnkcore.command.PortalCommand(plugin);
+                commandManager.registerCommand(portalCommand);
+                logger.info("PortalCommand registered");
             }
 
         } catch (Exception e) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
@@ -42,7 +42,13 @@ public class PortalService {
         DISABLED,
         ALREADY_EXISTS,
         NOT_FOUND,
-        PERSIST_FAILED
+        PERSIST_FAILED,
+        /**
+         * The portal exists but cannot be acted on right now — typically its world or chunk is not
+         * loaded. Distinct from {@link #NOT_FOUND}: the portal is fine, we simply cannot reach it,
+         * so a caller must not treat this as grounds for deleting anything (#1859).
+         */
+        UNAVAILABLE
     }
 
     /**
@@ -335,6 +341,181 @@ public class PortalService {
             logger.info("Portal deleted at " + key);
         }
         return true;
+    }
+
+    /**
+     * Result of checking a registered portal against the actual world (#1859, #1860).
+     *
+     * <p>{@link #UNVERIFIED} is deliberately distinct from {@link #ORPHANED}: a portal in an
+     * unloaded world or chunk cannot be inspected without force-loading it, and reporting
+     * "not currently readable" as "gone" would condemn healthy portals. Callers must treat the two
+     * differently — in particular nothing should ever be auto-deleted on UNVERIFIED.</p>
+     */
+    public enum Verification {
+        /** Trigger block and a correctly-stamped sign are both present. */
+        VERIFIED,
+        /** The world or chunk is not loaded, so the portal could not be checked. */
+        UNVERIFIED,
+        /** The trigger block or the stamped sign is missing — the row no longer matches the world. */
+        ORPHANED,
+        /** No portal is registered under that id. */
+        UNKNOWN
+    }
+
+    /**
+     * Returns every registered portal, ordered by world then coordinates.
+     *
+     * <p>Served from the in-memory index, which is authoritative for runtime lookups, so this is
+     * safe to call on the main thread and keeps working during a database outage.</p>
+     *
+     * @return all registered portals; never null
+     */
+    public List<PortalDTO> listPortals() {
+        List<PortalDTO> portals = new java.util.ArrayList<>(byId.values());
+        portals.sort(java.util.Comparator
+                .comparing(PortalDTO::getWorld, java.util.Comparator.nullsLast(String::compareTo))
+                .thenComparingInt(PortalDTO::getX)
+                .thenComparingInt(PortalDTO::getY)
+                .thenComparingInt(PortalDTO::getZ));
+        return portals;
+    }
+
+    /**
+     * Returns registered portals in one world.
+     *
+     * @param world the world name; null or blank returns every portal
+     * @return matching portals; never null
+     */
+    public List<PortalDTO> listPortalsInWorld(String world) {
+        if (world == null || world.isBlank()) {
+            return listPortals();
+        }
+        List<PortalDTO> portals = new java.util.ArrayList<>();
+        for (PortalDTO portal : listPortals()) {
+            if (world.equalsIgnoreCase(portal.getWorld())) {
+                portals.add(portal);
+            }
+        }
+        return portals;
+    }
+
+    /**
+     * Resolves a portal by a full id or an unambiguous id prefix.
+     *
+     * <p>Portal signs display only the first eight characters of the id, so an operator reading a
+     * sign has a prefix rather than the full UUID. An ambiguous prefix resolves to empty rather
+     * than picking one — guessing which portal an admin meant is how the wrong one gets deleted.</p>
+     *
+     * @param idOrPrefix the full portal id, or a prefix of it
+     * @return the single matching portal, or empty when nothing or more than one matches
+     */
+    public Optional<PortalDTO> resolvePortal(String idOrPrefix) {
+        if (idOrPrefix == null || idOrPrefix.isBlank()) {
+            return Optional.empty();
+        }
+        PortalDTO exact = byId.get(idOrPrefix);
+        if (exact != null) {
+            return Optional.of(exact);
+        }
+        String prefix = idOrPrefix.toLowerCase();
+        PortalDTO match = null;
+        for (Map.Entry<String, PortalDTO> entry : byId.entrySet()) {
+            if (entry.getKey().toLowerCase().startsWith(prefix)) {
+                if (match != null) {
+                    return Optional.empty(); // ambiguous
+                }
+                match = entry.getValue();
+            }
+        }
+        return Optional.ofNullable(match);
+    }
+
+    /**
+     * Checks a registered portal against the world: is its trigger block still the configured
+     * material, and is a sign carrying its id still mounted on it.
+     *
+     * <p>Never force-loads a world or chunk — an unloaded portal reports {@link Verification#UNVERIFIED}.
+     * Must be called on the main thread (it reads block state).</p>
+     *
+     * @param portalId the portal id
+     * @return the verification outcome
+     */
+    public Verification verify(String portalId) {
+        PortalDTO portal = byId.get(portalId);
+        if (portal == null) {
+            return Verification.UNKNOWN;
+        }
+
+        World world = Bukkit.getWorld(portal.getWorld());
+        if (world == null) {
+            return Verification.UNVERIFIED;
+        }
+        if (!world.isChunkLoaded(portal.getX() >> 4, portal.getZ() >> 4)) {
+            return Verification.UNVERIFIED;
+        }
+
+        Block anchor = world.getBlockAt(portal.getX(), portal.getY(), portal.getZ());
+        Material triggerMaterial = config.getTriggerMaterial();
+        if (triggerMaterial != null && anchor.getType() != triggerMaterial) {
+            return Verification.ORPHANED;
+        }
+
+        return PortalSignWriter
+                .findSignOnAnchor(anchor, PortalSignWriter.portalIdKey(plugin), portalId)
+                .isPresent()
+                ? Verification.VERIFIED
+                : Verification.ORPHANED;
+    }
+
+    /**
+     * Rewrites and re-stamps the registration sign for an existing portal.
+     *
+     * <p>Recovers a portal whose sign text was overwritten or whose PDC stamp was lost — for
+     * example after a rollback or a schematic paste, which restores the sign block without its
+     * persistent data (#1614). Requires a sign still mounted on the anchor; it will not place one,
+     * because choosing a face and material on an admin's behalf is a build decision, not a repair.</p>
+     *
+     * <p>Must be called on the main thread.</p>
+     *
+     * @param portalId        the portal id
+     * @param transferService the transfer service used to render the destination line; may be null
+     * @return a result describing the outcome
+     */
+    public PortalResult repairSign(String portalId, org.fourz.rvnkcore.service.transfer.TransferService transferService) {
+        PortalDTO portal = byId.get(portalId);
+        if (portal == null) {
+            return new PortalResult(Status.NOT_FOUND, "No portal registered with id " + portalId, null);
+        }
+
+        World world = Bukkit.getWorld(portal.getWorld());
+        if (world == null) {
+            return new PortalResult(Status.UNAVAILABLE, "World '" + portal.getWorld() + "' is not loaded", portal);
+        }
+        if (!world.isChunkLoaded(portal.getX() >> 4, portal.getZ() >> 4)) {
+            return new PortalResult(Status.UNAVAILABLE,
+                    "Chunk at " + portal.getX() + "," + portal.getZ() + " is not loaded", portal);
+        }
+
+        Block anchor = world.getBlockAt(portal.getX(), portal.getY(), portal.getZ());
+        // Accept any sign mounted on the anchor — the whole point of a repair is that the stamp may
+        // be missing, so matching on the id here would reject exactly the case we came to fix.
+        Optional<Block> signBlock = PortalSignWriter
+                .findSignOnAnchor(anchor, PortalSignWriter.portalIdKey(plugin), null);
+        if (signBlock.isEmpty()) {
+            return new PortalResult(Status.NOT_FOUND,
+                    "No sign is mounted on this portal's anchor block — place one, then repair again", portal);
+        }
+
+        String[] lines = PortalSignWriter.buildDisplayLines(transferService, portal.getTargetServer(), portalId);
+        boolean written = PortalSignWriter.write(
+                signBlock.get(), PortalSignWriter.portalIdKey(plugin), portalId, lines);
+        if (!written) {
+            return new PortalResult(Status.UNAVAILABLE, "Block is no longer a sign", portal);
+        }
+
+        logger.info("Portal sign repaired (id " + portalId + ") at " + portal.getWorld() + " "
+                + portal.getX() + "," + portal.getY() + "," + portal.getZ());
+        return new PortalResult(Status.SUCCESS, "Portal sign repaired", portal);
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
@@ -284,9 +284,26 @@ public class PortalService {
      * @return true if a portal with that id was present and removed
      */
     public boolean deletePortalById(String portalId) {
+        return deletePortalById(portalId, true);
+    }
+
+    /**
+     * Deletes a portal by id, optionally stripping its registration sign back to a plain sign.
+     *
+     * @param portalId  The portal id (as stamped on the registration sign)
+     * @param clearSign true to blank the sign and remove its portal-id stamp. Pass false when the
+     *                  sign is already being destroyed (the block-break path), where clearing it
+     *                  would be pointless work on a block about to become air.
+     * @return true if a portal with that id was present and removed
+     */
+    public boolean deletePortalById(String portalId, boolean clearSign) {
         PortalDTO portal = byId.remove(portalId);
         if (portal == null) {
             return false;
+        }
+
+        if (clearSign) {
+            clearRegistrationSign(portal, portalId);
         }
 
         World world = Bukkit.getWorld(portal.getWorld());
@@ -314,6 +331,30 @@ public class PortalService {
             logger.info("Portal deleted (id " + portalId + ")");
         }
         return true;
+    }
+
+    /**
+     * Strips a deleted portal's registration sign back to a plain sign.
+     *
+     * <p>A sign left carrying the stamp of a portal that no longer exists is <b>inert</b>: the
+     * sign-change handler short-circuits on the stamp, so the sign can be neither re-registered nor
+     * edited into anything else, and the block-break handler demands delete permission to remove
+     * it. Clearing the stamp on delete is what keeps the sign reusable.</p>
+     *
+     * <p>Best-effort: an unloaded world or chunk is skipped rather than force-loaded. Any sign left
+     * behind that way is recovered by the sign-change handler, which clears a stale stamp on the
+     * next edit.</p>
+     */
+    private void clearRegistrationSign(PortalDTO portal, String portalId) {
+        World world = Bukkit.getWorld(portal.getWorld());
+        if (world == null || !world.isChunkLoaded(portal.getX() >> 4, portal.getZ() >> 4)) {
+            logger.debug("Portal " + portalId + " sign not cleared — world or chunk not loaded");
+            return;
+        }
+        Block anchor = world.getBlockAt(portal.getX(), portal.getY(), portal.getZ());
+        PortalSignWriter.findSignOnAnchor(anchor, PortalSignWriter.portalIdKey(plugin), portalId)
+                .ifPresent(signBlock -> PortalSignWriter.clearStamp(
+                        signBlock, PortalSignWriter.portalIdKey(plugin)));
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
@@ -128,6 +128,31 @@ public final class PortalSignWriter {
     }
 
     /**
+     * Strips a sign back to a plain, reusable sign: removes the portal-id stamp and blanks the
+     * four lines.
+     *
+     * <p>Called when a portal is removed. Without it the sign keeps a stamp pointing at a portal
+     * that no longer exists, which makes the sign inert — it cannot be re-registered and its text
+     * cannot be changed, because the stamp short-circuits the sign-change handler.</p>
+     *
+     * @param block the sign block
+     * @param key   the portal-id key
+     * @return true when the sign was cleared; false when the block is not (or is no longer) a sign
+     */
+    public static boolean clearStamp(Block block, NamespacedKey key) {
+        BlockState state = block.getState();
+        if (!(state instanceof Sign sign)) {
+            return false;
+        }
+        sign.getPersistentDataContainer().remove(key);
+        for (int i = 0; i < 4; i++) {
+            sign.setLine(i, "");
+        }
+        sign.update();
+        return true;
+    }
+
+    /**
      * Resolves the block a sign is mounted on: the block behind a wall sign, or the block below a
      * standing sign.
      *

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
@@ -1,0 +1,185 @@
+package org.fourz.rvnkcore.service.portal;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+import org.fourz.rvnkcore.api.config.TransferConfig;
+import org.fourz.rvnkcore.service.transfer.TransferService;
+
+import java.util.Optional;
+
+/**
+ * Shared read/write logic for cross-server portal registration signs (#1859).
+ *
+ * <p>Extracted from {@code PortalSignListener} so the listener, {@link PortalService} and the
+ * {@code /portal} command all render and identify portal signs the same way. Before this existed,
+ * sign rendering and the PDC stamp lived privately inside the listener, which is why a portal whose
+ * sign had been destroyed could not be repaired — and why {@code deletePortalById} had exactly one
+ * reachable call site.</p>
+ *
+ * <p>All methods are main-thread Bukkit operations. Callers are responsible for confirming the
+ * world and chunk are loaded first; nothing here force-loads a chunk, because treating an unloaded
+ * chunk as "the sign is gone" would report a healthy portal as broken.</p>
+ *
+ * @since 1.5.64
+ */
+public final class PortalSignWriter {
+
+    /** PersistentDataContainer key under which a registration sign stores its portal id. */
+    public static final String PORTAL_ID_KEY = "portal_id";
+
+    private PortalSignWriter() {
+    }
+
+    /**
+     * Builds the {@link NamespacedKey} used for the portal-id PDC stamp.
+     *
+     * @param plugin the owning plugin
+     * @return the namespaced key
+     */
+    public static NamespacedKey portalIdKey(Plugin plugin) {
+        return new NamespacedKey(plugin, PORTAL_ID_KEY);
+    }
+
+    /**
+     * Builds the four display lines of a portal sign: header, destination, world, short id.
+     *
+     * @param transferService the transfer service, for the target's friendly name and world; may be null
+     * @param targetServer    the target server name
+     * @param portalId        the portal id, which drives the short-id line
+     * @return four legacy-coded sign lines
+     */
+    public static String[] buildDisplayLines(TransferService transferService, String targetServer, String portalId) {
+        TransferConfig.Target tgt = transferService != null
+                ? transferService.getConfig().resolveTarget(targetServer) : null;
+        String display = (tgt != null && tgt.display() != null && !tgt.display().isEmpty())
+                ? tgt.display() : targetServer;
+        String world = (tgt != null && tgt.world() != null && !tgt.world().isEmpty())
+                ? tgt.world() : "";
+        String shortId = (portalId != null && portalId.length() >= 8)
+                ? portalId.substring(0, 8) : (portalId != null ? portalId : "");
+        return new String[]{
+                "§9[server]",
+                "§a" + display,
+                world.isEmpty() ? "" : "§7" + world,
+                "§8" + shortId
+        };
+    }
+
+    /**
+     * Reads the portal id stamped on a sign block.
+     *
+     * @param block the candidate sign block
+     * @param key   the portal-id key
+     * @return the stamped id, or empty when the block is not a sign or carries no stamp
+     */
+    public static Optional<String> readPortalId(Block block, NamespacedKey key) {
+        BlockState state = block.getState();
+        if (!(state instanceof Sign sign)) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(sign.getPersistentDataContainer().get(key, PersistentDataType.STRING));
+    }
+
+    /**
+     * Stamps a portal id into a sign block's PersistentDataContainer.
+     *
+     * @param block    the sign block
+     * @param key      the portal-id key
+     * @param portalId the id to store
+     * @return true when the stamp was applied; false when the block is no longer a sign
+     */
+    public static boolean stamp(Block block, NamespacedKey key, String portalId) {
+        BlockState state = block.getState();
+        if (!(state instanceof Sign sign)) {
+            return false;
+        }
+        sign.getPersistentDataContainer().set(key, PersistentDataType.STRING, portalId);
+        sign.update();
+        return true;
+    }
+
+    /**
+     * Writes both the display lines and the PDC stamp onto a sign block.
+     *
+     * @param block    the sign block
+     * @param key      the portal-id key
+     * @param portalId the portal id
+     * @param lines    the four display lines
+     * @return true when written; false when the block is no longer a sign
+     */
+    public static boolean write(Block block, NamespacedKey key, String portalId, String[] lines) {
+        BlockState state = block.getState();
+        if (!(state instanceof Sign sign)) {
+            return false;
+        }
+        for (int i = 0; i < 4 && i < lines.length; i++) {
+            sign.setLine(i, lines[i]);
+        }
+        sign.getPersistentDataContainer().set(key, PersistentDataType.STRING, portalId);
+        sign.update();
+        return true;
+    }
+
+    /**
+     * Resolves the block a sign is mounted on: the block behind a wall sign, or the block below a
+     * standing sign.
+     *
+     * @param signBlock the sign block
+     * @return the mounting block, or null when the block is not a sign
+     */
+    public static Block resolveMountBlock(Block signBlock) {
+        BlockData data = signBlock.getBlockData();
+        if (data instanceof WallSign wallSign) {
+            // A wall sign faces outward; the block it is attached to sits behind it.
+            return signBlock.getRelative(wallSign.getFacing().getOppositeFace());
+        }
+        if (data instanceof org.bukkit.block.data.type.Sign) {
+            // A standing sign is mounted on the block directly below it.
+            return signBlock.getRelative(BlockFace.DOWN);
+        }
+        return null;
+    }
+
+    /**
+     * Finds the registration sign mounted on a portal's anchor block.
+     *
+     * <p>Searches the six neighbours of the anchor for a sign that is actually mounted on it. When
+     * {@code portalId} is supplied, only a sign carrying that exact stamp matches — which is what
+     * distinguishes "this portal's sign is intact" from "some other sign happens to be adjacent".</p>
+     *
+     * @param anchor   the portal anchor (the frame block the sign is mounted on)
+     * @param key      the portal-id key
+     * @param portalId the id the sign must carry, or null to accept any sign mounted on the anchor
+     * @return the matching sign block, or empty
+     */
+    public static Optional<Block> findSignOnAnchor(Block anchor, NamespacedKey key, String portalId) {
+        BlockFace[] faces = {
+                BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST,
+                BlockFace.WEST, BlockFace.UP, BlockFace.DOWN
+        };
+        for (BlockFace face : faces) {
+            Block candidate = anchor.getRelative(face);
+            if (!(candidate.getState() instanceof Sign)) {
+                continue;
+            }
+            Block mount = resolveMountBlock(candidate);
+            if (mount == null || !mount.equals(anchor)) {
+                continue;
+            }
+            if (portalId == null) {
+                return Optional.of(candidate);
+            }
+            if (portalId.equals(readPortalId(candidate, key).orElse(null))) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/toolkitplugin/src/main/resources/plugin.yml
+++ b/toolkitplugin/src/main/resources/plugin.yml
@@ -116,6 +116,11 @@ commands:
     description: Cross-server transfer commands (movement only)
     usage: /server transfer <target> [confirm]
     permission: rvnkcore.transfer
+  portal:
+    description: Cross-server portal administration, and the cross-system portal view
+    usage: /portal <list|info|delete|tp|repair|reload|types> [args]
+    aliases: [portals]
+    permission: rvnkcore.portal.admin
   pref:
     description: Manage your notification preferences
     usage: |
@@ -330,6 +335,9 @@ permissions:
   rvnkcore.portal.use:
     description: Allows triggering a cross-server portal
     default: true
+  rvnkcore.portal.admin:
+    description: Allows use of /portal (list, info, tp, repair, reload, types)
+    default: op
   rvnkcore.portal.*:
     description: All cross-server portal permissions
     default: op
@@ -337,3 +345,4 @@ permissions:
       rvnkcore.portal.create: true
       rvnkcore.portal.delete: true
       rvnkcore.portal.use: true
+      rvnkcore.portal.admin: true


### PR DESCRIPTION
## Server portal protection + management commands (#1857)

Adds `/portal`, the `PortalService` management API, and the extension point that lets RVNKWorlds contribute to it — plus a sign-lifecycle fix found during live testing.

### Why

Cross-server portals had **no command surface at all**. Management was entirely sign-driven, so a portal whose sign was destroyed became both invisible and unremovable — `deletePortalById` had exactly one reachable call site (the sign-break handler), which by definition cannot fire when the sign is already gone. `PortalRepository.listAll()` was implemented and unreachable.

### Commits

- `666fb5b` feat: `IPortalCommandExtension` SPI (#1861)
- `90604c3` feat: `/portal` command + `PortalService` management API (#1859)
- `62a6f94` fix: a deleted portal left its sign permanently inert (#1859)

### Design notes worth reviewing

**RVNKCore owns `/portal` outright.** RVNKWorlds cannot take it over by declaring `portal` in its own `plugin.yml` — commands resolve via `plugin.getCommand(name)` and must be declared statically, and Bukkit awards the bare label to whichever plugin registers first. Since RVNKWorlds declares `depend: [RVNKCore]`, the core always enables first, so a second declaration would silently yield only `rvnkworlds:portal`. The override is therefore **behavioural**: extensions resolve per invocation, so load/unload mid-session cannot leave the command broken.

**RVNKCore never reads RVNKWorlds' portal data.** The implementor renders its own rows, so there is no shared DTO and no second source of truth. All optional SPI methods have defaults, so adding to the interface later will not `AbstractMethodError` an implementor compiled against an older core.

**`verify()` is three-state on purpose.** `UNVERIFIED` (world/chunk not loaded) is distinct from `ORPHANED`. A portal that cannot be inspected without force-loading a chunk must never be reported as broken — that false-absence trap is how healthy data gets deleted.

**The sign fix.** `onSignChange` returned unconditionally when a stamp was present, so once a portal row was deleted the sign could never be re-registered nor edited — permanently inert. Now a stale stamp is cleared and the edit falls through, which also rescues signs already broken in the world.

### Verification

Live on RVNK Dev (1.5.66-alpha) and production (standalone, no RVNKWorlds):

- `/portal types` resolved the SPI and printed RVNKWorlds' description
- `/portal list --type world alphac` returned output **byte-identical** to `/world portal list alphac` — proving delegation, not a second implementation
- `verify()` confirmed a real portal against world state; prefix resolution worked
- A dead sign recovered in one edit and registered a new portal on the same block
- On prod (RVNKWorlds absent): "unavailable: no portal provider is loaded" — **not** an empty list, and a southmesa portal in an unloaded chunk correctly read `unverified`

`plugin.yml` validated by parsing it out of the built jar with a real YAML parser.

### Still open

`appendListing` completes when the listing is dispatched, not when rows are sent — `WorldPortalSubCommand` owns its async fetch with no completion callback. World rows may print a tick or two after the section header.

Deploy note: **must ship together with RVNKWorlds 1.6.84** — the SPI contract does not hold across a partial deploy.
