### PR TITLE
style(rvnktools): normalize typographic punctuation in console strings to ASCII

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.78-alpha</version>
+    <version>1.5.79-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/RVNKCore.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/RVNKCore.java
@@ -189,7 +189,7 @@ public class RVNKCore extends JavaPlugin implements Listener {
                 DatabaseConfig clusterConfig = coreConfigLoader.getClusterDatabaseConfig();
                 if (clusterConfig == null) {
                     logger.warning("cluster.enabled=true with role=member but cluster.mysql.host/database "
-                            + "are not set — cluster features disabled, local database unaffected");
+                            + "are not set - cluster features disabled, local database unaffected");
                     return;
                 }
                 ConnectionProvider clusterPool = factory.createConnectionProvider(clusterConfig);
@@ -198,10 +198,10 @@ public class RVNKCore extends JavaPlugin implements Listener {
             }
 
             databaseSetup.initializeClusterTables(clusterConnectionProvider);
-            logger.info("Cluster-shared data enabled — " + clusterConnectionProvider.describeTarget());
+            logger.info("Cluster-shared data enabled - " + clusterConnectionProvider.describeTarget());
 
         } catch (Exception e) {
-            logger.error("Cluster database setup failed (role=" + role + ") — cluster features "
+            logger.error("Cluster database setup failed (role=" + role + ") - cluster features "
                     + "disabled; this server's local database is unaffected", e);
             closeClusterProviderQuietly();
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/chat/ChatRelayEgress.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/chat/ChatRelayEgress.java
@@ -101,7 +101,7 @@ public class ChatRelayEgress {
             return ctx;
         } catch (Exception e) {
             logger.warning("ChatRelay insecure-tls requested but trust-all SSLContext failed: "
-                + e.getMessage() + " — self-signed peers will not be reachable");
+                + e.getMessage() + " - self-signed peers will not be reachable");
             return null;
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ApiConfig.java
@@ -239,7 +239,7 @@ public class ApiConfig {
             }
             
             if (apiKey == null || apiKey.trim().isEmpty() || "changeme".equals(apiKey.trim()) || apiKey.trim().length() < 16) {
-                logger.error("API key is insecure (default 'changeme' or shorter than 16 characters) — API server will not start. Set api.auth.key in config.yml.");
+                logger.error("API key is insecure (default 'changeme' or shorter than 16 characters) - API server will not start. Set api.auth.key in config.yml.");
                 isValid = false;
             }
             

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ChatRelayConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/ChatRelayConfig.java
@@ -146,10 +146,10 @@ public class ChatRelayConfig {
             valid = false;
         }
         if (peers.isEmpty()) {
-            logger.warning("Chat relay enabled but no peers configured — nothing will be relayed");
+            logger.warning("Chat relay enabled but no peers configured - nothing will be relayed");
         }
         if (insecureTls) {
-            logger.warning("Chat relay insecure-tls is ON — peer TLS certificates are NOT verified "
+            logger.warning("Chat relay insecure-tls is ON - peer TLS certificates are NOT verified "
                 + "(self-signed peers accepted). Only use on a trusted server-to-server network; the "
                 + "egress X-API-Key would be exposed to a man-in-the-middle.");
         }
@@ -168,7 +168,7 @@ public class ChatRelayConfig {
                 valid = false;
             }
             if (serverId.equals(peer.id())) {
-                logger.error("Chat relay peer '" + peer.id() + "' has the same id as this server — would loop");
+                logger.error("Chat relay peer '" + peer.id() + "' has the same id as this server - would loop");
                 valid = false;
             }
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/PortalConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/PortalConfig.java
@@ -87,7 +87,7 @@ public class PortalConfig {
         boolean valid = true;
         if (triggerMaterial == null) {
             logger.error("Portal trigger-block '" + triggerBlock
-                    + "' did not resolve to a Material — portals cannot be triggered");
+                    + "' did not resolve to a Material - portals cannot be triggered");
             valid = false;
         } else if (!triggerMaterial.isBlock()) {
             logger.error("Portal trigger-block '" + triggerBlock
@@ -95,7 +95,7 @@ public class PortalConfig {
             valid = false;
         }
         if (signHeader.isEmpty()) {
-            logger.warning("Portal sign-header is empty — signs cannot be recognised as portals");
+            logger.warning("Portal sign-header is empty - signs cannot be recognised as portals");
         }
         return valid;
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/TransferConfig.java
@@ -213,7 +213,7 @@ public class TransferConfig {
         }
         boolean valid = true;
         if (targets.isEmpty()) {
-            logger.warning("Transfer enabled but no targets configured — nothing can be transferred to");
+            logger.warning("Transfer enabled but no targets configured - nothing can be transferred to");
         }
         for (Map.Entry<String, Target> entry : targets.entrySet()) {
             String name = entry.getKey();

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/WebhookConfig.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/config/WebhookConfig.java
@@ -88,7 +88,7 @@ public class WebhookConfig {
             try {
                 String host = URI.create(url).getHost();
                 if (isInternalHost(host)) {
-                    logger.error("Webhook URL resolves to a private/loopback address — SSRF risk blocked: " + host);
+                    logger.error("Webhook URL resolves to a private/loopback address - SSRF risk blocked: " + host);
                     valid = false;
                 }
             } catch (Exception e) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/AuthController.java
@@ -223,7 +223,7 @@ public class AuthController extends HttpServlet {
         } catch (TimeoutException e) {
             // DB-pool contention (not a real failure) — degrade gracefully so the caller can retry (#1466).
             logger.warning("Session-token lookup for UUID " + uuid + " timed out after "
-                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) — returning 503");
+                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) - returning 503");
             ApiUtils.sendError(resp, gson, 503, "LOOKUP_TIMEOUT",
                     "Player lookup timed out, please retry");
         } catch (Exception e) {
@@ -293,7 +293,7 @@ public class AuthController extends HttpServlet {
             // DB-pool contention (not a real failure) — degrade gracefully so the WebUI/widget can
             // retry instead of treating the user as logged-out. Logged at WARN, not ERROR (#1466).
             logger.warning("Session validation for UUID " + uuid + " timed out after "
-                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) — returning 503");
+                    + PLAYER_LOOKUP_TIMEOUT_SECONDS + "s (DB-pool contention) - returning 503");
             ApiUtils.sendError(resp, gson, 503, "LOOKUP_TIMEOUT",
                     "Player lookup timed out, please retry");
         } catch (Exception e) {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/ChatRelayController.java
@@ -302,7 +302,7 @@ public class ChatRelayController extends HttpServlet {
 
         if (obj != null && obj.has("components") && !obj.get("components").isJsonNull()) {
             ApiUtils.sendError(resp, gson, 400, "BAD_REQUEST",
-                    "Room posts are plain text — use 'message'. Styled 'components' is supported on "
+                    "Room posts are plain text - use 'message'. Styled 'components' is supported on "
                     + "POST /v1/chat/broadcast only.");
             return;
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WhitelistController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/WhitelistController.java
@@ -105,7 +105,7 @@ public class WhitelistController extends HttpServlet {
         String ign = body.get("ign").toString().trim();
         if (!ign.matches("[a-zA-Z0-9_]{3,16}")) {
             ApiUtils.sendError(resp, gson, 400, "INVALID_IGN",
-                    "IGN must be 3–16 characters (letters, numbers, underscores)");
+                    "IGN must be 3-16 characters (letters, numbers, underscores)");
             return;
         }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/ClusterBanListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/ClusterBanListener.java
@@ -74,7 +74,7 @@ public class ClusterBanListener implements Listener {
             }
 
             logger.info("Refused login for " + event.getName()
-                    + " — banned on the network roster (#1814)");
+                    + " - banned on the network roster (#1814)");
             event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_BANNED,
                     "You are banned from the Ravenkraft network.");
 
@@ -82,7 +82,7 @@ public class ClusterBanListener implements Listener {
             // Fail open — see the class javadoc. Logged at WARNING because a persistent failure
             // means bans silently stop being enforced, which should not pass unnoticed.
             logger.warning("Network ban check failed for " + event.getName()
-                    + " — allowing login (fail-open): " + e.getMessage());
+                    + " - allowing login (fail-open): " + e.getMessage());
         }
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerBanListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/PlayerBanListener.java
@@ -40,7 +40,7 @@ public class PlayerBanListener implements Listener {
             return;
         }
 
-        logger.info("Ban detected for " + playerName + " — updating record and firing webhook");
+        logger.info("Ban detected for " + playerName + " - updating record and firing webhook");
 
         // Update player record with banned status
         try {

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/presence/PresenceEgress.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/presence/PresenceEgress.java
@@ -107,7 +107,7 @@ public class PresenceEgress {
             return ctx;
         } catch (Exception e) {
             logger.warning("Presence insecure-tls requested but trust-all SSLContext failed: "
-                + e.getMessage() + " — self-signed peers will not be reachable");
+                + e.getMessage() + " - self-signed peers will not be reachable");
             return null;
         }
     }
@@ -190,7 +190,7 @@ public class PresenceEgress {
                 if (!h.circuitLogged) {
                     h.circuitLogged = true;
                     logger.warning(logTag + " appears offline after " + h.failures
-                            + " consecutive failures (" + reason + ") — pausing presence polling for "
+                            + " consecutive failures (" + reason + ") - pausing presence polling for "
                             + (CIRCUIT_MS / 60_000L) + " minutes");
                 } else {
                     logger.debug(logTag + " still offline (" + reason + ")");
@@ -200,7 +200,7 @@ public class PresenceEgress {
                 if (!h.backoffLogged) {
                     h.backoffLogged = true;
                     logger.warning(logTag + " failed " + h.failures + "x (" + reason
-                            + ") — backing off to every " + (BACKOFF_MS / 1000L)
+                            + ") - backing off to every " + (BACKOFF_MS / 1000L)
                             + "s; further failures at DEBUG until it recovers");
                 } else {
                     logger.debug(logTag + " failed (" + reason + ")");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServerSSLFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServerSSLFactory.java
@@ -112,7 +112,7 @@ public class ServerSSLFactory {
                 return keystoreFile;
             }
             // SANs changed — delete and regenerate
-            logger.info("Configured hostnames changed — regenerating TLS certificate");
+            logger.info("Configured hostnames changed - regenerating TLS certificate");
             keystoreFile.delete();
         }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/impl/ServletRegistrationServiceImpl.java
@@ -156,7 +156,7 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
             registeredServlets.put(normalizedPath,
                     new ServletRegistration(servlet, displayName, requireAuth, true));
             logger.info("Servlet at " + normalizedPath + " rebound to " + displayName
-                    + " (hot swap) — previous delegate replaced");
+                    + " (hot swap) - previous delegate replaced");
             return true;
         }
 
@@ -190,7 +190,7 @@ public class ServletRegistrationServiceImpl implements IServletRegistrationServi
             DelegatingServlet wrapper = boundWrappers.get(normalizedPath);
             if (wrapper != null) {
                 wrapper.clearDelegate();
-                logger.debug("Cleared delegate for " + normalizedPath + " — path now returns 503");
+                logger.debug("Cleared delegate for " + normalizedPath + " - path now returns 503");
             }
             return true;
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/PortalCommand.java
@@ -144,7 +144,7 @@ public class PortalCommand extends BaseCommand {
             // loaded — the #1752 confusion, one level up.
             if (extension == null) {
                 sender.sendMessage(ChatColor.GOLD + "World portals" + ChatColor.GRAY
-                        + " — unavailable: no portal provider is loaded (RVNKWorlds absent).");
+                        + " - unavailable: no portal provider is loaded (RVNKWorlds absent).");
             } else {
                 sender.sendMessage(ChatColor.GOLD + "World portals" + ChatColor.GRAY
                         + " (via " + extension.providerName() + ")");
@@ -158,7 +158,7 @@ public class PortalCommand extends BaseCommand {
                             logger.warning("Portal extension '" + extension.providerName()
                                     + "' failed while listing world portals: " + ex);
                             sender.sendMessage(ChatColor.RED
-                                    + "  (world portal listing failed — see console)");
+                                    + "  (world portal listing failed - see console)");
                         }
                     });
                 }
@@ -181,7 +181,7 @@ public class PortalCommand extends BaseCommand {
             sender.sendMessage(ChatColor.RED + "No cross-server portal matches '" + args[0]
                     + "' (unknown id, or an ambiguous prefix).");
             if (extension != null) {
-                sender.sendMessage(ChatColor.GRAY + "  It may be a world portal — try "
+                sender.sendMessage(ChatColor.GRAY + "  It may be a world portal - try "
                         + ChatColor.WHITE + "/world portal info " + args[0]);
             }
             return true;
@@ -200,7 +200,7 @@ public class PortalCommand extends BaseCommand {
                 + (portal.getOwnerUuid() != null ? portal.getOwnerUuid() : "unknown"));
         sender.sendMessage(ChatColor.GRAY + "  state      " + colourFor(state) + state.name().toLowerCase(Locale.ROOT));
         if (state == PortalService.Verification.UNVERIFIED) {
-            sender.sendMessage(ChatColor.GRAY + "             world or chunk not loaded — not checked, not broken");
+            sender.sendMessage(ChatColor.GRAY + "             world or chunk not loaded - not checked, not broken");
         } else if (state == PortalService.Verification.ORPHANED) {
             sender.sendMessage(ChatColor.GRAY + "             trigger block or stamped sign missing; "
                     + "repair with /portal repair, or remove with /portal delete");
@@ -319,7 +319,7 @@ public class PortalCommand extends BaseCommand {
         PortalService service = portalService();
         sender.sendMessage(ChatColor.GOLD + "Portal systems on this server");
         if (service != null) {
-            sender.sendMessage(ChatColor.WHITE + "  SERVER " + ChatColor.GRAY + "(RVNKCore) — "
+            sender.sendMessage(ChatColor.WHITE + "  SERVER " + ChatColor.GRAY + "(RVNKCore) - "
                     + service.getConfig().getSignHeader() + " sign on a "
                     + service.getConfig().getTriggerBlock() + " frame; sends you to another server. "
                     + "Manage with /portal.");
@@ -327,11 +327,11 @@ public class PortalCommand extends BaseCommand {
         IPortalCommandExtension extension = extension();
         if (extension == null) {
             sender.sendMessage(ChatColor.WHITE + "  WORLD  " + ChatColor.GRAY
-                    + "— no provider loaded (RVNKWorlds absent).");
+                    + "- no provider loaded (RVNKWorlds absent).");
         } else {
             String described = extension.describe();
             sender.sendMessage(ChatColor.WHITE + "  WORLD  " + ChatColor.GRAY + "(" + extension.providerName()
-                    + ") — " + (described != null ? described : "no description provided"));
+                    + ") - " + (described != null ? described : "no description provided"));
         }
         return true;
     }
@@ -455,7 +455,7 @@ public class PortalCommand extends BaseCommand {
         }
         if (!clashes.isEmpty()) {
             logger.warning("Portal extension '" + provider + "' claims subcommand(s) reserved by core: "
-                    + String.join(", ", clashes) + " — core wins, these will not be dispatched.");
+                    + String.join(", ", clashes) + " - core wins, these will not be dispatched.");
         }
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/ServerTransferCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/command/ServerTransferCommand.java
@@ -72,7 +72,7 @@ public class ServerTransferCommand extends BaseCommand {
                 && service.getConfig().resolveTarget(targetName) != null) {
             player.sendMessage(ChatColor.YELLOW + "You are about to transfer to '"
                     + ChatColor.WHITE + targetName.toLowerCase() + ChatColor.YELLOW + "'.");
-            player.sendMessage(ChatColor.GRAY + "This is a server change — movement only. "
+            player.sendMessage(ChatColor.GRAY + "This is a server change - movement only. "
                     + "Your items, economy and quest progress do NOT travel with you.");
             player.sendMessage(ChatColor.YELLOW + "Run " + ChatColor.WHITE + "/server transfer "
                     + targetName.toLowerCase() + " confirm" + ChatColor.YELLOW + " to proceed.");

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/BaseRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/BaseRepository.java
@@ -372,7 +372,7 @@ public abstract class BaseRepository<T, ID> {
                     return results;
                 }
             } catch (SQLException e) {
-                logger.error("queryList failed — SQL: " + sql, e);
+                logger.error("queryList failed - SQL: " + sql, e);
                 throw new DatabaseException("Query execution failed", e);
             }
         });

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PlayerRepository.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/repository/PlayerRepository.java
@@ -252,7 +252,7 @@ public class PlayerRepository extends BaseRepository<PlayerDTO, UUID> {
         // and by this point it has already run.
         if (identityIsRemote()) {
             throw new IllegalStateException(
-                "Per-server backfill is not available once player identity is cluster-shared — "
+                "Per-server backfill is not available once player identity is cluster-shared - "
                 + "rvnk_players now holds the authoritative server's activity values, not this "
                 + "server's. Run this before enabling cluster.share-player-identity.");
         }
@@ -324,11 +324,11 @@ public class PlayerRepository extends BaseRepository<PlayerDTO, UUID> {
     public IdentityUnionResult unionIdentityIntoCluster() {
         if (clusterProvider == null) {
             throw new IllegalStateException(
-                "No cluster pool on this server — enable cluster.enabled first.");
+                "No cluster pool on this server - enable cluster.enabled first.");
         }
         if (clusterProvider == localProvider) {
             throw new IllegalStateException(
-                "This server IS the cluster database (authoritative) — its players are already the "
+                "This server IS the cluster database (authoritative) - its players are already the "
                 + "cluster roster. Run this on a member server.");
         }
 
@@ -435,11 +435,11 @@ public class PlayerRepository extends BaseRepository<PlayerDTO, UUID> {
     public int[] unionPreferencesIntoCluster() {
         if (clusterProvider == null) {
             throw new IllegalStateException(
-                "No cluster pool on this server — enable cluster.enabled first.");
+                "No cluster pool on this server - enable cluster.enabled first.");
         }
         if (clusterProvider == localProvider) {
             throw new IllegalStateException(
-                "This server IS the cluster database (authoritative) — its preferences are already "
+                "This server IS the cluster database (authoritative) - its preferences are already "
                 + "the cluster's. Run this on a member server.");
         }
 
@@ -477,7 +477,7 @@ public class PlayerRepository extends BaseRepository<PlayerDTO, UUID> {
                         inserted[t] += write.executeUpdate();
                     }
                 }
-                logger.info("Preference union: " + table + " — " + inserted[t] + " row(s) inserted");
+                logger.info("Preference union: " + table + " - " + inserted[t] + " row(s) inserted");
             }
         } catch (SQLException e) {
             logger.error("Preference union failed", e);
@@ -690,7 +690,7 @@ public class PlayerRepository extends BaseRepository<PlayerDTO, UUID> {
             return rs.getTimestamp(column);
         } catch (SQLException e) {
             if (e.getMessage() != null && e.getMessage().contains("Zero date value prohibited")) {
-                logger.warning("Zero date in column '" + column + "' — treating as null (row will self-heal on next update)");
+                logger.warning("Zero date in column '" + column + "' - treating as null (row will self-heal on next update)");
                 return null;
             }
             throw e;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalProtectionListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalProtectionListener.java
@@ -100,7 +100,7 @@ public class PortalProtectionListener implements Listener {
 
         if (config != null && !player.hasPermission(config.getPermissionDelete())) {
             event.setCancelled(true);
-            player.sendMessage("§cThat block anchors a cross-server portal — you don't have "
+            player.sendMessage("§cThat block anchors a cross-server portal - you don't have "
                     + "permission to remove it.");
             return;
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalSignListener.java
@@ -102,7 +102,7 @@ public class PortalSignListener implements Listener {
                 existingSign.getPersistentDataContainer().remove(portalIdKey);
                 existingSign.update();
                 logger.debug("Cleared stale portal stamp " + existingId + " from sign at "
-                        + event.getBlock().getLocation() + " — portal no longer registered");
+                        + event.getBlock().getLocation() + " - portal no longer registered");
             }
         }
 
@@ -221,7 +221,7 @@ public class PortalSignListener implements Listener {
         // would strand an un-removable sign in the world for anyone without delete permission.
         if (portalService.getPortalById(portalId).isEmpty()) {
             logger.debug("Sign at " + block.getLocation() + " carried stale portal stamp " + portalId
-                    + " — allowing break, portal is not registered");
+                    + " - allowing break, portal is not registered");
             return;
         }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PortalStepListener.java
@@ -404,7 +404,7 @@ public class PortalStepListener implements Listener {
             // No safe exit computed — keep grace so they don't instantly re-transfer while standing in
             // the portal; onPlayerMove clears it when they step out.
             logger.debug("Portal arrival: no safe exit for " + player.getName()
-                    + " at portal " + portal.getPortalId() + " — holding arrival grace");
+                    + " at portal " + portal.getPortalId() + " - holding arrival grace");
         });
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PresenceListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/event/PresenceListener.java
@@ -92,7 +92,7 @@ public class PresenceListener implements Listener {
                     switch (target) {
                         case SIDEBAR -> player.sendMessage(ChatColor.GREEN + "Network roster: sidebar.");
                         case TAB -> player.sendMessage(ChatColor.GREEN
-                                + "Network roster moved to the tab list — hold Tab to see it.");
+                                + "Network roster moved to the tab list - hold Tab to see it.");
                         case OFF -> player.sendMessage(ChatColor.GRAY
                                 + "Network roster hidden. Use /list sidebar or /list tab.");
                     }
@@ -177,7 +177,7 @@ public class PresenceListener implements Listener {
         List<PresenceService.ServerGroup> groups = service.getMergedRoster();
         int total = service.totalCount();
         sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "Network"
-                + ChatColor.GRAY + " — " + ChatColor.WHITE + total + ChatColor.GRAY + " online across servers");
+                + ChatColor.GRAY + " - " + ChatColor.WHITE + total + ChatColor.GRAY + " online across servers");
         for (PresenceService.ServerGroup g : groups) {
             ChatColor tag = g.isLocal() ? ChatColor.GREEN : ChatColor.AQUA;
             String names = g.getPlayers().stream()

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/ApiServerInitializer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/ApiServerInitializer.java
@@ -119,9 +119,9 @@ public class ApiServerInitializer {
             WebhookConfig webhookConfig = configLoader.getWebhookConfig();
             if (webhookConfig.isEnabled()) {
                 webhookConfig.validate(logger);
-                logger.info("Webhook notifier enabled — server-id: " + webhookConfig.getServerId() + ", URL: " + webhookConfig.getUrl());
+                logger.info("Webhook notifier enabled - server-id: " + webhookConfig.getServerId() + ", URL: " + webhookConfig.getUrl());
             } else {
-                logger.debug("Webhook notifier registered (disabled — no-op mode)");
+                logger.debug("Webhook notifier registered (disabled - no-op mode)");
             }
             registry.registerService(WebhookNotifier.class, new WebhookNotifier(webhookConfig, logger));
 
@@ -131,10 +131,10 @@ public class ApiServerInitializer {
             ChatRelayConfig chatRelayConfig = configLoader.getChatRelayConfig();
             if (chatRelayConfig.isEnabled()) {
                 chatRelayConfig.validate(logger);
-                logger.info("Chat relay enabled — server-id: " + chatRelayConfig.getServerId()
+                logger.info("Chat relay enabled - server-id: " + chatRelayConfig.getServerId()
                         + ", peers: " + chatRelayConfig.getPeers().size());
             } else {
-                logger.debug("Chat relay service registered (disabled — no-op mode)");
+                logger.debug("Chat relay service registered (disabled - no-op mode)");
             }
             ChatRelayEgress chatRelayEgress = new ChatRelayEgress(chatRelayConfig, logger);
             registry.registerService(ChatRelayService.class,

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/CoreServiceFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/init/CoreServiceFactory.java
@@ -111,7 +111,7 @@ public class CoreServiceFactory {
     private ConnectionProvider identityProvider() {
         if (clusterConnectionProvider != null
                 && ConfigLoader.getInstance(plugin).isPlayerIdentityShared()) {
-            logger.info("Player identity is cluster-shared — " + clusterConnectionProvider.describeTarget());
+            logger.info("Player identity is cluster-shared - " + clusterConnectionProvider.describeTarget());
             return clusterConnectionProvider;
         }
         return connectionProvider;
@@ -145,19 +145,19 @@ public class CoreServiceFactory {
             try {
                 int[] moved = registry.getService(PlayerService.class).unionPreferencesIntoCluster();
                 if (moved[0] + moved[1] + moved[2] > 0) {
-                    logger.info("Carried local preferences into the cluster before cut-over — "
+                    logger.info("Carried local preferences into the cluster before cut-over - "
                             + moved[0] + " pref, " + moved[1] + " type, " + moved[2] + " channel row(s)");
                 }
             } catch (Exception e) {
                 // Serve preferences locally rather than cut over to a cluster that may be missing
                 // this server's rows. A visibly unchanged setup beats silently resetting everyone.
-                logger.error("Preference union failed — keeping preferences LOCAL for this boot; "
+                logger.error("Preference union failed - keeping preferences LOCAL for this boot; "
                         + "no settings were lost", e);
                 return connectionProvider;
             }
         }
 
-        logger.info("Player preferences are cluster-shared — "
+        logger.info("Player preferences are cluster-shared - "
                 + clusterConnectionProvider.describeTarget());
         return clusterConnectionProvider;
     }
@@ -189,7 +189,7 @@ public class CoreServiceFactory {
         // is the normal single-server case rather than an error.
         if (clusterConnectionProvider != null) {
             registry.registerService(ClusterConnectionProvider.class, clusterConnectionProvider);
-            logger.debug("  + ClusterConnectionProvider registered — "
+            logger.debug("  + ClusterConnectionProvider registered - "
                     + clusterConnectionProvider.describeTarget()
                     + " (" + (System.currentTimeMillis() - startTime) + "ms)");
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatRelayService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatRelayService.java
@@ -107,7 +107,7 @@ public class ChatRelayService {
     public void registerChatConsumer(Consumer<ChatMessageDTO> consumer) {
         this.externalConsumer = consumer;
         logger.info("Chat relay consumer " + (consumer != null ? "registered" : "cleared")
-            + " — " + (consumer != null ? "external chatroom owns routing/rendering"
+            + " - " + (consumer != null ? "external chatroom owns routing/rendering"
                                         : "built-in !-trigger relay active"));
     }
 
@@ -128,7 +128,7 @@ public class ChatRelayService {
     public void registerRoomInjector(Consumer<ChatMessageDTO> injector) {
         this.roomInjector = injector;
         logger.info("Chat room injector " + (injector != null ? "registered" : "cleared")
-            + " — " + (injector != null ? "bot room posts render via the chatroom"
+            + " - " + (injector != null ? "bot room posts render via the chatroom"
                                         : "bot room posts fall back to bot-format"));
     }
 
@@ -203,7 +203,7 @@ public class ChatRelayService {
         // Apply chat-relay.buffer.size on reload, not only at boot — a config key that is parsed and
         // never consumed is a recurring defect in this codebase (#1590, #1598, #1558, #1605).
         buffer.resize(newConfig.getBufferSize());
-        logger.info("ChatRelayService config refreshed — server-id=" + config.getServerId()
+        logger.info("ChatRelayService config refreshed - server-id=" + config.getServerId()
             + ", peers=" + config.getPeers().size() + ", insecure-tls=" + config.isInsecureTls()
             + ", buffer=" + buffer.capacity());
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/portal/PortalService.java
@@ -225,9 +225,9 @@ public class PortalService {
         boolean persisted = repository.create(portal);
         if (!persisted) {
             logger.warning("Portal " + portal.getPortalId()
-                    + " added to in-memory index but failed to persist — will resync on reload");
+                    + " added to in-memory index but failed to persist - will resync on reload");
             return new PortalResult(Status.PERSIST_FAILED,
-                    "Portal created in memory but could not be saved — check the database.", portal);
+                    "Portal created in memory but could not be saved - check the database.", portal);
         }
 
         logger.info("Portal created at " + key + " -> '" + targetServer + "' by " + ownerUuid);
@@ -285,9 +285,9 @@ public class PortalService {
         boolean persisted = repository.create(portal);
         if (!persisted) {
             logger.warning("Framed portal " + portal.getPortalId()
-                    + " added to in-memory index but failed to persist — will resync on reload");
+                    + " added to in-memory index but failed to persist - will resync on reload");
             return new PortalResult(Status.PERSIST_FAILED,
-                    "Portal lit in memory but could not be saved — check the database.", portal);
+                    "Portal lit in memory but could not be saved - check the database.", portal);
         }
 
         logger.info("Framed portal created (" + interior.size() + " blocks) in " + world
@@ -346,7 +346,7 @@ public class PortalService {
         boolean persisted = repository.deleteById(portalId);
         if (!persisted) {
             logger.warning("Portal " + portalId
-                    + " removed from in-memory index but DB delete did not confirm — will resync on reload");
+                    + " removed from in-memory index but DB delete did not confirm - will resync on reload");
         } else {
             logger.info("Portal deleted (id " + portalId + ")");
         }
@@ -368,7 +368,7 @@ public class PortalService {
     private void clearRegistrationSign(PortalDTO portal, String portalId) {
         World world = Bukkit.getWorld(portal.getWorld());
         if (world == null || !world.isChunkLoaded(portal.getX() >> 4, portal.getZ() >> 4)) {
-            logger.debug("Portal " + portalId + " sign not cleared — world or chunk not loaded");
+            logger.debug("Portal " + portalId + " sign not cleared - world or chunk not loaded");
             return;
         }
         Block anchor = world.getBlockAt(portal.getX(), portal.getY(), portal.getZ());
@@ -397,7 +397,7 @@ public class PortalService {
         boolean persisted = repository.deleteByLocation(world, x, y, z);
         if (!persisted) {
             logger.warning("Portal at " + key
-                    + " removed from in-memory index but DB delete did not confirm — will resync on reload");
+                    + " removed from in-memory index but DB delete did not confirm - will resync on reload");
         } else {
             logger.info("Portal deleted at " + key);
         }
@@ -564,7 +564,7 @@ public class PortalService {
                 .findSignOnAnchor(anchor, PortalSignWriter.portalIdKey(plugin), null);
         if (signBlock.isEmpty()) {
             return new PortalResult(Status.NOT_FOUND,
-                    "No sign is mounted on this portal's anchor block — place one, then repair again", portal);
+                    "No sign is mounted on this portal's anchor block - place one, then repair again", portal);
         }
 
         String[] lines = PortalSignWriter.buildDisplayLines(
@@ -604,7 +604,7 @@ public class PortalService {
     public void refreshConfig(PortalConfig newConfig) {
         if (newConfig == null) return;
         this.config = newConfig;
-        logger.info("PortalService config refreshed — trigger=" + config.getTriggerBlock()
+        logger.info("PortalService config refreshed - trigger=" + config.getTriggerBlock()
             + ", header=" + config.getSignHeader());
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/presence/PresenceScoreboard.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/presence/PresenceScoreboard.java
@@ -345,7 +345,7 @@ public class PresenceScoreboard {
                 numberStyleLogged = true;
                 logger.warning("Presence sidebar: could not hide score numbers ("
                         + t.getClass().getSimpleName() + ": " + t.getMessage()
-                        + ") — they will render in red");
+                        + ") - they will render in red");
             }
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/presence/PresenceService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/presence/PresenceService.java
@@ -74,7 +74,7 @@ public class PresenceService {
     public void refreshConfig(ChatRelayConfig newConfig) {
         this.config = newConfig;
         this.egress = new PresenceEgress(newConfig, logger);
-        logger.info("PresenceService config refreshed — peers=" + newConfig.getPeers().size()
+        logger.info("PresenceService config refreshed - peers=" + newConfig.getPeers().size()
                 + ", enabled=" + newConfig.isEnabled());
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequestService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/teleport/TpaRequestService.java
@@ -255,7 +255,7 @@ public class TpaRequestService {
             current.getBlockZ() != start.getBlockZ()) {
 
             cancelWarmup(uuid);
-            player.sendMessage("§c✖ Teleport cancelled — you moved!");
+            player.sendMessage("§c✖ Teleport cancelled - you moved!");
             return true;
         }
         return false;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/transfer/TransferService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/transfer/TransferService.java
@@ -162,12 +162,12 @@ public class TransferService {
             transferring.remove(transferId);
             logger.error("Transfer failed for " + player.getName() + " -> " + targetName, e);
             lastTransfer.remove(player.getUniqueId());
-            return new TransferResult(Status.DISABLED, "Transfer failed — see server log.");
+            return new TransferResult(Status.DISABLED, "Transfer failed - see server log.");
         }
 
         return new TransferResult(Status.SUCCESS,
                 "Transferring you to '" + targetName.toLowerCase()
-                        + "' (movement only — your items do not travel).");
+                        + "' (movement only - your items do not travel).");
     }
 
     /** @return the backing transfer configuration. */
@@ -184,6 +184,6 @@ public class TransferService {
     public void refreshConfig(TransferConfig newConfig) {
         if (newConfig == null) return;
         this.config = newConfig;
-        logger.info("TransferService config refreshed — targets: " + config.getTargetNames());
+        logger.info("TransferService config refreshed - targets: " + config.getTargetNames());
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/BaseCommand.java
@@ -278,7 +278,7 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
             sender.sendMessage(line);
         }
         if (anyExamples) {
-            sender.sendMessage(ChatColor.AQUA + "*" + ChatColor.GRAY + " has worked examples — "
+            sender.sendMessage(ChatColor.AQUA + "*" + ChatColor.GRAY + " has worked examples - "
                     + ChatColor.WHITE + "/" + getName() + " help <subcommand>");
         }
     }
@@ -307,7 +307,7 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
         sender.sendMessage(ChatColor.WHITE + subCommand.getDescription());
         sender.sendMessage(ChatColor.YELLOW + "Usage: " + ChatColor.WHITE + subCommand.getUsage());
         if (subCommand.isPlayerOnly()) {
-            sender.sendMessage(ChatColor.GRAY + "Players only — not available from console.");
+            sender.sendMessage(ChatColor.GRAY + "Players only - not available from console.");
         }
         if (subCommand.getPermission() != null) {
             sender.sendMessage(ChatColor.GRAY + "Permission: " + subCommand.getPermission());
@@ -316,7 +316,7 @@ public abstract class BaseCommand implements RVNKCommand, CommandExecutor, TabCo
         List<String> examples = subCommand.getExamples();
         if (examples.isEmpty()) {
             sender.sendMessage(ChatColor.GRAY
-                    + "No further examples — the usage line above is the whole grammar.");
+                    + "No further examples - the usage line above is the whole grammar.");
             return;
         }
         sender.sendMessage(ChatColor.YELLOW + "Examples:");

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/CommandManager.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/CommandManager.java
@@ -129,7 +129,7 @@ public class CommandManager {
                 AuthTokenStore authTokenStore = registry.getService(AuthTokenStore.class);
                 registerCommand(new LinkCommand(plugin, authTokenStore));
             } else {
-                logger.info("AuthTokenStore not available — /link command not registered (API server may be disabled)");
+                logger.info("AuthTokenStore not available - /link command not registered (API server may be disabled)");
             }
         } catch (Exception e) {
             logger.warning("Failed to register /link command: " + e.getMessage());

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/CycleSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/CycleSubCommand.java
@@ -35,7 +35,7 @@ public class CycleSubCommand extends BaseSubCommand {
             }
             
             sender.sendMessage("§c✖ Cycle commands reload not available. Use /rvnktools reload instead.");
-            logger.info("Cycle reload attempted by " + sender.getName() + " — redirected to /rvnktools reload");
+            logger.info("Cycle reload attempted by " + sender.getName() + " - redirected to /rvnktools reload");
             return true;
         }
         

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/DebugSubCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/DebugSubCommand.java
@@ -76,7 +76,7 @@ public class DebugSubCommand extends BaseSubCommand {
 
     private boolean executeSetup(CommandSender sender) {
         if (Bukkit.getPluginManager().getPlugin("LuckPerms") == null) {
-            sender.sendMessage("§c✖ LuckPerms is not installed — cannot apply permission defaults.");
+            sender.sendMessage("§c✖ LuckPerms is not installed - cannot apply permission defaults.");
             sender.sendMessage("§7Install LuckPerms and run this command again.");
             return true;
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/PingCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/PingCommand.java
@@ -93,7 +93,7 @@ public class PingCommand extends BaseCommand {
             }
             logger.warning("Server.getTPS() returned an unusable value: " + result);
         } catch (NoSuchMethodException e) {
-            logger.debug("Server.getTPS() not available — falling back to the NMS recentTps field");
+            logger.debug("Server.getTPS() not available - falling back to the NMS recentTps field");
         } catch (Exception e) {
             logger.warning("Server.getTPS() failed: " + e.getMessage());
         }

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/command/manager/commands/RVNKCoreCommand.java
@@ -84,7 +84,7 @@ public class RVNKCoreCommand extends BaseCommand {
         java.util.Map<String, java.util.List<String>> m = new java.util.LinkedHashMap<>();
         m.put("debug", java.util.List.of(
                 "/rvnkcore debug",
-                "  full system diagnostics — also what a bare /rvnkcore runs"));
+                "  full system diagnostics - also what a bare /rvnkcore runs"));
         m.put("services", java.util.List.of(
                 "/rvnkcore services",
                 "  every interface registered in the ServiceRegistry, and by which plugin",
@@ -92,7 +92,7 @@ public class RVNKCoreCommand extends BaseCommand {
         m.put("db", java.util.List.of(
                 "/rvnkcore db",
                 "  connectivity plus row totals; alias: database",
-                "RVNKCore's MySQL is cross-host — a hang here usually means a missing",
+                "RVNKCore's MySQL is cross-host - a hang here usually means a missing",
                 "socketTimeout in connectionParameters, not a dead server."));
         m.put("version", java.util.List.of(
                 "/rvnkcore version",
@@ -101,7 +101,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 "/rvnkcore reload",
                 "  re-reads config only",
                 "Adding a key to a shipped config.yml does NOT reach a server that already",
-                "has the file — saveResource writes only when the file is absent."));
+                "has the file - saveResource writes only when the file is absent."));
         m.put("plugins", java.util.List.of(
                 "/rvnkcore plugins",
                 "  which ecosystem plugins are present and what they registered"));
@@ -124,7 +124,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 "/rvnkcore mojang verify Shad0melt",
                 "  accepts a username or a UUID",
                 "/rvnkcore mojang stats",
-                "  cache and rate-limit counters — the lookup is rate limited"));
+                "  cache and rate-limit counters - the lookup is rate limited"));
         m.put("migrate", java.util.List.of(
                 "/rvnkcore migrate playerstate",
                 "/rvnkcore migrate playeridentity",
@@ -390,7 +390,7 @@ public class RVNKCoreCommand extends BaseCommand {
             sender.sendMessage(ChatFormat.colorize(
                     "&c✖ Usage: /rvnkcore netban <add|remove|check> <player>"));
             sender.sendMessage(ChatFormat.colorize(
-                    "&7   Network-wide ban flag. Separate from Minecraft's per-server /ban —"));
+                    "&7   Network-wide ban flag. Separate from Minecraft's per-server /ban -"));
             sender.sendMessage(ChatFormat.colorize(
                     "&7   /pardon does NOT clear this, use 'netban remove'."));
             return;
@@ -417,7 +417,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 boolean target = action.equals("add");
                 if (dto.isBanned() == target) {
                     sender.sendMessage(ChatFormat.colorize("&7   " + dto.getCurrentName()
-                            + " is already " + (target ? "banned" : "not banned") + " — no change"));
+                            + " is already " + (target ? "banned" : "not banned") + " - no change"));
                     return;
                 }
 
@@ -428,7 +428,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 sender.sendMessage(ChatFormat.colorize(
                         "&7   Applies on every server in the cluster. Minecraft's own per-server"));
                 sender.sendMessage(ChatFormat.colorize(
-                        "&7   ban list is unaffected — use /ban and /pardon for that separately."));
+                        "&7   ban list is unaffected - use /ban and /pardon for that separately."));
             } catch (Exception e) {
                 sender.sendMessage(ChatFormat.colorize("&c✖ netban failed: " + e.getMessage()));
             }
@@ -449,10 +449,10 @@ public class RVNKCoreCommand extends BaseCommand {
                 org.fourz.rvnkcore.api.service.PlayerService svc =
                         rvnkCore.getService(org.fourz.rvnkcore.api.service.PlayerService.class);
                 int[] r = svc.unionPreferencesIntoCluster();
-                sender.sendMessage(ChatFormat.colorize("&a✓ Union complete — &e" + r[0]
+                sender.sendMessage(ChatFormat.colorize("&a✓ Union complete - &e" + r[0]
                         + " &fpref, &e" + r[1] + " &ftype, &e" + r[2] + " &fchannel row(s) inserted"));
                 sender.sendMessage(ChatFormat.colorize(
-                        "&7   Rows the cluster already had were left as-is — a preference set on two"));
+                        "&7   Rows the cluster already had were left as-is - a preference set on two"));
                 sender.sendMessage(ChatFormat.colorize(
                         "&7   servers has no objectively correct winner, so none was picked."));
                 sender.sendMessage(ChatFormat.colorize(
@@ -510,9 +510,9 @@ public class RVNKCoreCommand extends BaseCommand {
             sender.sendMessage(ChatFormat.colorize(
                     "&c✖ Usage: /rvnkcore migrate <playerstate|playeridentity|playerprefs>"));
             sender.sendMessage(ChatFormat.colorize(
-                    "&7   playerstate    — copy per-server activity into rvnk_player_server_state"));
+                    "&7   playerstate    - copy per-server activity into rvnk_player_server_state"));
             sender.sendMessage(ChatFormat.colorize(
-                    "&7   playeridentity — union this server's players into the cluster roster"));
+                    "&7   playeridentity - union this server's players into the cluster roster"));
             sender.sendMessage(ChatFormat.colorize(
                     "&7   Both are idempotent and safe with players online."));
             return;
@@ -524,7 +524,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 org.fourz.rvnkcore.api.service.PlayerService svc =
                         rvnkCore.getService(org.fourz.rvnkcore.api.service.PlayerService.class);
                 int inserted = svc.backfillServerState();
-                sender.sendMessage(ChatFormat.colorize("&a✓ Backfill complete — &e" + inserted
+                sender.sendMessage(ChatFormat.colorize("&a✓ Backfill complete - &e" + inserted
                         + " &frow(s) inserted"));
                 sender.sendMessage(ChatFormat.colorize(
                         "&7   Existing rows were left untouched (they are newer than the legacy columns)."));
@@ -552,7 +552,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 for (String note : r.notes) {
                     sender.sendMessage(ChatFormat.colorize("&7   " + note));
                 }
-                sender.sendMessage(ChatFormat.colorize("&a✓ Union complete — examined &e" + r.examined
+                sender.sendMessage(ChatFormat.colorize("&a✓ Union complete - examined &e" + r.examined
                         + "&f, inserted &e" + r.inserted
                         + "&f, first_join corrected &e" + r.firstJoinCorrected));
                 sender.sendMessage(ChatFormat.colorize(
@@ -617,7 +617,7 @@ public class RVNKCoreCommand extends BaseCommand {
         sender.sendMessage(ChatFormat.colorize("&c▶ &6Cluster-Shared Database"));
         sender.sendMessage(ChatFormat.colorize("&7   • &f Role: &b"
                 + (cluster.isAuthoritative() ? "authoritative" : "member")
-                + " &7— " + cluster.describeTarget()));
+                + " &7- " + cluster.describeTarget()));
 
         long startMs = System.currentTimeMillis();
         try (java.sql.Connection conn = cluster.getConnection()) {
@@ -635,7 +635,7 @@ public class RVNKCoreCommand extends BaseCommand {
             sender.sendMessage(ChatFormat.colorize("&a✓ Result: Cluster reachable ("
                     + (System.currentTimeMillis() - startMs) + "ms)"));
         } catch (Exception e) {
-            sender.sendMessage(ChatFormat.colorize("&c✖ Result: Cluster unreachable — " + e.getMessage()));
+            sender.sendMessage(ChatFormat.colorize("&c✖ Result: Cluster unreachable - " + e.getMessage()));
             sender.sendMessage(ChatFormat.colorize("&7   Local database is unaffected."));
         }
     }
@@ -743,7 +743,7 @@ public class RVNKCoreCommand extends BaseCommand {
                 // Neutral, not a red failure. Several absences are deliberate — RVNKWorlds is never
                 // installed on production by design, and not every tier runs every plugin — so a red
                 // cross here reported healthy servers as broken.
-                sender.sendMessage(ChatFormat.colorize("&7   • &8– &7" + name + " &8(not installed)"));
+                sender.sendMessage(ChatFormat.colorize("&7   • &8- &7" + name + " &8(not installed)"));
                 notLoaded++;
             }
         }
@@ -779,7 +779,7 @@ public class RVNKCoreCommand extends BaseCommand {
         sender.sendMessage(ChatFormat.colorize("&c▶ &6Resource Pack"));
 
         if (url == null || url.isBlank()) {
-            sender.sendMessage(ChatFormat.colorize("&7   • &8– none configured"));
+            sender.sendMessage(ChatFormat.colorize("&7   • &8- none configured"));
             return;
         }
 
@@ -810,7 +810,7 @@ public class RVNKCoreCommand extends BaseCommand {
             String shortHash = hash.length() > 8 ? hash.substring(0, 8) : hash;
             sender.sendMessage(ChatFormat.colorize("&8     sha1 " + shortHash));
         } else {
-            sender.sendMessage(ChatFormat.colorize("&8     &eno sha1 — clients re-download every join"));
+            sender.sendMessage(ChatFormat.colorize("&8     &eno sha1 - clients re-download every join"));
         }
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnktools/link/LinkCommand.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnktools/link/LinkCommand.java
@@ -53,7 +53,7 @@ public class LinkCommand extends BaseCommand {
         } else {
             this.callbackUrl = configured;
         }
-        logger.info("Link command initialized — callback URL: " + this.callbackUrl);
+        logger.info("Link command initialized - callback URL: " + this.callbackUrl);
     }
 
     @Override
@@ -252,7 +252,7 @@ public class LinkCommand extends BaseCommand {
         String url = callbackUrl + "?token=" + token;
 
         String issuerName = (sender instanceof Player p) ? p.getName() : "console";
-        logger.info("Invite issued — invitee=" + resolvedName + " targetUuid=" + uuid
+        logger.info("Invite issued - invitee=" + resolvedName + " targetUuid=" + uuid
                 + " ttlMinutes=" + ttlMinutes + " issuer=" + issuerName);
 
         sender.sendMessage(ChatFormat.colorize(


### PR DESCRIPTION
🍎 ICARUS: Typographic punctuation in console strings normalized to ASCII.

Em and en dashes become hyphens, smart quotes become straight quotes, the ellipsis becomes three
dots. Applied by `scripts/minecraft/normalize_console_punctuation.py`, which rewrites only inside
Java string literals.

## Deliberately untouched

- **`§` colour codes** — functional, not decorative. All 626 across the six plugins are unchanged.
- **Decorative glyphs** — box drawing, check marks, arrows, warning signs. Minecraft's own font
  renders these correctly in game, which is where players read them.
- **Comments** — prose in a comment never reaches a player or an operator.

## Player-facing impact

None. A hyphen and an em dash both render correctly in the Minecraft font; this is a
punctuation-style change, not a behaviour change.

Pom version bumped so the running server can identify this code.
