### PR TITLE
Integrate icarus/dev: chat tail API, portal protection, world holds, compiler pin — RVNKCore 1.5.78-alpha

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.73-alpha</version>
+    <version>1.5.74-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.75-alpha</version>
+    <version>1.5.76-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.76-alpha</version>
+    <version>1.5.78-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.74-alpha</version>
+    <version>1.5.75-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
@@ -148,6 +148,9 @@ public class ChatRelayController extends HttpServlet {
         m.put("senderName", dto.getSenderName());
         m.put("senderUuid", dto.getSenderUuid());
         m.put("message", dto.getMessage());
+        // Line kind (global/world emote, death relay, join/leave notice, ...). Without it a
+        // relayed system notice is indistinguishable from player speech downstream (#1873).
+        m.put("channel", dto.getChannel());
         m.put("room", dto.getRoom());
         m.put("world", dto.getWorld());
         m.put("originServerId", dto.getOriginServerId());

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/CoreServer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/CoreServer.java
@@ -7,6 +7,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.fourz.rvnkcore.api.auth.AuthTokenStore;
 import org.fourz.rvnkcore.api.config.ApiConfig;
 import org.fourz.rvnkcore.api.service.IServletRegistrationService;
@@ -162,9 +163,15 @@ public class CoreServer {
         }
 
         try {
-            // Create server instance
-            server = new Server();
-            
+            // Create server instance.
+            // api.server.max-threads was read into ApiConfig and validated, but never reached Jetty —
+            // `new Server()` builds its own QueuedThreadPool with Jetty's default of 200, so the
+            // configured value (and its validation warning above 200) described nothing (#1558).
+            QueuedThreadPool threadPool = new QueuedThreadPool(config.getMaxThreads());
+            threadPool.setName("rvnkcore-api");
+            server = new Server(threadPool);
+            logger.info("API thread pool max threads: " + config.getMaxThreads());
+
             // Setup connectors (HTTP/HTTPS)
             connectorFactory.setupConnectors(server);
             

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
@@ -147,9 +147,14 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
     
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        // An explicit help request always wins, for leaf and parent commands alike.
+        // An explicit help request always wins, for leaf and parent commands alike. With a verb
+        // argument it serves that verb's usage and worked examples (#1981).
         if (args.length > 0 && args[0].equalsIgnoreCase("help")) {
-            sendHelp(sender);
+            if (args.length >= 2) {
+                sendVerbHelp(sender, args[1].toLowerCase());
+            } else {
+                sendHelp(sender);
+            }
             return true;
         }
 
@@ -238,13 +243,88 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
         sender.sendMessage(ChatColor.YELLOW + "Usage: " + ChatColor.WHITE + getUsage());
         
         if (!subCommands.isEmpty()) {
-            sender.sendMessage(ChatColor.YELLOW + "Subcommands:");
-            for (Map.Entry<String, SubCommand> entry : subCommands.entrySet()) {
-                SubCommand subCommand = entry.getValue();
-                if (subCommand.hasPermission(sender)) {
-                    sender.sendMessage(ChatColor.GRAY + "  " + entry.getKey() + 
-                        ChatColor.WHITE + " - " + subCommand.getDescription());
-                }
+            sendSubCommandList(sender);
+        }
+    }
+
+    /**
+     * The subcommand list, generated from the registry.
+     *
+     * <p>Split out so a command that wants extra lines of its own can print them around the
+     * generated list rather than hand-maintaining a duplicate of it. A hand-kept list drifts: the
+     * {@code /rvnktools} one advertised a {@code createtestdata} command that has no handler
+     * anywhere in the plugin, and RVNKWorlds' curated list had silently lost six verbs. (#1981)</p>
+     */
+    protected void sendSubCommandList(CommandSender sender) {
+        List<String> names = new ArrayList<>(subCommands.keySet());
+        Collections.sort(names);
+
+        List<String> lines = new ArrayList<>();
+        boolean anyExamples = false;
+        for (String name : names) {
+            SubCommand subCommand = subCommands.get(name);
+            if (subCommand == null || !subCommand.hasPermission(sender)) {
+                continue;
+            }
+            boolean hasExamples = !subCommand.getExamples().isEmpty();
+            anyExamples |= hasExamples;
+            lines.add(ChatColor.GRAY + "  " + name
+                    + (hasExamples ? ChatColor.AQUA + "*" : " ")
+                    + ChatColor.WHITE + " - " + subCommand.getDescription());
+        }
+
+        sender.sendMessage(ChatColor.YELLOW + "Subcommands (" + lines.size() + "):");
+        for (String line : lines) {
+            sender.sendMessage(line);
+        }
+        if (anyExamples) {
+            sender.sendMessage(ChatColor.AQUA + "*" + ChatColor.GRAY + " has worked examples — "
+                    + ChatColor.WHITE + "/" + getName() + " help <subcommand>");
+        }
+    }
+
+    /**
+     * {@code /<command> help <verb>} &mdash; one subcommand's usage and worked examples.
+     *
+     * <p>Usage always prints; examples print only when the subcommand overrides
+     * {@link SubCommand#getExamples()}. A verb with none says so rather than showing an empty
+     * section, so the reader knows the usage line is the whole grammar.</p>
+     */
+    protected void sendVerbHelp(CommandSender sender, String verb) {
+        SubCommand subCommand = getSubCommand(verb);
+        if (subCommand == null) {
+            sender.sendMessage(ChatColor.RED + "Unknown subcommand: " + verb);
+            sender.sendMessage(ChatColor.GRAY + "Use " + ChatColor.WHITE + "/" + getName() + " help"
+                    + ChatColor.GRAY + " for the list.");
+            return;
+        }
+        if (!subCommand.hasPermission(sender)) {
+            sendNoPermissionMessage(sender);
+            return;
+        }
+
+        sender.sendMessage(ChatColor.GOLD + "=== " + getName() + " " + verb + " ===");
+        sender.sendMessage(ChatColor.WHITE + subCommand.getDescription());
+        sender.sendMessage(ChatColor.YELLOW + "Usage: " + ChatColor.WHITE + subCommand.getUsage());
+        if (subCommand.isPlayerOnly()) {
+            sender.sendMessage(ChatColor.GRAY + "Players only — not available from console.");
+        }
+        if (subCommand.getPermission() != null) {
+            sender.sendMessage(ChatColor.GRAY + "Permission: " + subCommand.getPermission());
+        }
+
+        List<String> examples = subCommand.getExamples();
+        if (examples.isEmpty()) {
+            sender.sendMessage(ChatColor.GRAY
+                    + "No further examples — the usage line above is the whole grammar.");
+            return;
+        }
+        sender.sendMessage(ChatColor.YELLOW + "Examples:");
+        for (String example : examples) {
+            if (example.startsWith("  ")) {
+                sender.sendMessage(ChatColor.DARK_GRAY + "     " + example.trim());
+            } else {
+                sender.sendMessage(ChatColor.WHITE + "  " + example);
             }
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
@@ -147,28 +147,41 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
     
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        // If no arguments or help is requested, show help
-        if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
+        // An explicit help request always wins, for leaf and parent commands alike.
+        if (args.length > 0 && args[0].equalsIgnoreCase("help")) {
             sendHelp(sender);
             return true;
         }
-        
+
+        // A bare invocation only means "show help" for a command that dispatches to subcommands.
+        // A leaf command must reach executeCommand(), which is the only reason to override it.
+        // This previously returned help unconditionally on zero args, which made every no-argument
+        // command in the plugin unreachable — /ping and /discord both answered with their own usage
+        // text instead of running (#1600).
+        if (args.length == 0) {
+            if (!subCommands.isEmpty()) {
+                sendHelp(sender);
+                return true;
+            }
+            return executeCommand(sender, args);
+        }
+
         // Check for subcommands
         String subCommandName = args[0].toLowerCase();
         SubCommand subCommand = getSubCommand(subCommandName);
-        
+
         if (subCommand != null) {
             // Check if subcommand is player-only
             if (subCommand.isPlayerOnly() && !(sender instanceof Player)) {
                 sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
                 return true;
             }
-            
+
             // Execute subcommand with remaining arguments
             String[] subArgs = Arrays.copyOfRange(args, 1, args.length);
             return subCommand.execute(sender, subArgs);
         }
-        
+
         // If no subcommand found, try to execute the base command
         return executeCommand(sender, args);
     }
@@ -182,6 +195,12 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
      * @return true if the command was handled successfully
      */
     protected boolean executeCommand(CommandSender sender, String[] args) {
+        // Reachable with zero args now that a bare leaf invocation dispatches here (#1600).
+        // A subclass that does not override this has no bare-invocation behaviour to offer.
+        if (args.length == 0) {
+            sendHelp(sender);
+            return true;
+        }
         sendUnknownSubCommandMessage(sender, args[0]);
         return true;
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/SubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/SubCommand.java
@@ -72,8 +72,31 @@ public interface SubCommand {
     
     /**
      * Get the parent command of this subcommand.
-     * 
+     *
      * @return The parent command
      */
     RVNKCommand getParent();
+
+    /**
+     * Worked examples for this subcommand, served by {@code /&lt;command&gt; help &lt;verb&gt;}.
+     *
+     * <p>Return concrete, runnable lines with real-looking arguments &mdash; not a restatement of
+     * {@link #getUsage()}, which the help prints above them. A line beginning with two spaces is
+     * rendered as an indented note under the example above it.</p>
+     *
+     * <p><b>Why the examples live in the jar.</b> Restating them in {@code docs/plugins/commands/}
+     * means an assistant must read a whole page to answer a question about one verb, and the copy
+     * drifts from the build with nothing to catch it &mdash; RVNKWorlds' page had lost six verbs
+     * and RVNKQuests' index advertised three commands with the wrong grammar. Shipping them here
+     * makes them per-verb and unable to drift. The doc pages keep what no command can print:
+     * sequence diagrams, backend class references and changelogs. (#1981)</p>
+     *
+     * <p>Default is empty, so existing subcommands need no change. A verb whose whole grammar fits
+     * in one usage line does not need examples, and the help marks which verbs have them.</p>
+     *
+     * @return example lines, or an empty list when the usage string says everything
+     */
+    default List<String> getExamples() {
+        return List.of();
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/CycleSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/CycleSubCommand.java
@@ -61,4 +61,13 @@ public class CycleSubCommand extends BaseSubCommand {
         }
         return Collections.emptyList();
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/rvnktools cycle reload",
+                "  re-read the cycle-commands config",
+                "/rvnktools cycle help");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/DebugSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/DebugSubCommand.java
@@ -125,4 +125,14 @@ public class DebugSubCommand extends BaseSubCommand {
         }
         return Collections.emptyList();
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/rvnktools debug",
+                "  current debug state and system info",
+                "/rvnktools debug setup",
+                "  bootstrap the LuckPerms permission defaults");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/LinksSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/LinksSubCommand.java
@@ -52,4 +52,12 @@ public class LinksSubCommand extends BaseSubCommand {
         }
         return Collections.emptyList();
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/rvnktools links reload",
+                "  re-read the links config after editing it");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/PingCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/PingCommand.java
@@ -25,13 +25,8 @@ public class PingCommand extends BaseCommand {
 
     @Override
     protected boolean executeCommand(CommandSender sender, String[] args) {
-        // Get TPS information
-        double[] tps = new double[3];
-        try {
-            Object server = Bukkit.getServer().getClass().getMethod("getServer").invoke(Bukkit.getServer());
-            tps = (double[]) server.getClass().getField("recentTps").get(server);
-        } catch (Exception e) {
-            logger.error("Failed to get TPS information", e);
+        double[] tps = readRecentTps();
+        if (tps == null) {
             sender.sendMessage("§cError retrieving TPS information.");
             return true;
         }
@@ -48,7 +43,11 @@ public class PingCommand extends BaseCommand {
                 .append(Bukkit.getMaxPlayers()).append("\n");
         message.append("§eMemory Usage: §f").append(formatMemory(runtime.totalMemory() - runtime.freeMemory()))
                 .append("/").append(formatMemory(runtime.maxMemory())).append("\n");
-        message.append("§eCPU Usage: §f").append(df.format(osBean.getSystemLoadAverage())).append("%\n");
+        // getSystemLoadAverage() is a run-queue load average, not a CPU percentage, and returns a
+        // negative value when the platform cannot supply it.
+        double loadAverage = osBean.getSystemLoadAverage();
+        message.append("§eLoad Average (1m): §f")
+                .append(loadAverage < 0 ? "unavailable" : df.format(loadAverage)).append("\n");
         message.append("§eServer Version: §f").append(Bukkit.getVersion()).append("\n");
         message.append("§eJava Version: §f").append(System.getProperty("java.version")).append("\n");
         message.append("§eOperating System: §f").append(System.getProperty("os.name")).append(" ")
@@ -70,6 +69,45 @@ public class PingCommand extends BaseCommand {
     public List<String> tabComplete(CommandSender sender, String[] args) {
         // Ping command doesn't need tab completion, it takes no arguments
         return Collections.emptyList();
+    }
+
+    /**
+     * Read the server's recent TPS averages.
+     *
+     * <p>RVNKCore compiles against spigot-api, which has no {@code Server#getTPS()}, so the call is
+     * made reflectively. Paper declares {@code public double[] getTPS()} on {@code Server} and every
+     * Ravenkraft tier runs Paper, so this is the primary path.</p>
+     *
+     * <p>The previous implementation reached through {@code CraftServer.getServer()} for the NMS
+     * {@code recentTps} field. That threw {@code NoSuchFieldException} on Paper 26.2 — the field is
+     * not public on the Mojang-mapped server — so the command reported an error every time it was
+     * reached. Falling back to it keeps plain Spigot working (#1600).</p>
+     *
+     * @return the 1m/5m/15m averages, or {@code null} if neither source is available
+     */
+    private double[] readRecentTps() {
+        try {
+            Object result = Bukkit.getServer().getClass().getMethod("getTPS").invoke(Bukkit.getServer());
+            if (result instanceof double[] tps && tps.length >= 3) {
+                return tps;
+            }
+            logger.warning("Server.getTPS() returned an unusable value: " + result);
+        } catch (NoSuchMethodException e) {
+            logger.debug("Server.getTPS() not available — falling back to the NMS recentTps field");
+        } catch (Exception e) {
+            logger.warning("Server.getTPS() failed: " + e.getMessage());
+        }
+
+        try {
+            Object server = Bukkit.getServer().getClass().getMethod("getServer").invoke(Bukkit.getServer());
+            Object tps = server.getClass().getField("recentTps").get(server);
+            if (tps instanceof double[] values && values.length >= 3) {
+                return values;
+            }
+        } catch (Exception e) {
+            logger.error("Failed to get TPS information from both Server.getTPS() and recentTps", e);
+        }
+        return null;
     }
 
     /**

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
@@ -40,9 +40,19 @@ import java.util.UUID;
  */
 public class RVNKCoreCommand extends BaseCommand {
 
+    /**
+     * Bukkit plugins only.
+     *
+     * <p>{@code MickyHats} was listed here and is <b>not a plugin</b> — it is the server resource
+     * pack, set through {@code resource-pack} in {@code server.properties}. Looking it up with
+     * {@code PluginManager#getPlugin} could only ever return null, so every tier reported a
+     * permanent "not loaded" failure for something that was working correctly, and the
+     * not-available count was inflated by one everywhere. The pack is now reported from the server
+     * API in its own section by {@link #handleResourcePack(CommandSender)}.</p>
+     */
     private static final String[] RVNK_PLUGIN_NAMES = {
         "RVNKCore", "RVNKWorlds", "RVNKLore", "RVNKQuests",
-        "BarterShops", "TokenEconomy", "MickyHats"
+        "BarterShops", "TokenEconomy"
     };
 
     private final RVNKCore rvnkCore;
@@ -627,15 +637,83 @@ public class RVNKCoreCommand extends BaseCommand {
                 sender.sendMessage(ChatFormat.colorize("&7   • &a✓ &f" + name + " v" + version + "&7 (enabled" + extra + ")"));
                 loaded++;
             } else if (p != null) {
+                // Present but disabled IS a fault — it means the jar loaded and then failed, so this
+                // one keeps a warning colour.
                 sender.sendMessage(ChatFormat.colorize("&7   • &e⚠ &f" + name + "&7 (loaded but disabled)"));
                 notLoaded++;
             } else {
-                sender.sendMessage(ChatFormat.colorize("&7   • &c✖ &f" + name + "&7 (not loaded)"));
+                // Neutral, not a red failure. Several absences are deliberate — RVNKWorlds is never
+                // installed on production by design, and not every tier runs every plugin — so a red
+                // cross here reported healthy servers as broken.
+                sender.sendMessage(ChatFormat.colorize("&7   • &8– &7" + name + " &8(not installed)"));
                 notLoaded++;
             }
         }
 
-        sender.sendMessage(ChatFormat.colorize("&a✓ Result: " + loaded + " loaded, " + notLoaded + " not available"));
+        sender.sendMessage(ChatFormat.colorize("&a✓ Result: " + loaded + " loaded, " + notLoaded + " not installed"));
+
+        handleResourcePack(sender);
+    }
+
+    /**
+     * Report the server resource pack, read from the running server rather than any hardcoded name.
+     *
+     * <p>Nothing here names a specific pack. The previous code hardcoded {@code MickyHats} as if it
+     * were a plugin, which meant renaming or replacing the pack would have needed a code change and
+     * meanwhile produced a permanent false failure. Reading {@code getResourcePack()} reflects
+     * whatever {@code server.properties} actually sets, including nothing at all.</p>
+     */
+    private void handleResourcePack(CommandSender sender) {
+        String url;
+        boolean required;
+        String hash;
+        try {
+            url = Bukkit.getResourcePack();
+            required = Bukkit.isResourcePackRequired();
+            hash = Bukkit.getResourcePackHash();
+        } catch (Throwable t) {
+            // Never let a diagnostics command die on an optional API.
+            sender.sendMessage(ChatFormat.colorize("&c▶ &6Resource Pack"));
+            sender.sendMessage(ChatFormat.colorize("&7   • &e⚠ unavailable: " + t.getClass().getSimpleName()));
+            return;
+        }
+
+        sender.sendMessage(ChatFormat.colorize("&c▶ &6Resource Pack"));
+
+        if (url == null || url.isBlank()) {
+            sender.sendMessage(ChatFormat.colorize("&7   • &8– none configured"));
+            return;
+        }
+
+        String file = url;
+        String host = "";
+        try {
+            java.net.URI uri = java.net.URI.create(url);
+            String path = uri.getPath() == null ? "" : uri.getPath();
+            int slash = path.lastIndexOf('/');
+            if (slash >= 0 && slash + 1 < path.length()) {
+                file = path.substring(slash + 1);
+            }
+            if (uri.getHost() != null) {
+                host = uri.getHost();
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Not a parseable URI — fall back to showing the raw value.
+        }
+
+        // required=false means players are prompted and may decline, so the pack is NOT guaranteed
+        // to be applied. Saying "enforced" when it is optional would misreport what players see.
+        String enforcement = required ? "&crequired" : "&7optional";
+        sender.sendMessage(ChatFormat.colorize("&7   • &a✓ &f" + file + " &8(" + enforcement + "&8)"));
+        if (!host.isEmpty()) {
+            sender.sendMessage(ChatFormat.colorize("&8     " + host));
+        }
+        if (hash != null && !hash.isBlank()) {
+            String shortHash = hash.length() > 8 ? hash.substring(0, 8) : hash;
+            sender.sendMessage(ChatFormat.colorize("&8     sha1 " + shortHash));
+        } else {
+            sender.sendMessage(ChatFormat.colorize("&8     &eno sha1 — clients re-download every join"));
+        }
     }
 
     // ========================================================

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
@@ -61,9 +61,105 @@ public class RVNKCoreCommand extends BaseCommand {
     public RVNKCoreCommand(RVNKCore plugin) {
         super(plugin, "rvnkcore",
               "RVNKCore diagnostics, testing, and system information",
-              "/rvnkcore <debug|services|db|version|reload|plugins|commands|health|test|mojang> [args]",
+              "/rvnkcore <debug|services|db|version|reload|plugins|commands|health|test|mojang"
+                      + "|migrate|netban|help> [args]",
               "rvnktools.admin.test");
         this.rvnkCore = plugin;
+    }
+
+    /**
+     * Worked examples per verb (#1981).
+     *
+     * <p>{@code /rvnkcore} dispatches from a switch rather than the subcommand registry, so it
+     * cannot inherit {@code BaseCommand.sendVerbHelp}. The examples live here instead of in
+     * {@code docs/plugins/commands/rvnkcore.md} for the same reason they do elsewhere: shipped in
+     * the jar they are fetched per verb and cannot drift from the build.</p>
+     *
+     * <p>A line starting with two spaces renders as a note under the example above it.</p>
+     */
+    private static final java.util.Map<String, java.util.List<String>> VERB_EXAMPLES =
+            buildVerbExamples();
+
+    private static java.util.Map<String, java.util.List<String>> buildVerbExamples() {
+        java.util.Map<String, java.util.List<String>> m = new java.util.LinkedHashMap<>();
+        m.put("debug", java.util.List.of(
+                "/rvnkcore debug",
+                "  full system diagnostics — also what a bare /rvnkcore runs"));
+        m.put("services", java.util.List.of(
+                "/rvnkcore services",
+                "  every interface registered in the ServiceRegistry, and by which plugin",
+                "A plugin whose service is missing here did not finish onEnable."));
+        m.put("db", java.util.List.of(
+                "/rvnkcore db",
+                "  connectivity plus row totals; alias: database",
+                "RVNKCore's MySQL is cross-host — a hang here usually means a missing",
+                "socketTimeout in connectionParameters, not a dead server."));
+        m.put("version", java.util.List.of(
+                "/rvnkcore version",
+                "  read the running version here, never from a commit message or issue comment"));
+        m.put("reload", java.util.List.of(
+                "/rvnkcore reload",
+                "  re-reads config only",
+                "Adding a key to a shipped config.yml does NOT reach a server that already",
+                "has the file — saveResource writes only when the file is absent."));
+        m.put("plugins", java.util.List.of(
+                "/rvnkcore plugins",
+                "  which ecosystem plugins are present and what they registered"));
+        m.put("commands", java.util.List.of(
+                "/rvnkcore commands",
+                "  every command RVNKCore registered, with its permission"));
+        m.put("health", java.util.List.of(
+                "/rvnkcore health",
+                "  the same signal the REST /v1/health endpoint serves"));
+        m.put("test", java.util.List.of(
+                "/rvnkcore test",
+                "  runs the all suite",
+                "/rvnkcore test all",
+                "/rvnkcore test services",
+                "/rvnkcore test db"));
+        m.put("mojang", java.util.List.of(
+                "/rvnkcore mojang name Shad0melt",
+                "  resolve a username to a UUID",
+                "/rvnkcore mojang uuid 28fc0be8-1afb-4b2f-8557-bc28655a8b06",
+                "/rvnkcore mojang verify Shad0melt",
+                "  accepts a username or a UUID",
+                "/rvnkcore mojang stats",
+                "  cache and rate-limit counters — the lookup is rate limited"));
+        m.put("migrate", java.util.List.of(
+                "/rvnkcore migrate playerstate",
+                "/rvnkcore migrate playeridentity",
+                "/rvnkcore migrate playerprefs",
+                "Migrations are one-way. Take a database backup before running one."));
+        m.put("netban", java.util.List.of(
+                "/rvnkcore netban check Shad0melt",
+                "/rvnkcore netban add Shad0melt",
+                "/rvnkcore netban remove Shad0melt",
+                "A network ban applies across every server in the cluster, not just this one."));
+        return m;
+    }
+
+    /**
+     * {@code /rvnkcore help <verb>} &mdash; one verb's examples.
+     */
+    @Override
+    protected void sendVerbHelp(CommandSender sender, String verb) {
+        java.util.List<String> lines = VERB_EXAMPLES.get(verb);
+        if (lines == null) {
+            sender.sendMessage(ChatFormat.colorize("&c✖ No examples for '" + verb + "'."));
+            sender.sendMessage(ChatFormat.colorize(
+                    "&7Verbs: &f" + String.join(" ", VERB_EXAMPLES.keySet())));
+            return;
+        }
+        sender.sendMessage(ChatFormat.colorize("&6/rvnkcore " + verb));
+        for (String line : lines) {
+            if (line.startsWith("  ")) {
+                sender.sendMessage(ChatFormat.colorize("&8     " + line.trim()));
+            } else if (line.startsWith("/")) {
+                sender.sendMessage(ChatFormat.colorize("&f  " + line));
+            } else {
+                sender.sendMessage(ChatFormat.colorize("&7  " + line));
+            }
+        }
     }
 
     @Override
@@ -120,6 +216,8 @@ public class RVNKCoreCommand extends BaseCommand {
                         args.length > 1 ? args[1].toLowerCase() : "",
                         args.length > 2 ? args[2] : "");
                 break;
+            // "help" never reaches here — BaseCommand.execute intercepts it and routes to the
+            // sendHelp / sendVerbHelp overrides below.
             default:
                 sender.sendMessage(ChatFormat.colorize("&c✖ Unknown subcommand: " + sub));
                 sendHelp(sender);
@@ -1095,19 +1193,30 @@ public class RVNKCoreCommand extends BaseCommand {
     // Help
     // ========================================================
 
+    /**
+     * The verb index, generated from {@link #VERB_EXAMPLES} so it cannot drift.
+     *
+     * <p>The previous hand-written list omitted {@code migrate}, {@code netban} and {@code help} —
+     * three of the twelve verbs — for the same reason every hand-kept list in this repo has
+     * drifted: nothing makes you update it when the switch gains a case. Adding a verb to
+     * {@code VERB_EXAMPLES} now adds it here, and {@code /rvnkcore help <verb>} serves it. (#1981)</p>
+     */
     @Override
     public void sendHelp(CommandSender sender) {
         sender.sendMessage(ChatFormat.colorize("&6=== RVNKCore Commands ==="));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore debug &7- Comprehensive system diagnostics"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore services &7- List registered services"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore db &7- Test database connectivity"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore version &7- Show version information"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore reload &7- Reload configuration"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore plugins &7- List RVNK plugin status"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore commands &7- Show CommandManager state"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore health &7- Full system health check"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore test [all|services|db] &7- Run test suite"));
-        sender.sendMessage(ChatFormat.colorize("&e/rvnkcore mojang <op> [args] &7- Mojang API operations"));
+        for (java.util.Map.Entry<String, java.util.List<String>> e : VERB_EXAMPLES.entrySet()) {
+            java.util.List<String> body = e.getValue();
+            String note = "";
+            for (String line : body) {
+                if (line.startsWith("  ")) {
+                    note = " &7- " + line.trim();
+                    break;
+                }
+            }
+            sender.sendMessage(ChatFormat.colorize("&e/rvnkcore " + e.getKey() + note));
+        }
+        sender.sendMessage(ChatFormat.colorize(
+                "&7Examples for one verb: &f/rvnkcore help <verb>"));
     }
 
     private void sendMojangHelp(CommandSender sender) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKToolsCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKToolsCommand.java
@@ -34,19 +34,23 @@ public class RVNKToolsCommand extends BaseCommand {
         return true;
     }
 
+    /**
+     * The subcommand list is generated (#1981); only the standalone shortcuts are hand-written,
+     * because no registry knows about them.
+     *
+     * <p>The previous hand-kept list advertised
+     * {@code /rvnktools createtestdata [all|types|announcements]}. That command has no handler
+     * anywhere in the plugin and never ran &mdash; the line was the only trace of it. That is the
+     * cost of restating a registry by hand, so the list below comes from the registry.</p>
+     */
     @Override
     public void sendHelp(CommandSender sender) {
         sender.sendMessage("§c▶ §6RVNKTools Administrative Commands");
-        sender.sendMessage("§7   Use /rvnktools <subcommand> for detailed help");
+        sender.sendMessage("§7   Use §f/rvnktools help <subcommand>§7 for usage and examples");
         sender.sendMessage("");
-        sender.sendMessage("§f/rvnktools links reload §7- Reload links configuration");
-        sender.sendMessage("§f/rvnktools cycle reload §7- Reload cycle commands configuration");
-        sender.sendMessage("§f/rvnktools teleport worldswap [world] §7- Teleport between worlds");
-        sender.sendMessage("§f/rvnktools reload §7- Reload plugin configuration");
-        sender.sendMessage("§f/rvnktools debug §7- Show debug information");
-        sender.sendMessage("§f/rvnktools createtestdata [all|types|announcements] §7- Create test data for API");
+        sendSubCommandList(sender);
         sender.sendMessage("");
-        sender.sendMessage("§e⚠ §7Quick access commands:");
+        sender.sendMessage("§e⚠ §7Standalone shortcuts (not subcommands):");
         sender.sendMessage("§f/worldswap [world] §7- Direct world swap command");
         sender.sendMessage("§f/event [world] §7- Event world shortcut command");
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TeleportSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/TeleportSubCommand.java
@@ -60,4 +60,14 @@ public class TeleportSubCommand extends BaseSubCommand {
         }
         return Collections.emptyList();
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/rvnktools teleport worldswap",
+                "  swap to your configured default world",
+                "/rvnktools teleport worldswap event",
+                "The standalone /worldswap [world] does the same thing with less typing.");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportCoordsSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportCoordsSubCommand.java
@@ -139,4 +139,16 @@ public class TeleportCoordsSubCommand extends BaseSubCommand {
 
         return completions;
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/teleport coords 100 64 -200",
+                "  teleport yourself to the coordinates",
+                "/teleport coords Shad0melt 100 64 -200",
+                "  teleport that player there",
+                "Coordinates land in the player's CURRENT world. To cross worlds use",
+                "/world tp <world> <player> - a plain teleport does not activate a world.");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportHereSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportHereSubCommand.java
@@ -66,4 +66,12 @@ public class TeleportHereSubCommand extends BaseSubCommand {
 
         return completions;
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/teleport here Shad0melt",
+                "  bring that player to you; requires a player sender");
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportPlayerSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/teleport/TeleportPlayerSubCommand.java
@@ -104,4 +104,14 @@ public class TeleportPlayerSubCommand extends BaseSubCommand {
 
         return completions;
     }
+
+    /** Worked examples served by {@code help <verb>} (#1981). */
+    @Override
+    public java.util.List<String> getExamples() {
+        return java.util.List.of(
+                "/teleport player Shad0melt",
+                "  teleport yourself to that player",
+                "/teleport player Shad0melt wizardofire",
+                "  teleport the first player to the second");
+    }
 }

--- a/toolkitplugin/src/main/resources/config.yml
+++ b/toolkitplugin/src/main/resources/config.yml
@@ -242,21 +242,20 @@ portal:
 logging:
   level: INFO
 
-# Storage configuration for RVNKCore database tables
+# Table-naming configuration for RVNKCore database tables.
+#
+# Only `type` and `<type>.tablePrefix` are read (DatabaseSetup). Connection settings live under
+# `database:` above — this section previously also carried host/port/database/username/password/useSSL,
+# a full second MySQL credential block that nothing ever read. Editing those did nothing while
+# appearing to be the place to configure the database, so they have been removed (#1605).
 storage:
-  # Storage type: sqlite (default) or mysql
+  # Selects which tablePrefix below applies: sqlite (default) or mysql
   type: sqlite
   sqlite:
     # Table prefix for shared database hosting (e.g., "core_" creates "core_rvnk_players")
     # Leave empty for no prefix (default)
     tablePrefix: ""
   mysql:
-    host: localhost
-    port: 3306
-    database: minecraft
-    username: root
-    password: ""
-    useSSL: false
     # Table prefix for shared database hosting
     tablePrefix: ""
 

--- a/toolkitplugin/src/test/java/org/fourz/rvnktools/command/manager/BaseCommandDispatchTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnktools/command/manager/BaseCommandDispatchTest.java
@@ -1,0 +1,194 @@
+package org.fourz.rvnktools.command.manager;
+
+import org.bukkit.command.CommandSender;
+import org.fourz.rvnkcore.RVNKCore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Dispatch tests for {@link BaseCommand#execute(CommandSender, String[])} (#1600).
+ *
+ * <p>The defect: a bare invocation returned help unconditionally, so any command with no arguments
+ * never reached {@link BaseCommand#executeCommand(CommandSender, String[])}. On Dev this made
+ * {@code /ping} and {@code /discord} answer with their own usage text instead of running. Only 2 of
+ * 23 BaseCommand subclasses register subcommands, so the great majority were leaf commands hitting
+ * the parent-command path.</p>
+ *
+ * <p>Control: reverting {@code execute()} to {@code if (args.length == 0 || ...) sendHelp} fails
+ * {@code leafCommandWithNoArgsReachesExecuteCommand} and
+ * {@code leafCommandWithNoArgsDoesNotShowHelp}, and passes every other case here — so these tests
+ * discriminate the fix rather than merely covering the method.</p>
+ */
+class BaseCommandDispatchTest {
+
+    private RVNKCore plugin;
+
+    /** Minimal concrete BaseCommand that records how it was dispatched. */
+    private static class ProbeCommand extends BaseCommand {
+        boolean executeCommandCalled;
+        boolean helpShown;
+        String[] receivedArgs;
+
+        ProbeCommand(RVNKCore plugin) {
+            super(plugin, "probe", "probe description", "/probe", null);
+        }
+
+        @Override
+        protected boolean executeCommand(CommandSender sender, String[] args) {
+            executeCommandCalled = true;
+            receivedArgs = args;
+            return true;
+        }
+
+        @Override
+        public void sendHelp(CommandSender sender) {
+            helpShown = true;
+        }
+    }
+
+    /** Stub subcommand that records invocation. */
+    private static class ProbeSubCommand implements SubCommand {
+        boolean executed;
+        String[] receivedArgs;
+
+        @Override
+        public boolean execute(CommandSender sender, String[] args) {
+            executed = true;
+            receivedArgs = args;
+            return true;
+        }
+
+        @Override
+        public List<String> tabComplete(CommandSender sender, String[] args) {
+            return List.of();
+        }
+
+        @Override
+        public String getName() {
+            return "sub";
+        }
+
+        @Override
+        public String getDescription() {
+            return "sub description";
+        }
+
+        @Override
+        public String getUsage() {
+            return "/probe sub";
+        }
+
+        @Override
+        public String getPermission() {
+            return null;
+        }
+
+        @Override
+        public boolean hasPermission(CommandSender sender) {
+            return true;
+        }
+
+        @Override
+        public boolean isPlayerOnly() {
+            return false;
+        }
+
+        @Override
+        public RVNKCommand getParent() {
+            return null;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        plugin = mock(RVNKCore.class);
+    }
+
+    @Test
+    @DisplayName("Leaf command with no args reaches executeCommand")
+    void leafCommandWithNoArgsReachesExecuteCommand() {
+        ProbeCommand command = new ProbeCommand(plugin);
+
+        assertTrue(command.execute(mock(CommandSender.class), new String[0]));
+
+        assertTrue(command.executeCommandCalled,
+                "a command with no subcommands must run on bare invocation");
+        assertEquals(0, command.receivedArgs.length);
+    }
+
+    @Test
+    @DisplayName("Leaf command with no args does not show help")
+    void leafCommandWithNoArgsDoesNotShowHelp() {
+        ProbeCommand command = new ProbeCommand(plugin);
+
+        command.execute(mock(CommandSender.class), new String[0]);
+
+        assertFalse(command.helpShown, "bare invocation of a leaf command is not a help request");
+    }
+
+    @Test
+    @DisplayName("Parent command with no args still shows help and does not execute")
+    void parentCommandWithNoArgsShowsHelp() {
+        ProbeCommand command = new ProbeCommand(plugin);
+        command.registerSubCommand("sub", new ProbeSubCommand());
+
+        command.execute(mock(CommandSender.class), new String[0]);
+
+        assertTrue(command.helpShown, "a command that dispatches to subcommands lists them");
+        assertFalse(command.executeCommandCalled);
+    }
+
+    @Test
+    @DisplayName("Explicit help argument shows help on a leaf command")
+    void explicitHelpArgumentShowsHelp() {
+        ProbeCommand command = new ProbeCommand(plugin);
+
+        command.execute(mock(CommandSender.class), new String[]{"help"});
+
+        assertTrue(command.helpShown);
+        assertFalse(command.executeCommandCalled);
+    }
+
+    @Test
+    @DisplayName("Leaf command passes its arguments through to executeCommand")
+    void leafCommandPassesArgumentsThrough() {
+        ProbeCommand command = new ProbeCommand(plugin);
+
+        command.execute(mock(CommandSender.class), new String[]{"alpha", "beta"});
+
+        assertTrue(command.executeCommandCalled);
+        assertArrayEquals(new String[]{"alpha", "beta"}, command.receivedArgs);
+    }
+
+    @Test
+    @DisplayName("Known subcommand receives the remaining arguments")
+    void knownSubCommandReceivesRemainingArgs() {
+        ProbeCommand command = new ProbeCommand(plugin);
+        ProbeSubCommand sub = new ProbeSubCommand();
+        command.registerSubCommand("sub", sub);
+
+        command.execute(mock(CommandSender.class), new String[]{"sub", "alpha"});
+
+        assertTrue(sub.executed);
+        assertArrayEquals(new String[]{"alpha"}, sub.receivedArgs);
+        assertFalse(command.executeCommandCalled);
+    }
+
+    @Test
+    @DisplayName("Unknown first argument falls through to executeCommand")
+    void unknownArgumentFallsThroughToExecuteCommand() {
+        ProbeCommand command = new ProbeCommand(plugin);
+        command.registerSubCommand("sub", new ProbeSubCommand());
+
+        command.execute(mock(CommandSender.class), new String[]{"notasubcommand"});
+
+        assertTrue(command.executeCommandCalled);
+        assertArrayEquals(new String[]{"notasubcommand"}, command.receivedArgs);
+    }
+}


### PR DESCRIPTION
Integration of 15 commits from `icarus/dev`. Ships RVNKCore **1.5.78-alpha**.

Merge this **first** — the other plugin PRs build against this version.

## Headlines

**Chat tail API (#1869/#1870/#1873)** — `GET /v1/chat/recent` with a cursor, returning `channel` so a system notice is distinguishable from speech. This is what replaces console scraping for chat reads; `activity_fallback` scraping had been giving wrong answers.

**Cross-server realm naming + portal protection (#1858)** — the portal sign and anchor are now protected from every destruction vector, and a crossing names the destination realm on both departure and arrival.

**World holds (#1883)** — `holdWorld` / `releaseWorld` runtime contract, so a plugin can pin a world against unload.

**Survey + lore contracts (#1923, #1924)** — `GET /worlds/survey` routed to a new `surveySite` contract, and `ILoreApiService.findNearbyLocations` for cross-plugin lore lookup.

**Three real bugs in 1.5.75-alpha (#1600, #1558, #1605)** — zero-arg commands never ran, TPS reflection was broken, and `max-threads` was never applied.

**Build toolchain (#1929)** — pins `maven-compiler-plugin` 3.13.0 with `fork=true` across all plugins. Unpinned poms resolved to 3.15.0 under Maven 3.9.14, whose in-process compiler reuse crashes `javac` on the *second* compilation: main sources compile, then `default-testCompile` fails claiming it cannot find main classes that plainly exist. Verify with `mvn help:effective-pom`, not by reading the pom.

**Command help (#1981)** — shared `SubCommand.getExamples` + `help <verb>`, and `createtestdata` dropped from the advertised verbs because it had no handler anywhere in the plugin.

## Verification

Live on Dev, Event and production at 1.5.78-alpha. Clean enable on all three, services registered, REST server up.
