### PR TITLE
feat(rvnkcore): lore/world-hold/survey contracts, chat tail, portal-anchor hardening

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.69-alpha</version>
+    <version>1.5.70-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.71-alpha</version>
+    <version>1.5.72-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.68-alpha</version>
+    <version>1.5.69-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.67-alpha</version>
+    <version>1.5.68-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.66-alpha</version>
+    <version>1.5.67-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.70-alpha</version>
+    <version>1.5.71-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>
@@ -166,13 +166,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.8.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.8.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -189,8 +189,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
+                    <fork>true</fork>
                     <release>21</release>
                 </configuration>
             </plugin>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.72-alpha</version>
+    <version>1.5.73-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ChatRelayConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ChatRelayConfig.java
@@ -40,15 +40,19 @@ public class ChatRelayConfig {
     private final String serverId;
     private final String serverLabel;
     private final String channelTrigger;
+    /** Default retained chat-tail size; ChatMessageBuffer clamps the final value. */
+    private static final int DEFAULT_BUFFER_SIZE = 500;
+
     private final int dedupCacheSize;
+    private final int bufferSize;
     private final int timeoutMs;
     private final boolean insecureTls;
     private final String botFormat;
     private final List<Peer> peers;
 
     private ChatRelayConfig(boolean enabled, String serverId, String serverLabel, String channelTrigger,
-                            int dedupCacheSize, int timeoutMs, boolean insecureTls, String botFormat,
-                            List<Peer> peers) {
+                            int dedupCacheSize, int bufferSize, int timeoutMs, boolean insecureTls,
+                            String botFormat, List<Peer> peers) {
         this.enabled = enabled;
         this.serverId = serverId != null ? serverId.trim() : "";
         // Friendly label for THIS server (e.g. "nations", "event"); stamped on outgoing chatroom
@@ -57,6 +61,8 @@ public class ChatRelayConfig {
                 ? serverLabel.trim() : this.serverId;
         this.channelTrigger = (channelTrigger != null && !channelTrigger.isEmpty()) ? channelTrigger : "!";
         this.dedupCacheSize = dedupCacheSize > 0 ? dedupCacheSize : 512;
+        // Retained chat tail for GET /v1/chat/recent (#1869). Clamped again by ChatMessageBuffer.
+        this.bufferSize = bufferSize > 0 ? bufferSize : DEFAULT_BUFFER_SIZE;
         this.timeoutMs = timeoutMs > 0 ? timeoutMs : 3000;
         this.insecureTls = insecureTls;
         this.botFormat = (botFormat != null && !botFormat.isEmpty()) ? botFormat : DEFAULT_BOT_FORMAT;
@@ -71,8 +77,8 @@ public class ChatRelayConfig {
      */
     public static ChatRelayConfig fromConfigurationSection(ConfigurationSection section) {
         if (section == null) {
-            return new ChatRelayConfig(false, "", "", "!", 512, 3000, false, DEFAULT_BOT_FORMAT,
-                    Collections.emptyList());
+            return new ChatRelayConfig(false, "", "", "!", 512, DEFAULT_BUFFER_SIZE, 3000,
+                    false, DEFAULT_BOT_FORMAT, Collections.emptyList());
         }
 
         List<Peer> peers = new ArrayList<>();
@@ -112,6 +118,7 @@ public class ChatRelayConfig {
             section.getString("server-label", ""),
             section.getString("channel-trigger", "!"),
             section.getInt("dedup-cache-size", 512),
+            section.getInt("buffer.size", DEFAULT_BUFFER_SIZE),
             section.getInt("timeout-ms", 3000),
             section.getBoolean("insecure-tls", false),
             section.getString("bot-format", DEFAULT_BOT_FORMAT),
@@ -189,6 +196,7 @@ public class ChatRelayConfig {
     public String getServerLabel() { return serverLabel; }
     public String getChannelTrigger() { return channelTrigger; }
     public int getDedupCacheSize() { return dedupCacheSize; }
+    public int getBufferSize() { return bufferSize; }
     public int getTimeoutMs() { return timeoutMs; }
     public boolean isInsecureTls() { return insecureTls; }
     public String getBotFormat() { return botFormat; }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
@@ -50,15 +50,42 @@ public class TransferConfig {
      * reach none of them ({@code saveResource(..., false)} only writes when the file is absent).
      * A code default applies immediately everywhere and is still overridable per target with a
      * {@code realm:} key.</p>
+     *
+     * <p>Keyed by every identifier a tier is known by, because the ecosystem genuinely uses more
+     * than one for the same server: production is {@code prod} as a transfer target and
+     * {@code nations} as a chat-relay tag, and Dev is {@code dev} to {@code getServerId()} but
+     * {@code test} as its chat label. Mapping only one of each pair would leave the other rendering
+     * a raw infrastructure word in a player-facing sentence.</p>
      */
     private static final Map<String, String> DEFAULT_REALMS = Map.of(
             "prod", "the home realm",
+            "nations", "the home realm",
             "event", "the Arcology",
+            "arcology", "the Arcology",
             "dev", "the fragile worlds",
             "test", "the fragile worlds");
 
     /** Neutral stand-in when a crossing's destination cannot be resolved. */
     public static final String UNKNOWN_REALM = "another realm";
+
+    /**
+     * The in-fiction realm name for a server identifier.
+     *
+     * <p>For callers that hold a server identity rather than a transfer target — the arrival
+     * broadcast naming the realm it is running in, or a chat notice naming the tier an event
+     * happened on.</p>
+     *
+     * @param serverName A server id or chat label ({@code prod}, {@code nations}, {@code event},
+     *                   {@code dev}, {@code test}); null or unknown yields {@link #UNKNOWN_REALM}
+     * @return A non-blank realm name
+     */
+    public static String realmForServer(String serverName) {
+        if (serverName == null || serverName.isBlank()) {
+            return UNKNOWN_REALM;
+        }
+        return DEFAULT_REALMS.getOrDefault(
+                serverName.trim().toLowerCase(java.util.Locale.ROOT), UNKNOWN_REALM);
+    }
 
     /**
      * Resolves the in-fiction realm name for a target.
@@ -108,8 +135,15 @@ public class TransferConfig {
      * the fiction treats as travel between realms.</p>
      */
     public static final String DEFAULT_BROADCAST = "&d{player} &7has crossed to &f{realm}";
-    /** Default themed arrival broadcast — ASCII-safe (#1753). */
-    public static final String DEFAULT_ARRIVAL = "&d{player} &7steps through from across the network...";
+    /**
+     * Default themed arrival broadcast — ASCII-safe (#1753).
+     *
+     * <p>{@code {realm}} is the realm the player has arrived <b>in</b>, not the one they left.
+     * The destination knows its own identity for free; the origin is only recoverable via a
+     * transfer cookie and a client round-trip, which would leave the message silent whenever the
+     * client did not answer.</p>
+     */
+    public static final String DEFAULT_ARRIVAL = "&d{player} &7has crossed into &f{realm}";
 
     private TransferConfig(boolean enabled, int cooldownSeconds, String permission,
                            boolean confirm, Map<String, Target> targets, String broadcastMessage,

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
@@ -33,8 +33,53 @@ public class TransferConfig {
      * @param port    The destination server port
      * @param display Friendly server name for signs/messages (e.g. {@code "Nations"}); defaults to the target name
      * @param world   Friendly destination world/realm name for signs (informational; may be empty)
+     * @param realm   In-fiction name of the destination for crossing messages (e.g. {@code "the Arcology"})
      */
-    public record Target(String host, int port, String display, String world) {
+    public record Target(String host, int port, String display, String world, String realm) {
+    }
+
+    /**
+     * In-fiction realm names, keyed by target name.
+     *
+     * <p>Players do not cross to "prod" or "event" — they cross to the home realm and the Arcology.
+     * {@code display} cannot carry this: it is the operator-facing server name and is also stamped
+     * onto portal signs, so overloading it would change those too.</p>
+     *
+     * <p>Defaulted in code rather than shipped in {@code config.yml} on purpose. Dev, Event and
+     * production all already have that file, so a new key added to the packaged resource would
+     * reach none of them ({@code saveResource(..., false)} only writes when the file is absent).
+     * A code default applies immediately everywhere and is still overridable per target with a
+     * {@code realm:} key.</p>
+     */
+    private static final Map<String, String> DEFAULT_REALMS = Map.of(
+            "prod", "the home realm",
+            "event", "the Arcology",
+            "dev", "the fragile worlds",
+            "test", "the fragile worlds");
+
+    /** Neutral stand-in when a crossing's destination cannot be resolved. */
+    public static final String UNKNOWN_REALM = "another realm";
+
+    /**
+     * Resolves the in-fiction realm name for a target.
+     *
+     * @param targetName The configured target key (case-insensitive)
+     * @param configured The explicit {@code realm:} value, or null/blank when unset
+     * @param display    The target's display name, used as the last resort
+     * @return A non-blank realm name
+     */
+    // Package-private rather than private so the realm table can be tested directly. Building a
+    // Bukkit ConfigurationSection off-server is not practical, so the alternative was a test that
+    // re-implemented this switch and therefore verified nothing.
+    static String resolveRealm(String targetName, String configured, String display) {
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        String byName = DEFAULT_REALMS.get(targetName.toLowerCase(java.util.Locale.ROOT));
+        if (byName != null) {
+            return byName;
+        }
+        return (display != null && !display.isBlank()) ? display : UNKNOWN_REALM;
     }
 
     private final boolean enabled;
@@ -55,8 +100,14 @@ public class TransferConfig {
      */
     private final String arrivalMessage;
 
-    /** Default themed transfer broadcast — ASCII-safe (no smart punctuation, #1753). */
-    public static final String DEFAULT_BROADCAST = "&d{player} &7was whisked away across the network...";
+    /**
+     * Default themed transfer broadcast — ASCII-safe (no smart punctuation, #1753).
+     *
+     * <p>Names the destination. The previous copy ("was whisked away across the network...") told
+     * nobody where the player went, and "the network" is infrastructure vocabulary for something
+     * the fiction treats as travel between realms.</p>
+     */
+    public static final String DEFAULT_BROADCAST = "&d{player} &7has crossed to &f{realm}";
     /** Default themed arrival broadcast — ASCII-safe (#1753). */
     public static final String DEFAULT_ARRIVAL = "&d{player} &7steps through from across the network...";
 
@@ -94,11 +145,13 @@ public class TransferConfig {
                 if (target == null) {
                     continue;
                 }
+                String display = target.getString("display", name);
                 targets.put(name, new Target(
                         target.getString("host", ""),
                         target.getInt("port", 25565),
-                        target.getString("display", name),
-                        target.getString("world", "")
+                        display,
+                        target.getString("world", ""),
+                        resolveRealm(name, target.getString("realm", null), display)
                 ));
             }
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
@@ -10,10 +10,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.fourz.rvnkcore.RVNKCore;
 import org.fourz.rvnkcore.api.model.ChatMessageDTO;
 import org.fourz.rvnkcore.api.util.ApiUtils;
+import org.fourz.rvnkcore.service.chatrelay.ChatMessageBuffer;
 import org.fourz.rvnkcore.service.chatrelay.ChatRelayService;
 import org.fourz.rvnkcore.util.log.LogManager;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * REST API controller for inbound cross-server chat relay messages.
@@ -28,6 +33,9 @@ import java.io.IOException;
  *       never relayed (#1777). Body: {@code {message, senderName?}}</li>
  *   <li>{@code POST /v1/chat/world} — Post a bot line into the WORLD room: scoped to one world,
  *       relayed to peers only when world-relay allows (#1777). Body: {@code {message, senderName?, world}}</li>
+ *   <li>{@code GET /v1/chat/recent} — Cursor-polled tail of recent chat, so a client can read what was
+ *       said without scraping the console log (#1870).
+ *       Query: {@code since, boot, limit, room, world}</li>
  * </ul>
  *
  * <p>The {@link ChatRelayService} is resolved lazily from the ServiceRegistry at request time,
@@ -58,6 +66,99 @@ public class ChatRelayController extends HttpServlet {
      */
     private ChatRelayService getService() {
         return RVNKCore.getServiceSafe(ChatRelayService.class);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String pathInfo = req.getPathInfo();
+
+        try {
+            if (pathInfo != null && pathInfo.equals("/recent")) {
+                handleRecent(req, resp);
+            } else {
+                ApiUtils.sendError(resp, gson, 404, "NOT_FOUND",
+                        "Unknown chat relay endpoint: GET " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling chat relay GET request", e);
+            ApiUtils.sendError(resp, gson, 500, "INTERNAL_ERROR", "Request failed");
+        }
+    }
+
+    /**
+     * Serves the recent-chat tail for cursor polling (#1870).
+     *
+     * <p>{@code GET /v1/chat/recent?since=&boot=&limit=&room=&world=}. The client sends the
+     * {@code seq} and {@code bootId} it last saw and receives everything after that {@code seq}.
+     * A {@code bootId} that no longer matches — or a cursor the buffer has already evicted past —
+     * comes back as {@code stale:true} with the buffer head, so the client resyncs instead of
+     * silently waiting on a sequence position that will never arrive.</p>
+     *
+     * <p>Read-only: this serves what the relay already saw. It cannot expose private messages,
+     * because {@code /msg}, {@code /tell} and {@code /r} never enter the chatroom path and so are
+     * never recorded.</p>
+     */
+    private void handleRecent(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        ChatRelayService service = getService();
+        if (service == null) {
+            ApiUtils.sendError(resp, gson, 503, "SERVICE_UNAVAILABLE", "Chat relay service not available");
+            return;
+        }
+
+        long since;
+        try {
+            String raw = req.getParameter("since");
+            since = (raw == null || raw.isBlank()) ? 0L : Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST", "since must be an integer");
+            return;
+        }
+
+        String boot = trimToNull(req.getParameter("boot"));
+        int limit = ApiUtils.getIntParam(req, "limit", ChatMessageBuffer.MAX_LIMIT);
+        String room = trimToNull(req.getParameter("room"));
+        String world = trimToNull(req.getParameter("world"));
+
+        ChatMessageBuffer.Page page = service.getBuffer().since(boot, since, limit, room, world);
+
+        List<Map<String, Object>> messages = new ArrayList<>(page.getMessages().size());
+        for (ChatMessageBuffer.Entry entry : page.getMessages()) {
+            messages.add(toWire(entry));
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("bootId", page.getBootId());
+        data.put("seq", page.getSeq());
+        data.put("stale", page.isStale());
+        data.put("messages", messages);
+
+        ApiUtils.sendSuccess(resp, gson, data);
+    }
+
+    /**
+     * Flattens a buffer entry to the wire shape. {@code seq} is a buffer concern rather than part of
+     * {@link ChatMessageDTO}, so the two are merged here rather than polluting the relay payload.
+     */
+    private Map<String, Object> toWire(ChatMessageBuffer.Entry entry) {
+        ChatMessageDTO dto = entry.getDto();
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("seq", entry.getSeq());
+        m.put("msgId", dto.getMsgId());
+        m.put("timestamp", dto.getTimestamp());
+        m.put("senderName", dto.getSenderName());
+        m.put("senderUuid", dto.getSenderUuid());
+        m.put("message", dto.getMessage());
+        m.put("room", dto.getRoom());
+        m.put("world", dto.getWorld());
+        m.put("originServerId", dto.getOriginServerId());
+        m.put("serverLabel", dto.getServerLabel());
+        return m;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) return null;
+        String t = value.trim();
+        return t.isEmpty() ? null : t;
     }
 
     @Override

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
@@ -41,6 +41,8 @@ public class RVNKWorldsController extends HttpServlet {
     private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^/groups/([^/]+)/?$");
     private static final Pattern METRICS_PATTERN = Pattern.compile("^/metrics/?$");
     private static final Pattern HEALTH_PATTERN = Pattern.compile("^/health/?$");
+    /** #1923 — dense site survey for agentic tooling. */
+    private static final Pattern SURVEY_PATTERN = Pattern.compile("^/survey/?$");
 
     public RVNKWorldsController(IRVNKWorldsApiService ignored, Gson gson, LogManager logger) {
         this.gson = gson;
@@ -94,6 +96,10 @@ public class RVNKWorldsController extends HttpServlet {
                 future = apiService.getMetrics();
             } else if (HEALTH_PATTERN.matcher(pathInfo).matches()) {
                 future = apiService.getHealthStatus();
+            } else if (SURVEY_PATTERN.matcher(pathInfo).matches()) {
+                // The whole query string is handed through: the survey takes several optional
+                // params and parsing them here would split the contract across two files.
+                future = apiService.surveySite(req.getQueryString());
             } else {
                 sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
                 return;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
@@ -72,4 +72,30 @@ public interface ILoreApiService {
 
     /** Roll an item back to a prior version (POST /lore/items/{id}/rollback, body {"version":N}). */
     CompletableFuture<ApiResponse<?>> rollbackItem(String id, String requestBody);
+
+    /**
+     * Lore locations within {@code radius} of a point, for cross-plugin spatial lookups (#1924).
+     *
+     * <p>Added so RVNKWorlds' site survey can answer "what lore is here?" without reaching into
+     * RVNKLore's schema. Reading {@code rvnklore_lore_location} directly would couple a consumer to
+     * another plugin's table name and prefix; this keeps the seam at the service boundary, matching
+     * how RVNKQuests consumes {@code IRVNKWorldsApiService}.</p>
+     *
+     * <p><b>Deliberately a default method.</b> Plugins here deploy independently and do go out of
+     * step — Event ran RVNKCore 1.5.71 against newer plugins for weeks. An abstract method would
+     * make an older RVNKLore throw {@code AbstractMethodError} against a newer core at the first
+     * call; this degrades to an honest "unavailable" instead, so a version-skewed tier loses the
+     * feature rather than the plugin.</p>
+     *
+     * @param world  world name; locations are per-server and carry a world name
+     * @param x      centre X
+     * @param z      centre Z — Y is ignored, matching the repository's 2D distance filter
+     * @param radius search radius in blocks
+     */
+    default CompletableFuture<ApiResponse<?>> findNearbyLocations(String world, double x, double z,
+                                                                  double radius) {
+        return CompletableFuture.completedFuture(
+            ApiResponse.error("NOT_SUPPORTED",
+                "Lore location lookup requires RVNKLore 1.0.108 or newer on this server."));
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IPortalCommandExtension.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IPortalCommandExtension.java
@@ -61,8 +61,10 @@ public interface IPortalCommandExtension {
     /**
      * Subcommand names this extension claims, lowercase, without a leading slash.
      *
-     * <p>RVNKCore's own subcommands always win a collision — a clash is logged as a startup
-     * warning and the claimed name is ignored rather than shadowing core behaviour.</p>
+     * <p>RVNKCore's own subcommands always win a collision: the claimed name is ignored rather
+     * than shadowing core behaviour. A clash is logged as a warning once per provider, the first
+     * time {@code /portal} considers dispatching to it — not at startup, since extensions register
+     * independently of command setup and are resolved per invocation.</p>
      *
      * @return claimed subcommand names; may be empty, never null
      */
@@ -99,9 +101,14 @@ public interface IPortalCommandExtension {
      * Writes this extension's portals into the output of {@code /portal list}.
      *
      * <p>RVNKCore prints the section header (so the {@code WORLD} vs {@code SERVER} labelling stays
-     * consistent regardless of implementor) and then calls this to fill in the rows. The returned
-     * future lets RVNKCore sequence sections rather than interleaving them — complete it only once
-     * the rows have actually been sent, and never block the calling thread waiting for a database.</p>
+     * consistent regardless of implementor) and then calls this to fill in the rows.</p>
+     *
+     * @implSpec Complete the returned future once the rows have been sent, and never block the
+     * calling thread waiting for a database. RVNKCore consumes it to surface failures — an
+     * exceptionally-completed future is logged and reported to the sender, so a provider that dies
+     * mid-listing does not just print a header and stop. It is <b>not</b> currently used to order
+     * one section against another; with a single provider there is nothing to interleave. Do not
+     * rely on cross-section sequencing.
      *
      * @param sender      who to write to
      * @param worldFilter world name to restrict the listing to, or null for every world

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
@@ -35,4 +35,54 @@ public interface IRVNKWorldsApiService {
     // Metrics & Health
     CompletableFuture<ApiResponse<?>> getMetrics();
     CompletableFuture<ApiResponse<?>> getHealthStatus();
+
+    // ---------------------------------------------------------------------------------------------
+    // Runtime holds (#1883)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Claims a world as in-use so RVNKWorlds' inactivity cleanup will not reclaim it.
+     *
+     * <p>Loading a world is not the same as keeping it. {@code WorldCleanupScheduler} unloads any
+     * unprotected world that has sat empty past the inactivity threshold and writes it back to
+     * {@code IMPORTED}. A world loaded to satisfy a quest requirement has, by definition, nobody
+     * standing in it yet — so without a hold it is reclaimed minutes later and the quest silently
+     * becomes unplayable again (#1883).</p>
+     *
+     * <p>A hold is <b>runtime state, not config</b>. It is deliberately distinct from
+     * {@code cleanup.protectedWorlds}: that list is an operator's permanent policy, while a hold is
+     * a plugin saying "I am using this right now". Holds do not survive a restart, which is correct —
+     * whatever placed the hold will re-place it when it loads again.</p>
+     *
+     * <p>Holds are tracked <b>per holder</b>, so two plugins claiming the same world do not clobber
+     * one another; the world stays held until every holder has released it. Re-holding an
+     * already-held world is a no-op success.</p>
+     *
+     * @param worldName World to hold (case-insensitive)
+     * @param holder    Stable identifier for the claimant, e.g. the plugin name. Used so releases
+     *                  only drop that claimant's hold
+     * @return future completing success once the hold is registered
+     * @since 1.5.70
+     */
+    default CompletableFuture<ApiResponse<?>> holdWorld(String worldName, String holder) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support runtime world holds"));
+    }
+
+    /**
+     * Releases a hold previously placed by {@link #holdWorld}.
+     *
+     * <p>Only drops the named holder's claim. The world becomes cleanup-eligible again once no
+     * holders remain and it is otherwise unprotected. Releasing a hold that was never placed is a
+     * no-op success — callers should not have to track whether they hold something.</p>
+     *
+     * @param worldName World to release (case-insensitive)
+     * @param holder    The same identifier passed to {@link #holdWorld}
+     * @return future completing success once the hold is gone
+     * @since 1.5.70
+     */
+    default CompletableFuture<ApiResponse<?>> releaseWorld(String worldName, String holder) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support runtime world holds"));
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
@@ -85,4 +85,25 @@ public interface IRVNKWorldsApiService {
         return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
             "This RVNKWorlds build does not support runtime world holds"));
     }
+
+    /**
+     * Site survey — one dense read describing a location well enough for an agent to act on (#1923).
+     *
+     * <p>Answers, in a single call: where this is, whether it is built or wild, what it is made of,
+     * what it might be, and who else is nearby. The alternative is several calls plus console
+     * scraping, and console output is truncated and lossy.</p>
+     *
+     * <p>Optional capabilities report {@code available: false} rather than being omitted. An agent
+     * must be able to distinguish "no claim here" from "claims cannot be evaluated" — those lead to
+     * different decisions, and a missing key looks like the former while meaning the latter.</p>
+     *
+     * @param query Raw query string: {@code player=<name>} or {@code world=<w>&x=&y=&z=},
+     *              plus optional {@code radius} and {@code include}
+     * @return future completing with the survey payload
+     * @since 1.5.72
+     */
+    default CompletableFuture<ApiResponse<?>> surveySite(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support the survey endpoint"));
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
@@ -43,6 +43,9 @@ public class PortalCommand extends BaseCommand {
     private static final List<String> CORE_SUBCOMMANDS =
             List.of("list", "info", "delete", "tp", "repair", "reload", "types");
 
+    /** Providers already checked for subcommand collisions, so the warning is logged once each. */
+    private final java.util.Set<String> warnedProviders = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
     public PortalCommand(RVNKCore plugin) {
         super(plugin, "portal",
                 "Cross-server portal administration",
@@ -145,7 +148,20 @@ public class PortalCommand extends BaseCommand {
             } else {
                 sender.sendMessage(ChatColor.GOLD + "World portals" + ChatColor.GRAY
                         + " (via " + extension.providerName() + ")");
-                extension.appendListing(sender, worldFilter);
+                // Consume the future rather than dropping it: a provider that fails mid-listing
+                // would otherwise print a header and then nothing, with no trace anywhere.
+                java.util.concurrent.CompletableFuture<Void> listing =
+                        extension.appendListing(sender, worldFilter);
+                if (listing != null) {
+                    listing.whenComplete((v, ex) -> {
+                        if (ex != null) {
+                            logger.warning("Portal extension '" + extension.providerName()
+                                    + "' failed while listing world portals: " + ex);
+                            sender.sendMessage(ChatColor.RED
+                                    + "  (world portal listing failed — see console)");
+                        }
+                    });
+                }
             }
         }
         return true;
@@ -401,8 +417,14 @@ public class PortalCommand extends BaseCommand {
         return RVNKCore.getServiceSafe(PortalService.class);
     }
 
-    /** Core subcommands always win a name clash; an extension cannot shadow built-in behaviour. */
+    /**
+     * Core subcommands always win a name clash; an extension cannot shadow built-in behaviour.
+     *
+     * <p>A clash is warned about once per provider rather than silently ignored, so an author who
+     * claims a reserved name finds out instead of wondering why their subcommand never fires.</p>
+     */
     private boolean claims(IPortalCommandExtension extension, String sub) {
+        warnOnCollisionsOnce(extension);
         if (CORE_SUBCOMMANDS.contains(sub)) {
             return false;
         }
@@ -412,6 +434,29 @@ public class PortalCommand extends BaseCommand {
             if (candidate != null && candidate.equalsIgnoreCase(sub)) return true;
         }
         return false;
+    }
+
+    /**
+     * Logs, once per provider, any subcommand names an extension claims that collide with a core
+     * subcommand. The SPI contract promises this warning; without it a shadowed name fails silently.
+     */
+    private void warnOnCollisionsOnce(IPortalCommandExtension extension) {
+        String provider = extension.providerName();
+        if (provider == null || !warnedProviders.add(provider)) {
+            return;
+        }
+        List<String> claimed = extension.subcommands();
+        if (claimed == null) return;
+        List<String> clashes = new ArrayList<>();
+        for (String candidate : claimed) {
+            if (candidate != null && CORE_SUBCOMMANDS.contains(candidate.toLowerCase(Locale.ROOT))) {
+                clashes.add(candidate);
+            }
+        }
+        if (!clashes.isEmpty()) {
+            logger.warning("Portal extension '" + provider + "' claims subcommand(s) reserved by core: "
+                    + String.join(", ", clashes) + " — core wins, these will not be dispatched.");
+        }
     }
 
     private ChatColor colourFor(PortalService.Verification state) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalProtectionListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalProtectionListener.java
@@ -1,0 +1,304 @@
+package org.fourz.rvnkcore.event;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.config.PortalConfig;
+import org.fourz.rvnkcore.service.portal.PortalService;
+import org.fourz.rvnkcore.service.portal.PortalSignWriter;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Protects a registered cross-server portal's sign and anchor block from every destruction vector
+ * other than a permitted player break (#1858).
+ *
+ * <p>{@link PortalSignListener} guards exactly one path: a <i>player</i> breaking the sign itself.
+ * Everything else silently orphaned the portal — the DB row survived while the world state did not,
+ * which is the drift #1614 documented and the reason a portal could be neither seen nor fixed.</p>
+ *
+ * <h3>The two protected blocks</h3>
+ * <ul>
+ *   <li>the <b>sign</b> carrying the portal-id PDC stamp, and</li>
+ *   <li>the <b>anchor</b> — the trigger-material block that sign is mounted on. Breaking the anchor
+ *       pops the sign off as an item, so leaving it unguarded made sign protection cosmetic.</li>
+ * </ul>
+ *
+ * <h3>Two different responses</h3>
+ * <p>A <b>player</b> breaking the anchor is treated exactly like breaking the sign: with
+ * {@link PortalConfig#getPermissionDelete()} the portal is deleted properly (row and sign both), and
+ * without it the break is cancelled. Every <b>non-player</b> vector — explosion, fire, piston,
+ * entity — is simply prevented. None of them may delete a portal row: a creeper is not an
+ * administrator, and a silently deleted portal is the failure this issue exists to stop.</p>
+ *
+ * <h3>Stale stamps are deliberately not protected</h3>
+ * <p>Protection requires the stamped id to resolve to a <i>live</i> portal. A sign whose portal was
+ * already deleted is left fully breakable — guarding it would strand an indestructible block in the
+ * world with nothing behind it. This matches the same allowance in
+ * {@link PortalSignListener#onBlockBreak}.</p>
+ *
+ * @since 1.5.69
+ */
+public class PortalProtectionListener implements Listener {
+
+    private final RVNKCore plugin;
+    private final LogManager logger;
+    private final NamespacedKey portalIdKey;
+
+    /**
+     * Creates a new PortalProtectionListener.
+     *
+     * @param plugin The owning RVNKCore plugin
+     */
+    public PortalProtectionListener(RVNKCore plugin) {
+        this.plugin = plugin;
+        this.logger = LogManager.getInstance(plugin, getClass());
+        this.portalIdKey = PortalSignWriter.portalIdKey(plugin);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Player vector: breaking the anchor block the sign is mounted on
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Handles a player breaking the anchor block beneath/behind a portal sign.
+     *
+     * <p>Signs are left to {@link PortalSignListener#onBlockBreak} so the two handlers never both act
+     * on one break. With delete permission the portal is removed cleanly — including clearing the
+     * sign, which is about to lose its support anyway. Without it, the break is cancelled.</p>
+     *
+     * @param event The block break event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onAnchorBreak(BlockBreakEvent event) {
+        Block block = event.getBlock();
+        if (isSign(block)) return; // PortalSignListener owns the sign-break path.
+
+        PortalService portalService = RVNKCore.getServiceSafe(PortalService.class);
+        if (portalService == null) return;
+
+        String portalId = anchorPortalId(block, portalService);
+        if (portalId == null) return;
+
+        Player player = event.getPlayer();
+        PortalConfig config = portalService.getConfig();
+
+        if (config != null && !player.hasPermission(config.getPermissionDelete())) {
+            event.setCancelled(true);
+            player.sendMessage("§cThat block anchors a cross-server portal — you don't have "
+                    + "permission to remove it.");
+            return;
+        }
+
+        // Clear the sign too: it is about to pop off its support, and a stamped sign lying as an item
+        // is exactly the orphan state #1860 has to reconcile afterwards.
+        boolean removed = portalService.deletePortalById(portalId, true);
+        if (removed) {
+            player.sendMessage("§aCross-server portal removed (anchor block broken).");
+            logger.info("Portal removed by " + player.getName() + " via anchor break (id " + portalId
+                    + ") at " + block.getWorld().getName() + " "
+                    + block.getX() + "," + block.getY() + "," + block.getZ());
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Non-player vectors: prevent, never delete
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Excludes portal signs and anchors from an entity explosion (creeper, TNT, ghast, wither).
+     *
+     * <p>Filters the block list rather than cancelling the event so the rest of the blast still
+     * resolves normally — only the portal survives.</p>
+     *
+     * @param event The entity explode event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityExplode(EntityExplodeEvent event) {
+        shieldFromExplosion(event.blockList(), "entity explosion");
+    }
+
+    /**
+     * Excludes portal signs and anchors from a block explosion (bed, respawn anchor).
+     *
+     * @param event The block explode event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockExplode(BlockExplodeEvent event) {
+        shieldFromExplosion(event.blockList(), "block explosion");
+    }
+
+    /**
+     * Prevents fire from burning away a portal sign or its anchor.
+     *
+     * @param event The block burn event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockBurn(BlockBurnEvent event) {
+        if (protectedPortalId(event.getBlock()) == null) return;
+        event.setCancelled(true);
+        logger.debug("Blocked fire burn on portal block at " + event.getBlock().getLocation());
+    }
+
+    /**
+     * Prevents a piston from pushing a portal sign or anchor out of position.
+     *
+     * @param event The piston extend event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPistonExtend(BlockPistonExtendEvent event) {
+        if (movesProtectedBlock(event.getBlocks())) {
+            event.setCancelled(true);
+            logger.debug("Blocked piston extend moving a portal block at "
+                    + event.getBlock().getLocation());
+        }
+    }
+
+    /**
+     * Prevents a sticky piston from pulling a portal sign or anchor out of position.
+     *
+     * @param event The piston retract event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        if (movesProtectedBlock(event.getBlocks())) {
+            event.setCancelled(true);
+            logger.debug("Blocked piston retract moving a portal block at "
+                    + event.getBlock().getLocation());
+        }
+    }
+
+    /**
+     * Prevents an entity from removing or replacing a portal sign or anchor — enderman pickup,
+     * wither shot, falling block landing, silverfish infestation.
+     *
+     * @param event The entity change block event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityChangeBlock(EntityChangeBlockEvent event) {
+        if (protectedPortalId(event.getBlock()) == null) return;
+        event.setCancelled(true);
+        logger.debug("Blocked " + event.getEntityType() + " from changing portal block at "
+                + event.getBlock().getLocation());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Removes every protected portal block from an explosion's block list.
+     *
+     * @param blocks the mutable block list from the explode event
+     * @param vector short description used in the debug log
+     */
+    private void shieldFromExplosion(List<Block> blocks, String vector) {
+        if (blocks.isEmpty()) return;
+        if (RVNKCore.getServiceSafe(PortalService.class) == null) return;
+
+        boolean[] shielded = {false};
+        blocks.removeIf(block -> {
+            if (protectedPortalId(block) == null) return false;
+            shielded[0] = true;
+            return true;
+        });
+        if (shielded[0]) {
+            logger.debug("Shielded portal block(s) from " + vector);
+        }
+    }
+
+    /**
+     * Tests whether any block in a piston movement list is protected.
+     *
+     * @param blocks the blocks the piston would move
+     * @return true when at least one is a live portal sign or anchor
+     */
+    private boolean movesProtectedBlock(List<Block> blocks) {
+        for (Block block : blocks) {
+            if (protectedPortalId(block) != null) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the id of the live portal this block belongs to, or null.
+     *
+     * <p>A block qualifies as either the stamped sign or the anchor that sign is mounted on. Both
+     * checks are gated behind a cheap material test first — signs by {@link Tag#ALL_SIGNS}, anchors
+     * by the configured trigger material — so an explosion sweeping a hundred blocks does not pay for
+     * a {@code getState()} snapshot on each one.</p>
+     *
+     * @param block the block to test
+     * @return the live portal id, or null when this block is not a protected portal component
+     */
+    private String protectedPortalId(Block block) {
+        PortalService portalService = RVNKCore.getServiceSafe(PortalService.class);
+        if (portalService == null) return null;
+
+        if (isSign(block)) {
+            String id = PortalSignWriter.readPortalId(block, portalIdKey).orElse(null);
+            return liveId(id, portalService);
+        }
+        return anchorPortalId(block, portalService);
+    }
+
+    /**
+     * Returns the id of the live portal whose sign is mounted on this anchor block, or null.
+     *
+     * @param block         the candidate anchor block
+     * @param portalService the resolved portal service
+     * @return the live portal id, or null
+     */
+    private String anchorPortalId(Block block, PortalService portalService) {
+        PortalConfig config = portalService.getConfig();
+        if (config == null) return null;
+
+        Material trigger = config.getTriggerMaterial();
+        if (trigger == null || block.getType() != trigger) return null;
+
+        Optional<Block> sign = PortalSignWriter.findSignOnAnchor(block, portalIdKey, null);
+        if (sign.isEmpty()) return null;
+
+        String id = PortalSignWriter.readPortalId(sign.get(), portalIdKey).orElse(null);
+        return liveId(id, portalService);
+    }
+
+    /**
+     * Narrows a stamped id to one that still resolves to a registered portal.
+     *
+     * <p>A stale stamp returns null on purpose — see the class javadoc.</p>
+     *
+     * @param portalId      the stamped id, may be null
+     * @param portalService the resolved portal service
+     * @return the id when the portal is live, otherwise null
+     */
+    private String liveId(String portalId, PortalService portalService) {
+        if (portalId == null) return null;
+        return portalService.getPortalById(portalId).isPresent() ? portalId : null;
+    }
+
+    /**
+     * Cheap material-level test for any sign variant, avoiding a BlockState snapshot.
+     *
+     * @param block the block to test
+     * @return true when the block is a standing, wall, or hanging sign
+     */
+    private static boolean isSign(Block block) {
+        return Tag.ALL_SIGNS.isTagged(block.getType());
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
@@ -92,7 +92,7 @@ public class PortalSignListener implements Listener {
                 if (existing.isPresent()) {
                     String[] lines = buildDisplayLines(
                             RVNKCore.getServiceSafe(TransferService.class),
-                            existing.get().getTargetServer(), existingId);
+                            existing.get().getTargetServer(), existingId, config);
                     for (int i = 0; i < 4; i++) event.setLine(i, lines[i]);
                     return;
                 }
@@ -177,7 +177,7 @@ public class PortalSignListener implements Listener {
         final String portalId = result.portal().getPortalId();
 
         // Reformat the sign to a friendly display: [server] | destination server | world | id.
-        String[] lines = buildDisplayLines(transferService, targetServer, portalId);
+        String[] lines = buildDisplayLines(transferService, targetServer, portalId, config);
         for (int i = 0; i < 4; i++) {
             event.setLine(i, lines[i]);
         }
@@ -261,8 +261,10 @@ public class PortalSignListener implements Listener {
      * @param portalId        The portal id (drives the short-id line)
      * @return four legacy-coded sign lines
      */
-    private String[] buildDisplayLines(TransferService transferService, String targetServer, String portalId) {
-        return PortalSignWriter.buildDisplayLines(transferService, targetServer, portalId);
+    private String[] buildDisplayLines(TransferService transferService, String targetServer,
+                                       String portalId, PortalConfig config) {
+        return PortalSignWriter.buildDisplayLines(transferService, targetServer, portalId,
+                config != null ? config.getSignHeader() : null);
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
@@ -368,8 +368,14 @@ public class PortalStepListener implements Listener {
             TransferConfig atc = (ats != null) ? ats.getConfig() : null;
             String arrival = (atc != null) ? atc.getArrivalMessage() : null;
             if (arrival != null && !arrival.isBlank()) {
+                // {realm} is the realm they arrived IN. getServerId() is the network identity every
+                // tier already agrees on (chat-relay.server-id, falling back to webhook.server-id) —
+                // deliberately not a new setting, per its own javadoc.
+                String realm = TransferConfig.realmForServer(
+                        org.fourz.rvnkcore.config.ConfigLoader.getInstance(plugin).getServerId());
                 Bukkit.broadcastMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&',
-                        arrival.replace("{player}", player.getName())));
+                        arrival.replace("{player}", player.getName())
+                                .replace("{realm}", realm)));
             }
         }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
@@ -530,8 +530,11 @@ public class PortalStepListener implements Listener {
             TransferConfig tc = ts.getConfig();
             String template = (tc != null) ? tc.getBroadcastMessage() : null;
             if (template != null && !template.isBlank()) {
+                // Read the realm BEFORE clearTransferring below drops the record.
+                String realm = ts.getTransferRealm(uuid);
                 Bukkit.broadcastMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&',
-                        template.replace("{player}", event.getPlayer().getName())));
+                        template.replace("{player}", event.getPlayer().getName())
+                                .replace("{realm}", realm)));
             }
             ts.clearTransferring(uuid);
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/RVNKToolsInitializer.java
@@ -280,6 +280,11 @@ public class RVNKToolsInitializer {
                             new PortalSignListener(plugin), plugin);
                     plugin.getServer().getPluginManager().registerEvents(
                             new PortalStepListener(plugin), plugin);
+                    // #1858: sign-break is only one destruction vector. Guard the anchor block and
+                    // every non-player path (explosion, fire, piston, entity) so a portal cannot be
+                    // orphaned into a row with no world state behind it.
+                    plugin.getServer().getPluginManager().registerEvents(
+                            new org.fourz.rvnkcore.event.PortalProtectionListener(plugin), plugin);
                     logger.info("Cross-server portal listeners registered (enabled="
                             + portalService.getConfig().isEnabled() + ")");
                 } else {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBuffer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBuffer.java
@@ -1,0 +1,234 @@
+package org.fourz.rvnkcore.service.chatrelay;
+
+import org.fourz.rvnkcore.api.model.ChatMessageDTO;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Bounded in-memory tail of recent chat, so a client can poll for what was said instead of scraping
+ * the console log (#1869).
+ *
+ * <h3>Cursor</h3>
+ * Every recorded message is stamped with a monotonic {@code seq} starting at 1. A client polls with
+ * the last {@code seq} it saw and receives everything after it. Because the buffer is memory-only,
+ * the sequence restarts on every plugin enable — so the buffer also carries a {@code bootId} minted
+ * at construction. A client that sends a {@code bootId} which no longer matches is told
+ * {@link Page#stale}, and resyncs from the buffer head.
+ *
+ * <p>Without that marker a post-restart client sits waiting on a {@code seq} the server has already
+ * reset past and <em>silently stops receiving chat</em> — no error, no way to tell "nothing was said"
+ * from "I am broken". {@code stale} is also raised when the client has fallen so far behind that
+ * messages were evicted before it read them, so a gap is reported rather than hidden.</p>
+ *
+ * <h3>Thread safety</h3>
+ * Writes arrive from the main thread and from async chat threads; reads arrive on Jetty request
+ * threads. Every public method is {@code synchronized} on this instance. Reads copy the matching
+ * slice out under the lock and return an immutable list, so a caller never iterates live state.
+ * (The {@code AtomicReference}-snapshot approach used by {@code LiveDataCache} does not fit here —
+ * that cache is refreshed on a timer, whereas this one is written per chat event.)
+ *
+ * <h3>Not persisted</h3>
+ * No table, no migration. Losing the buffer on restart is expected and is exactly what
+ * {@code bootId} exists to communicate.
+ *
+ * @since 1.5.68
+ */
+public final class ChatMessageBuffer {
+
+    /** Default retained-message count when {@code chat-relay.buffer.size} is unset. */
+    public static final int DEFAULT_SIZE = 500;
+
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 10_000;
+
+    /** Hard ceiling on messages returned by one poll, whatever the caller asks for. */
+    public static final int MAX_LIMIT = 200;
+
+    private final String bootId;
+    private final ArrayDeque<Entry> entries = new ArrayDeque<>();
+    private final Set<String> recordedIds = new HashSet<>();
+
+    private int capacity;
+    private long nextSeq = 1L;
+
+    /**
+     * Creates a buffer with a fresh {@code bootId}.
+     *
+     * @param capacity Requested retained-message count; clamped to [{@value MIN_SIZE}, {@value MAX_SIZE}]
+     */
+    public ChatMessageBuffer(int capacity) {
+        this.bootId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        this.capacity = clamp(capacity);
+    }
+
+    /** One retained message and the cursor position assigned to it. */
+    public static final class Entry {
+        private final long seq;
+        private final ChatMessageDTO dto;
+
+        Entry(long seq, ChatMessageDTO dto) {
+            this.seq = seq;
+            this.dto = dto;
+        }
+
+        public long getSeq() { return seq; }
+
+        public ChatMessageDTO getDto() { return dto; }
+    }
+
+    /** Result of a cursor read: the messages, where the cursor now sits, and whether it was stale. */
+    public static final class Page {
+        private final String bootId;
+        private final long seq;
+        private final boolean stale;
+        private final List<Entry> messages;
+
+        Page(String bootId, long seq, boolean stale, List<Entry> messages) {
+            this.bootId = bootId;
+            this.seq = seq;
+            this.stale = stale;
+            this.messages = messages;
+        }
+
+        /** Buffer identity for this plugin lifetime; send it back on the next poll. */
+        public String getBootId() { return bootId; }
+
+        /** Cursor to poll from next — the highest seq in {@link #getMessages()}, else the buffer head. */
+        public long getSeq() { return seq; }
+
+        /** True when the supplied cursor could not be honoured and the client must resync. */
+        public boolean isStale() { return stale; }
+
+        public List<Entry> getMessages() { return messages; }
+    }
+
+    /**
+     * Records a message, evicting the oldest entry when full.
+     *
+     * <p>Ignores a {@code msgId} already present. Both RVNKEvents' unconditional record and
+     * RVNKCore's relay path can see the same GLOBAL line, and it must appear once (#1871).</p>
+     *
+     * @param dto The message; ignored when null or missing a {@code msgId}
+     * @return true when a new entry was added
+     */
+    public synchronized boolean record(ChatMessageDTO dto) {
+        if (dto == null || dto.getMsgId() == null || dto.getMsgId().isEmpty()) return false;
+        if (!recordedIds.add(dto.getMsgId())) return false;
+
+        entries.addLast(new Entry(nextSeq++, dto));
+        evictToCapacity();
+        return true;
+    }
+
+    /**
+     * Reads everything after {@code sinceSeq}, oldest first.
+     *
+     * @param clientBootId Buffer identity the client last saw; null or mismatched forces a resync
+     * @param sinceSeq     Highest seq the client has already handled; {@code <= 0} means "from the head"
+     * @param limit        Maximum messages to return, clamped to [1, {@value MAX_LIMIT}]
+     * @param room         Room filter (case-insensitive), or null for every room
+     * @param world        World filter (case-insensitive — world names vary in case, #1627), or null
+     * @return A page; never null, possibly empty
+     */
+    public synchronized Page since(String clientBootId, long sinceSeq, int limit,
+                                   String room, String world) {
+        int cap = limit <= 0 ? MAX_LIMIT : Math.min(limit, MAX_LIMIT);
+
+        boolean bootMismatch = clientBootId == null
+                || clientBootId.isEmpty()
+                || !bootId.equals(clientBootId);
+
+        long oldest = entries.isEmpty() ? nextSeq : entries.peekFirst().getSeq();
+        // The client's next expected message is sinceSeq + 1. If the buffer has already evicted past
+        // that point, messages were lost between polls — report the gap instead of hiding it.
+        boolean gap = !bootMismatch && sinceSeq > 0 && (sinceSeq + 1) < oldest;
+
+        boolean stale = bootMismatch || gap;
+        long effectiveSince = stale ? 0L : sinceSeq;
+
+        List<Entry> out = new ArrayList<>();
+        for (Entry e : entries) {
+            if (e.getSeq() <= effectiveSince) continue;
+            if (!matches(e.getDto(), room, world)) continue;
+            out.add(e);
+            if (out.size() >= cap) break;
+        }
+
+        // Cursor advances to the last message actually returned. When a filter matched nothing, hold
+        // the caller's position rather than skipping past unread messages they filtered out.
+        long cursor;
+        if (!out.isEmpty()) {
+            cursor = out.get(out.size() - 1).getSeq();
+        } else if (stale) {
+            cursor = entries.isEmpty() ? nextSeq - 1 : entries.peekLast().getSeq();
+        } else {
+            cursor = sinceSeq;
+        }
+
+        return new Page(bootId, cursor, stale, Collections.unmodifiableList(out));
+    }
+
+    private static boolean matches(ChatMessageDTO dto, String room, String world) {
+        if (room != null && !room.isEmpty()) {
+            if (dto.getRoom() == null || !dto.getRoom().equalsIgnoreCase(room)) return false;
+        }
+        if (world != null && !world.isEmpty()) {
+            if (dto.getWorld() == null || !dto.getWorld().equalsIgnoreCase(world)) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Applies a new capacity, trimming immediately when it shrank.
+     *
+     * <p>Called from {@code refreshConfig} so {@code chat-relay.buffer.size} takes effect on reload
+     * rather than only at boot.</p>
+     *
+     * @param newCapacity Requested size; clamped to [{@value MIN_SIZE}, {@value MAX_SIZE}]
+     */
+    public synchronized void resize(int newCapacity) {
+        this.capacity = clamp(newCapacity);
+        evictToCapacity();
+    }
+
+    /** @return Buffer identity for this plugin lifetime. */
+    public String getBootId() { return bootId; }
+
+    /** @return Seq of the newest retained message, or 0 when empty. */
+    public synchronized long currentSeq() {
+        return entries.isEmpty() ? 0L : entries.peekLast().getSeq();
+    }
+
+    /** @return Retained message count. */
+    public synchronized int size() { return entries.size(); }
+
+    /** @return Effective capacity after clamping. */
+    public synchronized int capacity() { return capacity; }
+
+    private void evictToCapacity() {
+        while (entries.size() > capacity) {
+            Entry dropped = entries.removeFirst();
+            recordedIds.remove(dropped.getDto().getMsgId());
+        }
+        // Defensive: recordedIds tracks exactly what the deque holds, but a msgId collision on an
+        // evicted entry would otherwise leak. Rebuild if the two ever diverge.
+        if (recordedIds.size() > entries.size()) {
+            recordedIds.clear();
+            for (Iterator<Entry> it = entries.iterator(); it.hasNext(); ) {
+                recordedIds.add(it.next().getDto().getMsgId());
+            }
+        }
+    }
+
+    private static int clamp(int value) {
+        if (value < MIN_SIZE) return DEFAULT_SIZE;
+        return Math.min(value, MAX_SIZE);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatRelayService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatRelayService.java
@@ -47,6 +47,10 @@ public class ChatRelayService {
     // per-viewer rendering + world-relay. Null => injectRoom falls back to the flat bot-format render.
     private volatile Consumer<ChatMessageDTO> roomInjector;
 
+    // Bounded chat tail backing GET /v1/chat/recent (#1869). Survives config reload; the bootId is
+    // minted once here so a client can tell a restart from "nothing was said".
+    private final ChatMessageBuffer buffer;
+
     /**
      * Creates a new ChatRelayService.
      *
@@ -61,6 +65,32 @@ public class ChatRelayService {
         this.egress = egress;
         this.logger = logger;
         this.dedupCacheSize = config.getDedupCacheSize();
+        this.buffer = new ChatMessageBuffer(config.getBufferSize());
+    }
+
+    /**
+     * Records a message into the chat tail read by {@code GET /v1/chat/recent} (#1869).
+     *
+     * <p>Safe to call from any thread and idempotent per {@code msgId}, so a line that is both
+     * recorded locally by the chatroom and relayed through {@link #relay} lands once (#1871).</p>
+     *
+     * <p>Recording never affects delivery: a buffer failure must not cost anyone their message.</p>
+     *
+     * @param dto The message to retain
+     */
+    public void record(ChatMessageDTO dto) {
+        try {
+            buffer.record(dto);
+        } catch (RuntimeException e) {
+            logger.warning("Chat buffer record failed (message still delivered): " + e.getMessage());
+        }
+    }
+
+    /**
+     * @return The chat tail buffer, for the {@code /v1/chat/recent} read path
+     */
+    public ChatMessageBuffer getBuffer() {
+        return buffer;
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -142,6 +172,7 @@ public class ChatRelayService {
         dto.setRoom(roomName);
         dto.setWorld(world);
         dto.setServerLabel(config.getServerLabel());
+        record(dto);
 
         Consumer<ChatMessageDTO> injector = this.roomInjector;
         if (injector != null) {
@@ -169,8 +200,12 @@ public class ChatRelayService {
         if (newConfig == null) return;
         this.config = newConfig;
         this.egress = new ChatRelayEgress(newConfig, logger);
+        // Apply chat-relay.buffer.size on reload, not only at boot — a config key that is parsed and
+        // never consumed is a recurring defect in this codebase (#1590, #1598, #1558, #1605).
+        buffer.resize(newConfig.getBufferSize());
         logger.info("ChatRelayService config refreshed — server-id=" + config.getServerId()
-            + ", peers=" + config.getPeers().size() + ", insecure-tls=" + config.isInsecureTls());
+            + ", peers=" + config.getPeers().size() + ", insecure-tls=" + config.isInsecureTls()
+            + ", buffer=" + buffer.capacity());
     }
 
     /**
@@ -182,6 +217,7 @@ public class ChatRelayService {
     public void relay(ChatMessageDTO dto) {
         if (!config.isEnabled() || dto == null || dto.getMsgId() == null) return;
         markSeen(dto.getMsgId());
+        record(dto);
         egress.send(dto);
     }
 
@@ -228,6 +264,8 @@ public class ChatRelayService {
         if (hasComponents) {
             dto.setComponents(components);
         }
+
+        record(dto);
 
         // Origin local echo (main thread — the inbound REST POST is handled off-thread by Jetty).
         renderBot(dto);
@@ -361,6 +399,10 @@ public class ChatRelayService {
         if (dto.getServerLabel() == null || dto.getServerLabel().isEmpty()) {
             dto.setServerLabel(config.resolvePeerTag(dto.getOriginServerId()));
         }
+
+        // Record after the loop/duplicate guards so the tail holds one copy per distinct message,
+        // and before the BOT branch so persona lines from peers are readable too (#1869).
+        record(dto);
 
         // BOT-room lines (#1769, #1773) render via renderBot (styled tellraw when components are present,
         // else bot-format) and BYPASS the external chatroom consumer — a persona broadcast is not a

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
@@ -74,11 +74,20 @@ public class PortalService {
     /**
      * In-memory index: {@code world:x:y:z} -> portal. Authoritative for runtime lookups. Every
      * interior portal block of a framed portal is registered here so walk-through detection is O(1).
+     *
+     * <p><b>volatile, and replaced wholesale by {@link #loadIndex()} rather than cleared in place.</b>
+     * A reader on the main thread holds whichever map reference it read, so it always sees a complete
+     * index — never a half-built one. Clearing in place would open a window where
+     * {@code PortalStepListener} finds no portal, skips its {@code event.setCancelled(true)}, and
+     * vanilla sends a player standing in a cross-server portal to the Nether instead.</p>
      */
-    private final Map<String, PortalDTO> index = new ConcurrentHashMap<>();
+    private volatile Map<String, PortalDTO> index = new ConcurrentHashMap<>();
 
-    /** Portal-id -> portal, so a framed portal can be removed by its (sign-stamped) id in one call. */
-    private final Map<String, PortalDTO> byId = new ConcurrentHashMap<>();
+    /**
+     * Portal-id -> portal, so a framed portal can be removed by its (sign-stamped) id in one call.
+     * Swapped atomically alongside {@link #index}; see that field for why.
+     */
+    private volatile Map<String, PortalDTO> byId = new ConcurrentHashMap<>();
 
     /** Shared frame filler/clearer, used to return interior blocks to AIR on delete. */
     private final PortalFrameBuilder frameBuilder = new PortalFrameBuilder();
@@ -111,22 +120,33 @@ public class PortalService {
             logger.error("Portal schema could not be ensured; starting with an empty index", e);
         }
 
-        index.clear();
-        byId.clear();
+        // Build into fresh maps, then publish both by reference. Never clear the live maps: a reader
+        // on the main thread must see either the whole old index or the whole new one. Clearing in
+        // place let PortalStepListener miss a portal mid-reload and fall through to vanilla nether
+        // travel (Copilot review, rvnktools#41).
+        Map<String, PortalDTO> newIndex = new ConcurrentHashMap<>();
+        Map<String, PortalDTO> newById = new ConcurrentHashMap<>();
+
         List<PortalDTO> portals = repository.listAll();
         for (PortalDTO portal : portals) {
-            byId.put(portal.getPortalId(), portal);
+            newById.put(portal.getPortalId(), portal);
             List<int[]> blocks = portal.getPortalBlocks();
             if (blocks == null || blocks.isEmpty()) {
                 // Legacy single-block portal: the trigger is the anchor block itself.
-                index.put(locationKey(portal.getWorld(), portal.getX(), portal.getY(), portal.getZ()), portal);
+                newIndex.put(locationKey(portal.getWorld(), portal.getX(), portal.getY(), portal.getZ()), portal);
             } else {
                 for (int[] b : blocks) {
-                    index.put(locationKey(portal.getWorld(), b[0], b[1], b[2]), portal);
+                    newIndex.put(locationKey(portal.getWorld(), b[0], b[1], b[2]), portal);
                 }
             }
         }
-        logger.info("Portal index loaded: " + byId.size() + " portal(s), " + index.size()
+
+        // Publish. byId first, then index: index is what gates the vanilla-cancel, so it is the last
+        // thing to change and is never live before its portals are resolvable by id.
+        this.byId = newById;
+        this.index = newIndex;
+
+        logger.info("Portal index loaded: " + newById.size() + " portal(s), " + newIndex.size()
                 + " portal block(s) (enabled=" + config.isEnabled() + ")");
     }
 
@@ -458,10 +478,10 @@ public class PortalService {
         if (exact != null) {
             return Optional.of(exact);
         }
-        String prefix = idOrPrefix.toLowerCase();
+        String prefix = idOrPrefix.toLowerCase(java.util.Locale.ROOT);
         PortalDTO match = null;
         for (Map.Entry<String, PortalDTO> entry : byId.entrySet()) {
-            if (entry.getKey().toLowerCase().startsWith(prefix)) {
+            if (entry.getKey().toLowerCase(java.util.Locale.ROOT).startsWith(prefix)) {
                 if (match != null) {
                     return Optional.empty(); // ambiguous
                 }
@@ -547,7 +567,8 @@ public class PortalService {
                     "No sign is mounted on this portal's anchor block — place one, then repair again", portal);
         }
 
-        String[] lines = PortalSignWriter.buildDisplayLines(transferService, portal.getTargetServer(), portalId);
+        String[] lines = PortalSignWriter.buildDisplayLines(
+                transferService, portal.getTargetServer(), portalId, config.getSignHeader());
         boolean written = PortalSignWriter.write(
                 signBlock.get(), PortalSignWriter.portalIdKey(plugin), portalId, lines);
         if (!written) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalSignWriter.java
@@ -53,9 +53,12 @@ public final class PortalSignWriter {
      * @param transferService the transfer service, for the target's friendly name and world; may be null
      * @param targetServer    the target server name
      * @param portalId        the portal id, which drives the short-id line
+     * @param signHeader      the configured sign header (e.g. {@code [server]}); falls back to
+     *                        {@code [server]} when null or blank
      * @return four legacy-coded sign lines
      */
-    public static String[] buildDisplayLines(TransferService transferService, String targetServer, String portalId) {
+    public static String[] buildDisplayLines(TransferService transferService, String targetServer,
+                                            String portalId, String signHeader) {
         TransferConfig.Target tgt = transferService != null
                 ? transferService.getConfig().resolveTarget(targetServer) : null;
         String display = (tgt != null && tgt.display() != null && !tgt.display().isEmpty())
@@ -64,8 +67,12 @@ public final class PortalSignWriter {
                 ? tgt.world() : "";
         String shortId = (portalId != null && portalId.length() >= 8)
                 ? portalId.substring(0, 8) : (portalId != null ? portalId : "");
+        // Render the CONFIGURED header, not a literal. A server that sets portal.sign-header would
+        // otherwise get repaired signs whose header no longer matches the marker its own listener
+        // accepts, and /portal types would report a header signs do not show (Copilot, rvnktools#41).
+        String header = (signHeader != null && !signHeader.isBlank()) ? signHeader.trim() : "[server]";
         return new String[]{
-                "§9[server]",
+                "§9" + header,
                 "§a" + display,
                 world.isEmpty() ? "" : "§7" + world,
                 "§8" + shortId

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/transfer/TransferService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/transfer/TransferService.java
@@ -57,11 +57,27 @@ public class TransferService {
      * Players whose imminent disconnect is a cross-server transfer, not a real quit (#1763). A quit
      * handler suppresses the vanilla leave message and broadcasts the themed notice for these.
      */
-    private final java.util.Set<UUID> transferring = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<UUID, String> transferring = new ConcurrentHashMap<>();
 
     /** True when the player's pending disconnect is a transfer (checked by the quit handler). */
     public boolean isTransferring(UUID playerId) {
-        return transferring.contains(playerId);
+        return transferring.containsKey(playerId);
+    }
+
+    /**
+     * The in-fiction realm a departing player is bound for.
+     *
+     * <p>The quit handler fires after {@link #transfer} has already dispatched the packet, and a
+     * {@link org.bukkit.event.player.PlayerQuitEvent} carries no destination — so the departure
+     * broadcast can only name where someone went if it was recorded here first.</p>
+     *
+     * @param playerId The departing player
+     * @return The destination realm name, or {@link TransferConfig#UNKNOWN_REALM} when the
+     *         transfer was not recorded (flag expired, or a disconnect that was not a transfer)
+     */
+    public String getTransferRealm(UUID playerId) {
+        String realm = transferring.get(playerId);
+        return (realm == null || realm.isBlank()) ? TransferConfig.UNKNOWN_REALM : realm;
     }
 
     /** Clears a player's transfer flag (called once the quit is handled, or if it never happens). */
@@ -130,8 +146,10 @@ public class TransferService {
         // #1763: flag the imminent disconnect as a transfer so the quit handler suppresses the vanilla
         // leave message and broadcasts the themed notice. Auto-expire in case the transfer fails and no
         // quit follows.
+        // Records the destination realm, not just a flag: the quit handler needs it to say where the
+        // player went, and PlayerQuitEvent carries no destination of its own.
         final UUID transferId = player.getUniqueId();
-        transferring.add(transferId);
+        transferring.put(transferId, target.realm());
         plugin.getServer().getScheduler().runTaskLater(plugin, () -> transferring.remove(transferId), 200L);
 
         // Audit at the call site (no PlayerTransferEvent exists on spigot-api).

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/config/TransferRealmTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/config/TransferRealmTest.java
@@ -1,0 +1,116 @@
+package org.fourz.rvnkcore.api.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for in-fiction realm naming on cross-server crossings.
+ *
+ * <p>The departure broadcast is the only place a player is told where someone went, and the realm
+ * name is resolved from config defaults that no live server carries in its {@code config.yml} —
+ * so the defaults are the shipped behaviour, not a fallback.</p>
+ */
+@DisplayName("Transfer realm naming")
+class TransferRealmTest {
+
+    @Nested
+    @DisplayName("Default realm names")
+    class Defaults {
+
+        @Test
+        @DisplayName("The three known servers have their in-fiction names")
+        void knownServers() {
+            assertEquals("the home realm", realmFor("prod", null, "Nations"));
+            assertEquals("the Arcology", realmFor("event", null, "Event"));
+            assertEquals("the fragile worlds", realmFor("dev", null, "Dev"));
+        }
+
+        @Test
+        @DisplayName("'test' is an alias for dev")
+        void testAliasesDev() {
+            // Dev's chat-relay server-label is "test" while its webhook server-id is "dev";
+            // whichever name a transfer target uses must land on the same realm.
+            assertEquals("the fragile worlds", realmFor("test", null, "Test"));
+        }
+
+        @Test
+        @DisplayName("Target name matching is case-insensitive")
+        void caseInsensitive() {
+            assertEquals("the Arcology", realmFor("EVENT", null, "Event"));
+            assertEquals("the home realm", realmFor("Prod", null, "Nations"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Overrides and fallbacks")
+    class Overrides {
+
+        @Test
+        @DisplayName("An explicit realm: key wins over the default")
+        void explicitWins() {
+            assertEquals("the drowned city", realmFor("event", "the drowned city", "Event"));
+        }
+
+        @Test
+        @DisplayName("A blank realm: key falls through to the default")
+        void blankFallsThrough() {
+            assertEquals("the Arcology", realmFor("event", "   ", "Event"));
+        }
+
+        @Test
+        @DisplayName("An unknown target falls back to its display name")
+        void unknownUsesDisplay() {
+            // A fourth server added to config without a realm: key should read as something,
+            // not as an empty string in the middle of a sentence.
+            assertEquals("Sandbox", realmFor("sandbox", null, "Sandbox"));
+        }
+
+        @Test
+        @DisplayName("An unknown target with no display falls back to a neutral phrase")
+        void unknownWithNoDisplay() {
+            assertEquals(TransferConfig.UNKNOWN_REALM, realmFor("sandbox", null, ""));
+            assertEquals(TransferConfig.UNKNOWN_REALM, realmFor("sandbox", null, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Departure message")
+    class Message {
+
+        @Test
+        @DisplayName("Default names the destination realm")
+        void defaultNamesDestination() {
+            String rendered = TransferConfig.DEFAULT_BROADCAST
+                .replace("{player}", "Twinkies97")
+                .replace("{realm}", "the Arcology");
+
+            assertEquals("&dTwinkies97 &7has crossed to &fthe Arcology", rendered);
+        }
+
+        @Test
+        @DisplayName("Default carries both placeholders")
+        void carriesBothPlaceholders() {
+            assertTrue(TransferConfig.DEFAULT_BROADCAST.contains("{player}"),
+                "departure must name who crossed");
+            assertTrue(TransferConfig.DEFAULT_BROADCAST.contains("{realm}"),
+                "departure must name where they went - the old copy named neither");
+        }
+
+        @Test
+        @DisplayName("Default uses no smart punctuation (#1753)")
+        void asciiSafe() {
+            for (char c : TransferConfig.DEFAULT_BROADCAST.toCharArray()) {
+                assertTrue(c < 128, "non-ASCII char in default broadcast: " + c
+                    + " - the Minecraft font renders these as diamonds");
+            }
+        }
+    }
+
+    /** Calls the real resolver — same package, so no reimplementation of the table under test. */
+    private static String realmFor(String targetName, String configured, String display) {
+        return TransferConfig.resolveRealm(targetName, configured, display);
+    }
+}

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/config/TransferRealmTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/config/TransferRealmTest.java
@@ -77,6 +77,50 @@ class TransferRealmTest {
     }
 
     @Nested
+    @DisplayName("Realm by server identity")
+    class ByServer {
+
+        @Test
+        @DisplayName("Both names for production resolve to the same realm")
+        void productionAliases() {
+            // 'prod' is the transfer target key; 'nations' is the chat-relay tag. Mapping only one
+            // would print a raw infrastructure word in whichever message used the other.
+            assertEquals("the home realm", TransferConfig.realmForServer("prod"));
+            assertEquals("the home realm", TransferConfig.realmForServer("nations"));
+        }
+
+        @Test
+        @DisplayName("Both names for Dev resolve to the same realm")
+        void devAliases() {
+            // getServerId() yields 'dev'; the chat label is 'test'.
+            assertEquals("the fragile worlds", TransferConfig.realmForServer("dev"));
+            assertEquals("the fragile worlds", TransferConfig.realmForServer("test"));
+        }
+
+        @Test
+        @DisplayName("Event resolves to the Arcology")
+        void event() {
+            assertEquals("the Arcology", TransferConfig.realmForServer("event"));
+        }
+
+        @Test
+        @DisplayName("Unknown, blank and null identities yield a neutral phrase")
+        void unknownIsNeutral() {
+            // getServerId() returns "local" on a standalone server; that must still read as a
+            // sentence rather than as an empty string or the word "local".
+            assertEquals(TransferConfig.UNKNOWN_REALM, TransferConfig.realmForServer("local"));
+            assertEquals(TransferConfig.UNKNOWN_REALM, TransferConfig.realmForServer(""));
+            assertEquals(TransferConfig.UNKNOWN_REALM, TransferConfig.realmForServer(null));
+        }
+
+        @Test
+        @DisplayName("Identity matching tolerates case and padding")
+        void tolerant() {
+            assertEquals("the Arcology", TransferConfig.realmForServer("  EVENT  "));
+        }
+    }
+
+    @Nested
     @DisplayName("Departure message")
     class Message {
 
@@ -106,6 +150,25 @@ class TransferRealmTest {
                 assertTrue(c < 128, "non-ASCII char in default broadcast: " + c
                     + " - the Minecraft font renders these as diamonds");
             }
+            for (char c : TransferConfig.DEFAULT_ARRIVAL.toCharArray()) {
+                assertTrue(c < 128, "non-ASCII char in default arrival: " + c);
+            }
+        }
+
+        @Test
+        @DisplayName("Arrival names the realm too, and reads as the other half of the pair")
+        void arrivalMatchesDeparture() {
+            assertTrue(TransferConfig.DEFAULT_ARRIVAL.contains("{player}"));
+            assertTrue(TransferConfig.DEFAULT_ARRIVAL.contains("{realm}"),
+                "arrival must name a realm - the old copy named neither end");
+
+            String departure = TransferConfig.DEFAULT_BROADCAST
+                .replace("{player}", "Twinkies97").replace("{realm}", "the Arcology");
+            String arrival = TransferConfig.DEFAULT_ARRIVAL
+                .replace("{player}", "Twinkies97").replace("{realm}", "the Arcology");
+
+            assertEquals("&dTwinkies97 &7has crossed to &fthe Arcology", departure);
+            assertEquals("&dTwinkies97 &7has crossed into &fthe Arcology", arrival);
         }
     }
 

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImplTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImplTest.java
@@ -373,14 +373,22 @@ class ServletRegistrationServiceImplTest {
     class InputValidation {
 
         @Test
-        @DisplayName("Duplicate registration is rejected")
+        @DisplayName("Re-registration replaces the delegate and reports success (#1604)")
         void testDuplicateRegistration() {
             HttpServlet servlet1 = mock(HttpServlet.class);
             HttpServlet servlet2 = mock(HttpServlet.class);
 
+            // Re-registration used to return false. That WAS the bug (#1604): Jetty cannot remove a
+            // servlet from a started ServletContextHandler, so refusing the second registration left
+            // the first servlet mapped and serving the OLD plugin's classes after a hot reload —
+            // while the plugin logged Enabled and the endpoint returned 200. A deployed REST fix
+            // silently had no effect, which reads as "the fix doesn't work" rather than "the fix was
+            // never loaded". Re-registration now swaps the delegate and reports that it did.
             assertTrue(service.registerServlet("/api/duplicate/*", servlet1));
-            assertFalse(service.registerServlet("/api/duplicate/*", servlet2));
+            assertTrue(service.registerServlet("/api/duplicate/*", servlet2),
+                "re-registration must succeed so a hot-reloaded plugin actually takes over the path");
 
+            // Still one path — a swap, not a second mapping.
             assertEquals(1, service.getRegisteredCount());
         }
 

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/init/InitializerClassesTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/init/InitializerClassesTest.java
@@ -158,9 +158,14 @@ class InitializerClassesTest {
         // Verify accessor methods like getAnnounceManager() delegate to getService()
         Class<?> rvnkCore = Class.forName("org.fourz.rvnkcore.RVNKCore");
 
+        // getAnnounceManager() is deliberately absent: the announcement domain was removed from
+        // RVNKCore in #869 (7372199) and now lives in RVNKEvents. Asserting it here failed the
+        // build for a method that was intentionally deleted — the test was encoding the old shape.
+        assertThrows(NoSuchMethodException.class, () -> rvnkCore.getMethod("getAnnounceManager"),
+            "getAnnounceManager() was removed with the announcement domain (#869) — "
+            + "if this now exists, the domain has moved back into core and this test needs revisiting");
+
         // These methods should exist and return the expected types
-        assertDoesNotThrow(() -> rvnkCore.getMethod("getAnnounceManager"),
-            "RVNKCore should have getAnnounceManager() method");
         assertDoesNotThrow(() -> rvnkCore.getMethod("getLinkMaker"),
             "RVNKCore should have getLinkMaker() method");
         assertDoesNotThrow(() -> rvnkCore.getMethod("getPermissionService"),


### PR DESCRIPTION
10 commits on RVNKCore — new cross-plugin service contracts, the chat tail that backs the cross-server mesh, and portal-anchor hardening.

## New service contracts

- **`ILoreApiService.findNearbyLocations`** for cross-plugin lore lookup (#1924) — lets RVNKWorlds' site survey report real lore instead of guessing.
- **`holdWorld` / `releaseWorld`** runtime world-hold contract (#1883) — consumed by RVNKWorlds and RVNKQuests so a quest-required world is not swept by inactivity cleanup.
- **`GET /worlds/survey`** routed to a new `surveySite` contract (#1923).

## Chat

- **Chat tail buffer + `GET /v1/chat/recent`** (#1869, #1870) — the read path that replaced scraping console output for chat.
- Realm naming on cross-server crossings, plus `realmForServer()`; arrival is now named too.

## Fixes

- **Portal sign + anchor protected against every destruction vector** (#1858).
- Copilot review follow-ups on #41 — reload race, sign header, contracts.
- Two tests asserted deliberately-changed behaviour and blocked `mvn install`; corrected to the intended contract.
- Build: pin maven-compiler-plugin 3.13.0 + `fork` (#1929).

## Notes for review

RVNKCore is the library every other plugin compiles against, so this should merge before the dependent plugin PRs. Worth knowing: **production is currently two versions behind on RVNKCore** — Dev and Event are on `1.5.73-alpha`, Ravenkraft is on `1.5.71-alpha`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N17L7EKTYXcXHNWwit17gc