### PR TITLE
feat(rvnkcore): lore locations, coordinate probes, quests REST, health pluginVersion, chat newest-N fix

### DIFF
--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.83-alpha</version>
+    <version>1.5.84-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.81-alpha</version>
+    <version>1.5.82-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.80-alpha</version>
+    <version>1.5.81-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.85-alpha</version>
+    <version>1.5.86-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.79-alpha</version>
+    <version>1.5.80-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.82-alpha</version>
+    <version>1.5.83-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/pom.xml
+++ b/toolkitplugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.fourz</groupId>
     <artifactId>rvnkcore</artifactId>
-    <version>1.5.84-alpha</version>
+    <version>1.5.85-alpha</version>
 
     <name>RVNKCore</name>
     <description>Core unified library for Ravenkraft Minecraft plugins - provides ServiceRegistry, database abstraction, REST API, and shared services</description>

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/HealthController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/HealthController.java
@@ -56,6 +56,10 @@ public class HealthController extends HttpServlet {
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("status", "healthy");
         data.put("apiVersion", ApiVersion.API_VERSION);
+        // RVNKCore's own version (#2054): "version" below is the SERVER build, and the
+        // fleet drift table needs the plugin number the tiers actually run.
+        org.bukkit.plugin.Plugin core = Bukkit.getPluginManager().getPlugin("RVNKCore");
+        data.put("pluginVersion", core != null ? core.getDescription().getVersion() : null);
         data.put("mcVersion", parseMcVersion(Bukkit.getVersion()));
         data.put("version", Bukkit.getVersion());
         data.put("bukkitVersion", Bukkit.getBukkitVersion());

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/LoreController.java
@@ -93,6 +93,9 @@ public class LoreController extends HttpServlet {
                 future = apiService.getStats();
             } else if (pathInfo.equals("/health")) {
                 future = apiService.getHealthStatus();
+            } else if (pathInfo.equals("/locations")) {
+                // GET /lore/locations (#2053) - nearby with world/x/z/radius, else recent list
+                future = apiService.getLocations(req.getQueryString());
             } else if (pathInfo.equals("/items")) {
                 // GET /lore/items?name=<display name>
                 String name = req.getParameter("name");
@@ -144,6 +147,13 @@ public class LoreController extends HttpServlet {
                 ApiResponse<?> response = apiService.submitEntry(body)
                     .get(30, TimeUnit.SECONDS);
                 sendApiResponse(resp, response);
+            } else if (pathInfo.equals("/locations")) {
+                // POST /lore/locations (#2053) - validated create, replaces raw SQL seeding
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.createLocation(body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+                return;
             } else if (pathInfo.equals("/items")) {
                 // POST /lore/items — mint a single lore item (#1517)
                 String body = ApiUtils.readRequestBody(req);

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/QuestsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/QuestsController.java
@@ -1,0 +1,144 @@
+package org.fourz.rvnkcore.api.controller;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.fourz.rvnkcore.RVNKCore;
+import org.fourz.rvnkcore.api.model.response.ApiResponse;
+import org.fourz.rvnkcore.api.service.IQuestsApiService;
+import org.fourz.rvnkcore.api.util.ApiUtils;
+import org.fourz.rvnkcore.service.registry.ServiceRegistry;
+import org.fourz.rvnkcore.util.log.LogManager;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * REST API controller for RVNKQuests endpoints (#2042).
+ * Routes HTTP requests to {@link IQuestsApiService} provided by the RVNKQuests plugin.
+ *
+ * <p>Quests is not deployed on every tier (it is Event/Dev-only today), so a missing
+ * service is the NORMAL state on some servers, not a fault: all endpoints return a
+ * clean 503 with a message naming the situation — never a stack trace.</p>
+ *
+ * @since 1.5.82
+ */
+public class QuestsController extends HttpServlet {
+
+    private final Gson gson;
+    private final LogManager logger;
+
+    public QuestsController(IQuestsApiService ignored, Gson gson, LogManager logger) {
+        this.gson = gson;
+        this.logger = logger;
+    }
+
+    /**
+     * Lazily resolves the API service from ServiceRegistry.
+     * The service is registered by the RVNKQuests plugin after RVNKCore starts.
+     */
+    private IQuestsApiService getApiService() {
+        RVNKCore core = RVNKCore.getInstance();
+        if (core != null) {
+            ServiceRegistry registry = core.getServiceRegistry();
+            if (registry != null && registry.hasService(IQuestsApiService.class)) {
+                return registry.getService(IQuestsApiService.class);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IQuestsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendServiceUnavailable(resp);
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            CompletableFuture<ApiResponse<?>> future;
+
+            if (pathInfo.equals("/")) {
+                future = apiService.getQuests(ApiUtils.extractQueryParams(req));
+            } else if (pathInfo.matches("^/player/[^/]+$")) {
+                String uuid = pathInfo.substring("/player/".length());
+                future = apiService.getPlayerProgress(uuid);
+            } else if (pathInfo.matches("^/[^/]+$")) {
+                String questId = pathInfo.substring(1);
+                future = apiService.getQuestById(questId);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
+                return;
+            }
+
+            ApiResponse<?> response = future.get(30, TimeUnit.SECONDS);
+            sendApiResponse(resp, response);
+
+        } catch (Exception e) {
+            logger.error("Error handling Quests API request: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        IQuestsApiService apiService = getApiService();
+        if (apiService == null) {
+            sendServiceUnavailable(resp);
+            return;
+        }
+
+        String pathInfo = req.getPathInfo() != null ? req.getPathInfo() : "/";
+
+        try {
+            if (pathInfo.matches("^/[^/]+/assign$")) {
+                // POST /quests/{id}/assign  body: {"playerUuid": "..."}
+                String questId = pathInfo.substring(1, pathInfo.length() - "/assign".length());
+                String body = ApiUtils.readRequestBody(req);
+                ApiResponse<?> response = apiService.assignQuest(questId, body)
+                    .get(30, TimeUnit.SECONDS);
+                sendApiResponse(resp, response);
+            } else {
+                sendError(resp, 404, "NOT_FOUND", "Unknown POST endpoint: " + pathInfo);
+            }
+        } catch (Exception e) {
+            logger.error("Error handling Quests API POST: " + pathInfo, e);
+            sendError(resp, 500, "INTERNAL_ERROR", "An unexpected error occurred.");
+        }
+    }
+
+    @Override
+    protected void doOptions(HttpServletRequest req, HttpServletResponse resp) {
+        resp.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * 503, not 501: Quests is absent by design on some tiers (prod today), and 503
+     * "service unavailable on this server" states that plainly to a cross-tier caller.
+     */
+    private void sendServiceUnavailable(HttpServletResponse resp) {
+        sendError(resp, 503, "SERVICE_UNAVAILABLE",
+            "RVNKQuests is not loaded on this server; the quest API is unavailable here.");
+    }
+
+    private void sendApiResponse(HttpServletResponse resp, ApiResponse<?> response) {
+        int httpStatus = response.success() ? 200
+            : (response.error() != null ? response.error().suggestedHttpStatus() : 400);
+        ApiUtils.sendJson(resp, gson, httpStatus, response);
+    }
+
+    private void sendError(HttpServletResponse resp, int status, String code, String message) {
+        ApiUtils.sendError(resp, gson, status, code, message);
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/controller/RVNKWorldsController.java
@@ -43,6 +43,11 @@ public class RVNKWorldsController extends HttpServlet {
     private static final Pattern HEALTH_PATTERN = Pattern.compile("^/health/?$");
     /** #1923 — dense site survey for agentic tooling. */
     private static final Pattern SURVEY_PATTERN = Pattern.compile("^/survey/?$");
+    /** #2051 — coordinate probes: point/batch, column, heightmap grid, scatter sweep. */
+    private static final Pattern PROBE_PATTERN = Pattern.compile("^/probe/?$");
+    private static final Pattern COLUMN_PATTERN = Pattern.compile("^/column/?$");
+    private static final Pattern HEIGHTMAP_PATTERN = Pattern.compile("^/heightmap/?$");
+    private static final Pattern SCATTER_PATTERN = Pattern.compile("^/scatter/?$");
 
     public RVNKWorldsController(IRVNKWorldsApiService ignored, Gson gson, LogManager logger) {
         this.gson = gson;
@@ -100,6 +105,14 @@ public class RVNKWorldsController extends HttpServlet {
                 // The whole query string is handed through: the survey takes several optional
                 // params and parsing them here would split the contract across two files.
                 future = apiService.surveySite(req.getQueryString());
+            } else if (PROBE_PATTERN.matcher(pathInfo).matches()) {
+                future = apiService.probePoints(req.getQueryString());
+            } else if (COLUMN_PATTERN.matcher(pathInfo).matches()) {
+                future = apiService.columnProfile(req.getQueryString());
+            } else if (HEIGHTMAP_PATTERN.matcher(pathInfo).matches()) {
+                future = apiService.heightmapGrid(req.getQueryString());
+            } else if (SCATTER_PATTERN.matcher(pathInfo).matches()) {
+                future = apiService.scatterProbe(req.getQueryString());
             } else {
                 sendError(resp, 404, "NOT_FOUND", "Endpoint not found: " + pathInfo);
                 return;

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/ClusterBanListener.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/event/ClusterBanListener.java
@@ -81,8 +81,53 @@ public class ClusterBanListener implements Listener {
         } catch (Exception e) {
             // Fail open — see the class javadoc. Logged at WARNING because a persistent failure
             // means bans silently stop being enforced, which should not pass unnoticed.
+            //
+            // "by policy" is deliberate wording (#1995): the previous line read
+            // "allowing login (fail-open)", which scans as an apology for a bug rather than the
+            // documented trade-off it actually is. A reader tailing the console should not have to
+            // open this class to learn whether the fallback was intended.
             logger.warning("Network ban check failed for " + event.getName()
-                    + " - allowing login (fail-open): " + e.getMessage());
+                    + " - allowing login (fail-open by policy; local ban list still applies): "
+                    + describe(e));
         }
+    }
+
+    /**
+     * Describe a throwable in a way that survives a null message (#1995).
+     *
+     * <p>{@code getMessage()} is null for {@link java.util.concurrent.TimeoutException} and for many
+     * NPEs, so the original line rendered as {@code ...(fail-open): null} — it recorded that a
+     * failure happened while recording nothing whatsoever about it. That is worse than useless on a
+     * path that fails open, because the log is the only signal that enforcement stopped.</p>
+     *
+     * <p>The class name alone separates the failure modes that matter here: a
+     * {@code TimeoutException} means the roster lookup exceeded {@value #LOOKUP_TIMEOUT_MS}ms and
+     * points at database latency, while an {@code SQLException} or NPE points at the query or the
+     * connection. The first stack frame says where. Wrappers are unwrapped because
+     * {@code ExecutionException: null} names the wrapper and hides the cause.</p>
+     */
+    private static String describe(Throwable t) {
+        if (t == null) {
+            return "unknown (null throwable)";
+        }
+        Throwable root = t;
+        while ((root instanceof java.util.concurrent.ExecutionException
+                || root instanceof java.util.concurrent.CompletionException)
+                && root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+
+        StringBuilder sb = new StringBuilder(root.getClass().getName());
+        if (root.getMessage() != null) {
+            sb.append(": ").append(root.getMessage());
+        }
+        StackTraceElement[] frames = root.getStackTrace();
+        if (frames.length > 0) {
+            sb.append(" at ").append(frames[0]);
+        }
+        if (root != t) {
+            sb.append(" [wrapped in ").append(t.getClass().getSimpleName()).append(']');
+        }
+        return sb.toString();
     }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthPathPatterns.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/security/AuthPathPatterns.java
@@ -29,6 +29,7 @@ public final class AuthPathPatterns {
             "/bartershops/*",
             "/lore/*",
             "/rvnkworlds/*",
+            "/quests/*",
             "/docs/*"
     );
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/server/jetty/ServletFactory.java
@@ -15,6 +15,7 @@ import org.fourz.rvnkcore.api.controller.HealthController;
 import org.fourz.rvnkcore.api.controller.LoreController;
 import org.fourz.rvnkcore.api.controller.NotificationController;
 import org.fourz.rvnkcore.api.controller.RVNKWorldsController;
+import org.fourz.rvnkcore.api.controller.QuestsController;
 import org.fourz.rvnkcore.api.controller.PlayerController;
 import org.fourz.rvnkcore.api.controller.WebUIAccessController;
 import org.fourz.rvnkcore.api.controller.WhitelistController;
@@ -159,6 +160,7 @@ public class ServletFactory {
         registerBarterShopsController(context);
         registerLoreController(context);
         registerRVNKWorldsController(context);
+        registerQuestsController(context);
     }
 
     /**
@@ -306,6 +308,22 @@ public class ServletFactory {
             logger.debug("RVNKLore API controller registered at /lore/* (service resolved lazily)");
         } catch (Throwable e) {
             logger.warning("RVNKLore API controller not registered: " + e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Registers the Quests controller (#2042). The IQuestsApiService is registered by the
+     * RVNKQuests plugin at startup and resolved lazily; on a tier without RVNKQuests the
+     * controller answers 503, which is the intended state, not a fault.
+     */
+    private void registerQuestsController(ServletContextHandler context) {
+        try {
+            LogManager controllerLogger = LogManager.getInstance(plugin, QuestsController.class);
+            QuestsController controller = new QuestsController(null, gson, controllerLogger);
+            context.addServlet(new ServletHolder(controller), "/quests/*");
+            logger.debug("Quests API controller registered at /quests/* (service resolved lazily)");
+        } catch (Throwable e) {
+            logger.warning("Quests API controller not registered: " + e.getClass().getName() + ": " + e.getMessage());
         }
     }
 

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/ILoreApiService.java
@@ -98,4 +98,26 @@ public interface ILoreApiService {
             ApiResponse.error("NOT_SUPPORTED",
                 "Lore location lookup requires RVNKLore 1.0.108 or newer on this server."));
     }
+
+    // ── location surface (#2053) — the validated twin of the raw two-table INSERT ──
+
+    /**
+     * Lore locations over HTTP (GET /lore/locations). With {@code world}, {@code x}, {@code z}
+     * and {@code radius} in the query it answers nearby; otherwise a recent list, optionally
+     * filtered by {@code world} and capped by {@code limit}.
+     */
+    default CompletableFuture<ApiResponse<?>> getLocations(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "Lore location listing requires RVNKLore 1.0.127 or newer on this server."));
+    }
+
+    /**
+     * Create a lore location (POST /lore/locations). Body: {@code {name, description?, type,
+     * world, x, y, z, createdBy?}}. Creates the entry AND mirrors the coordinate row through
+     * the plugin's own validation - the governed replacement for direct SQL inserts.
+     */
+    default CompletableFuture<ApiResponse<?>> createLocation(String requestBody) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "Lore location creation requires RVNKLore 1.0.127 or newer on this server."));
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IQuestsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IQuestsApiService.java
@@ -1,0 +1,41 @@
+package org.fourz.rvnkcore.api.service;
+
+import org.fourz.rvnkcore.api.model.response.ApiResponse;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * API service interface for RVNKQuests REST endpoints (#2042).
+ * Implemented by the RVNKQuests plugin and registered with ServiceRegistry by reflection.
+ * The QuestsController in RVNKCore routes HTTP requests to this service.
+ *
+ * <p>Read surface first: definitions, one definition, player progress. The assign
+ * write verb is a {@code default} method so an older RVNKQuests build against a newer
+ * core degrades to an honest "unavailable" instead of {@code AbstractMethodError} —
+ * the same version-skew guard as {@link ILoreApiService#findNearbyLocations}.</p>
+ *
+ * @since 1.5.82
+ */
+public interface IQuestsApiService {
+
+    /** Quest definitions, paginated ({@code page}/{@code limit}); optional {@code category} filter. */
+    CompletableFuture<ApiResponse<?>> getQuests(Map<String, String> params);
+
+    /** One quest definition with its objectives and rewards. */
+    CompletableFuture<ApiResponse<?>> getQuestById(String questId);
+
+    /** A player's quest progress by UUID. */
+    CompletableFuture<ApiResponse<?>> getPlayerProgress(String playerUuid);
+
+    /**
+     * Assign a quest to a player (POST /quests/{id}/assign, body {"playerUuid": "..."}).
+     * Deliberately a default: the read path ships first (#2042); an implementation
+     * that has not added assign yet loses the verb, not the plugin.
+     */
+    default CompletableFuture<ApiResponse<?>> assignQuest(String questId, String requestBody) {
+        return CompletableFuture.completedFuture(
+            ApiResponse.error("NOT_SUPPORTED",
+                "Quest assignment requires a newer RVNKQuests build on this server."));
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/api/service/IRVNKWorldsApiService.java
@@ -106,4 +106,32 @@ public interface IRVNKWorldsApiService {
         return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
             "This RVNKWorlds build does not support the survey endpoint"));
     }
+
+    // ── coordinate probes (#2051) — point/column/grid siblings of the survey ──────
+    // Defaults, like surveySite: an older RVNKWorlds against a newer core loses the
+    // endpoint, not the plugin. All GET, so they stay under rvnk_api_read.
+
+    /** One block or a grouped list ({@code points=x,y,z;x,y,z;...}); {@code load=true} opt-in. */
+    default CompletableFuture<ApiResponse<?>> probePoints(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support the point probe (needs 1.6.143+)"));
+    }
+
+    /** Ground truth for one (x,z): surface heights, top block, RLE layer stack, liquid depth. */
+    default CompletableFuture<ApiResponse<?>> columnProfile(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support the column profile (needs 1.6.143+)"));
+    }
+
+    /** Surface heights + top materials on a step grid — terrain shape in one call. */
+    default CompletableFuture<ApiResponse<?>> heightmapGrid(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support the heightmap grid (needs 1.6.143+)"));
+    }
+
+    /** Strided lattice sweep across a box ({@code from}/{@code to}/{@code step}) with histogram. */
+    default CompletableFuture<ApiResponse<?>> scatterProbe(String query) {
+        return CompletableFuture.completedFuture(ApiResponse.error("NOT_SUPPORTED",
+            "This RVNKWorlds build does not support the scatter probe (needs 1.6.143+)"));
+    }
 }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/connection/ConnectionOutageLog.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/connection/ConnectionOutageLog.java
@@ -1,0 +1,112 @@
+package org.fourz.rvnkcore.database.connection;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Decides how loudly a connection failure should be logged during a database outage.
+ *
+ * <p>A cross-host database outage is an expected condition, not a surprise: the provider already
+ * signals it to callers by throwing. Logging a full stack trace on every retry therefore adds no
+ * diagnostic value after the first one, and it is an availability risk in its own right — a caller
+ * that retries on a timer turns a multi-hour outage into tens of thousands of log lines. RVNKWorlds'
+ * world sync runs every 60 seconds, so a single unattended outage produced roughly 35 lines a
+ * minute indefinitely (#2017). The same shape as the DEBUG-plus-load incident that queued ~150k
+ * lines and blocked shutdown for ~11 minutes (#1548).</p>
+ *
+ * <p>The policy: the <b>first</b> failure of an outage carries the full trace, because that is the
+ * one that explains the cause. Everything after it is the same cause repeating, so it collapses
+ * into a one-line summary emitted at most once per summary interval. Recovery reports once.</p>
+ *
+ * <p>This class decides only what to <i>log</i>. It never affects control flow — the caller
+ * receives the exception either way.</p>
+ *
+ * <p>Time is injected so the policy is testable without sleeping. Thread-safe.</p>
+ */
+public class ConnectionOutageLog {
+
+    /** What the caller should emit for this failure. */
+    public enum Action {
+        /** First failure of an outage — log the full stack trace so the cause is diagnosable. */
+        FULL_TRACE,
+        /** Outage continuing and the summary interval has elapsed — log one summary line. */
+        SUMMARY,
+        /** Outage continuing, already summarised recently — say nothing above debug. */
+        SUPPRESS
+    }
+
+    private final long summaryIntervalMs;
+
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final AtomicLong outageStartMs = new AtomicLong(0L);
+    private final AtomicLong lastSummaryMs = new AtomicLong(0L);
+
+    public ConnectionOutageLog(long summaryIntervalMs) {
+        this.summaryIntervalMs = summaryIntervalMs;
+    }
+
+    /**
+     * Records a failure and returns what the caller should log.
+     *
+     * @param nowMs current epoch millis
+     */
+    public Action recordFailure(long nowMs) {
+        int failures = consecutiveFailures.incrementAndGet();
+
+        if (failures == 1) {
+            outageStartMs.set(nowMs);
+            lastSummaryMs.set(nowMs);
+            return Action.FULL_TRACE;
+        }
+
+        long lastSummary = lastSummaryMs.get();
+        if (nowMs - lastSummary >= summaryIntervalMs
+                && lastSummaryMs.compareAndSet(lastSummary, nowMs)) {
+            return Action.SUMMARY;
+        }
+        return Action.SUPPRESS;
+    }
+
+    /**
+     * Records a success and clears any outage state.
+     *
+     * <p>Read {@link #outageDurationMs(long)} <b>before</b> calling this — it resets the clock.</p>
+     *
+     * @return the number of consecutive failures this success ended, or 0 if already healthy.
+     *         A non-zero return means the caller should log recovery exactly once.
+     */
+    public int recordSuccess() {
+        int failures = consecutiveFailures.getAndSet(0);
+        if (failures > 0) {
+            outageStartMs.set(0L);
+            lastSummaryMs.set(0L);
+        }
+        return failures;
+    }
+
+    /** Consecutive failures in the current outage, or 0 when healthy. */
+    public int failureCount() {
+        return consecutiveFailures.get();
+    }
+
+    /** How long the current outage has been running, or 0 when healthy. */
+    public long outageDurationMs(long nowMs) {
+        long began = outageStartMs.get();
+        return began > 0 ? nowMs - began : 0L;
+    }
+
+    /**
+     * Renders a millisecond duration as a short operator-facing string.
+     */
+    public static String describeDuration(long millis) {
+        long totalSeconds = millis / 1000L;
+        if (totalSeconds < 60L) {
+            return totalSeconds + "s";
+        }
+        long minutes = totalSeconds / 60L;
+        if (minutes < 60L) {
+            return minutes + "m";
+        }
+        return (minutes / 60L) + "h" + (minutes % 60L) + "m";
+    }
+}

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/connection/MySQLConnectionProvider.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/database/connection/MySQLConnectionProvider.java
@@ -33,6 +33,18 @@ public class MySQLConnectionProvider implements ConnectionProvider {
     private static final long MAX_SAFE_IDLE_TIMEOUT_MS = 120_000L;
     private static final long MAX_SAFE_MAX_LIFETIME_MS = 180_000L;
 
+    // Outage logging (#2017). A database outage is an EXPECTED condition on a cross-host MySQL —
+    // the provider already signals it to callers by throwing, so logging a full stack trace on
+    // every retry adds no diagnostic value and is an availability risk in its own right: a caller
+    // that retries on a timer (RVNKWorlds' world sync runs every 60s) turns a multi-hour outage
+    // into tens of thousands of log lines. That is the same shape as the DEBUG-plus-load incident
+    // that queued ~150k lines and blocked shutdown for ~11 minutes (#1548).
+    // Policy: full trace ONCE when an outage begins, a single-line summary at most every
+    // SUMMARY_INTERVAL_MS while it continues, and one line when it recovers.
+    private static final long OUTAGE_SUMMARY_INTERVAL_MS = 300_000L;
+
+    private final ConnectionOutageLog outageLog = new ConnectionOutageLog(OUTAGE_SUMMARY_INTERVAL_MS);
+
     private HikariDataSource dataSource;
     private final DatabaseConfig config;
     private final LogManager logger;
@@ -71,10 +83,55 @@ public class MySQLConnectionProvider implements ConnectionProvider {
                 }
                 throw new SQLException("Connection validation failed");
             }
+            recordConnectionSuccess();
             return conn;
         } catch (SQLException e) {
-            logger.error("Failed to obtain MySQL connection", e);
+            recordConnectionFailure(e);
             throw new DatabaseException("MySQL connection failed", e);
+        }
+    }
+
+    /**
+     * Notes a successful borrow, and reports recovery if an outage was in progress.
+     */
+    private void recordConnectionSuccess() {
+        // Duration must be read before recordSuccess(), which resets the outage clock.
+        long durationMs = outageLog.outageDurationMs(System.currentTimeMillis());
+        int failures = outageLog.recordSuccess();
+        if (failures > 0) {
+            logger.warning("MySQL connection recovered after " + failures
+                    + " failed attempt(s) over " + ConnectionOutageLog.describeDuration(durationMs));
+        }
+    }
+
+    /**
+     * Logs a connection failure without flooding the console on a sustained outage.
+     *
+     * <p>The first failure of an outage carries the full stack trace, because that is the one
+     * that explains the cause. Everything after it is the same cause repeating, so it is
+     * collapsed into a periodic one-line summary. Callers still receive the exception either
+     * way — this governs logging only, never control flow.</p>
+     */
+    private void recordConnectionFailure(SQLException e) {
+        long now = System.currentTimeMillis();
+        ConnectionOutageLog.Action action = outageLog.recordFailure(now);
+
+        switch (action) {
+            case FULL_TRACE:
+                logger.error("Failed to obtain MySQL connection", e);
+                break;
+            case SUMMARY:
+                logger.warning("MySQL still unavailable - " + outageLog.failureCount()
+                        + " failed attempt(s) over "
+                        + ConnectionOutageLog.describeDuration(outageLog.outageDurationMs(now))
+                        + "; last error: " + e.getMessage()
+                        + " (repeat stack traces suppressed)");
+                break;
+            case SUPPRESS:
+            default:
+                logger.debug("MySQL connection failure " + outageLog.failureCount()
+                        + ": " + e.getMessage());
+                break;
         }
     }
     
@@ -87,7 +144,10 @@ public class MySQLConnectionProvider implements ConnectionProvider {
         try (Connection testConn = dataSource.getConnection()) {
             return testConn.isValid(5);
         } catch (SQLException e) {
-            logger.warning("MySQL connection validation failed: " + e.getMessage());
+            // Debug, not warning: isValid() is polled by health checks and adapters, so during an
+            // outage this fires on every poll. recordConnectionFailure() owns the operator-facing
+            // narrative for an outage; this line would only duplicate it once per poll (#2017).
+            logger.debug("MySQL connection validation failed: " + e.getMessage());
             return false;
         }
     }

--- a/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBuffer.java
+++ b/toolkitplugin/src/main/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBuffer.java
@@ -154,11 +154,27 @@ public final class ChatMessageBuffer {
         long effectiveSince = stale ? 0L : sinceSeq;
 
         List<Entry> out = new ArrayList<>();
-        for (Entry e : entries) {
-            if (e.getSeq() <= effectiveSince) continue;
-            if (!matches(e.getDto(), room, world)) continue;
-            out.add(e);
-            if (out.size() >= cap) break;
+        if (effectiveSince == 0L) {
+            // No usable cursor (first read, or a stale resync): "recent" means the NEWEST
+            // cap matches (#2048). The old head-first scan handed a small limit the OLDEST
+            // slice, so a cursorless poller read a frozen window while every response
+            // looked healthy. Cursored reads below are untouched - forward pagination
+            // after since is correct for them.
+            Iterator<Entry> it = entries.descendingIterator();
+            while (it.hasNext()) {
+                Entry e = it.next();
+                if (!matches(e.getDto(), room, world)) continue;
+                out.add(e);
+                if (out.size() >= cap) break;
+            }
+            Collections.reverse(out); // chronological order on the wire, as before
+        } else {
+            for (Entry e : entries) {
+                if (e.getSeq() <= effectiveSince) continue;
+                if (!matches(e.getDto(), room, world)) continue;
+                out.add(e);
+                if (out.size() >= cap) break;
+            }
         }
 
         // Cursor advances to the last message actually returned. When a filter matched nothing, hold

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/event/ClusterBanListenerDescribeTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/api/event/ClusterBanListenerDescribeTest.java
@@ -1,0 +1,113 @@
+package org.fourz.rvnkcore.api.event;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Diagnosability of the fail-open ban check (#1995).
+ *
+ * <p>The reported line was:</p>
+ *
+ * <pre>Network ban check failed for wizardofire - allowing login (fail-open): null</pre>
+ *
+ * <p>{@code TimeoutException} carries a null message, as do many NPEs, so {@code getMessage()}
+ * produced the literal string "null" - a log line recording that enforcement had stopped while
+ * recording nothing at all about why. On a path that fails open, that log line is the only signal
+ * anyone gets, which is what made a one-line WARN worth fixing.</p>
+ *
+ * <p>These tests pin the property that no input yields a description of "null" or "".</p>
+ */
+class ClusterBanListenerDescribeTest {
+
+    /** describe() is private; it is a formatting detail, not API worth widening for a test. */
+    private static String describe(Throwable t) throws Exception {
+        Method m = ClusterBanListener.class.getDeclaredMethod("describe", Throwable.class);
+        m.setAccessible(true);
+        return (String) m.invoke(null, t);
+    }
+
+    @Test
+    @DisplayName("a null-message throwable still names its type - the #1995 regression")
+    void nullMessageStillIdentifiesTheFailure() throws Exception {
+        String out = describe(new TimeoutException());
+
+        assertAll(
+                () -> assertFalse(out.equals("null"), "must never render as the bare string null"),
+                () -> assertFalse(out.isBlank(), "must never render as empty"),
+                () -> assertTrue(out.contains("TimeoutException"),
+                        "must name the failure mode, got: " + out));
+    }
+
+    @Test
+    @DisplayName("a message is kept when there is one")
+    void messageIsPreserved() throws Exception {
+        String out = describe(new SQLException("Connection is closed"));
+        assertTrue(out.contains("SQLException"), out);
+        assertTrue(out.contains("Connection is closed"), out);
+    }
+
+    @Test
+    @DisplayName("wrappers are unwrapped - ExecutionException: null hides the real cause")
+    void wrappersAreUnwrapped() throws Exception {
+        String out = describe(new ExecutionException(new SQLException("pool exhausted")));
+
+        assertTrue(out.startsWith("java.sql.SQLException"),
+                "the cause should lead, not the wrapper, got: " + out);
+        assertTrue(out.contains("pool exhausted"), out);
+        assertTrue(out.contains("[wrapped in ExecutionException]"), out);
+    }
+
+    @Test
+    @DisplayName("CompletionException is unwrapped too")
+    void completionExceptionIsUnwrapped() throws Exception {
+        String out = describe(new CompletionException(new IllegalStateException("no service")));
+        assertTrue(out.startsWith("java.lang.IllegalStateException"), out);
+        assertTrue(out.contains("no service"), out);
+    }
+
+    @Test
+    @DisplayName("a wrapper with no cause does not loop or blow up")
+    void wrapperWithoutCauseIsSafe() throws Exception {
+        String out = describe(new ExecutionException("wrapper only", null));
+        assertTrue(out.contains("ExecutionException"), out);
+        assertFalse(out.contains("[wrapped in"), "nothing was unwrapped, so say nothing: " + out);
+    }
+
+    @Test
+    @DisplayName("a self-referencing cause terminates")
+    void selfReferencingCauseTerminates() throws Exception {
+        // Defensive: a throwable whose cause is itself would spin the unwrap loop forever.
+        ExecutionException loop = new ExecutionException("self", null) {
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+        String out = describe(loop);
+        assertTrue(out.contains("self") || out.contains("ExecutionException"), out);
+    }
+
+    @Test
+    @DisplayName("null throwable is handled")
+    void nullThrowable() throws Exception {
+        assertEquals("unknown (null throwable)", describe(null));
+    }
+
+    @Test
+    @DisplayName("a stack frame is included so the failure has a location")
+    void includesAFrame() throws Exception {
+        String out = describe(new TimeoutException());
+        assertTrue(out.contains(" at "), "expected a stack frame, got: " + out);
+    }
+}

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/database/ConnectionOutageLogTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/database/ConnectionOutageLogTest.java
@@ -1,0 +1,94 @@
+package org.fourz.rvnkcore.database;
+
+import org.fourz.rvnkcore.database.connection.ConnectionOutageLog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the outage log policy from #2017.
+ *
+ * <p>The behaviour under test is the one that made a two-minute database blip fill the console:
+ * a full stack trace on every retry. These tests assert that a sustained outage produces exactly
+ * one trace and then goes quiet, because nothing else in the codebase covered this path.</p>
+ */
+class ConnectionOutageLogTest {
+
+    private static final long SUMMARY_INTERVAL_MS = 300_000L;
+
+    @Test
+    @DisplayName("first failure of an outage asks for the full stack trace")
+    void firstFailureLogsFullTrace() {
+        ConnectionOutageLog log = new ConnectionOutageLog(SUMMARY_INTERVAL_MS);
+        assertEquals(ConnectionOutageLog.Action.FULL_TRACE, log.recordFailure(0L));
+    }
+
+    @Test
+    @DisplayName("a 60s retry loop produces ONE trace, not one per attempt")
+    void sustainedOutageDoesNotRepeatTheTrace() {
+        ConnectionOutageLog log = new ConnectionOutageLog(SUMMARY_INTERVAL_MS);
+
+        int traces = 0;
+        int summaries = 0;
+        // One hour of RVNKWorlds' 60-second world sync against a dead database.
+        for (int minute = 0; minute < 60; minute++) {
+            ConnectionOutageLog.Action action = log.recordFailure(minute * 60_000L);
+            if (action == ConnectionOutageLog.Action.FULL_TRACE) traces++;
+            if (action == ConnectionOutageLog.Action.SUMMARY) summaries++;
+        }
+
+        assertEquals(1, traces, "an hour-long outage must yield exactly one stack trace");
+        // Summaries at 5,10,...,55 minutes — bounded and readable, not 60 traces.
+        assertEquals(11, summaries, "summaries should be paced at the summary interval");
+        assertEquals(60, log.failureCount());
+    }
+
+    @Test
+    @DisplayName("summary is withheld until the interval has actually elapsed")
+    void summaryIsPacedByTheInterval() {
+        ConnectionOutageLog log = new ConnectionOutageLog(SUMMARY_INTERVAL_MS);
+        log.recordFailure(0L);
+        assertEquals(ConnectionOutageLog.Action.SUPPRESS, log.recordFailure(60_000L));
+        assertEquals(ConnectionOutageLog.Action.SUPPRESS, log.recordFailure(299_999L));
+        assertEquals(ConnectionOutageLog.Action.SUMMARY, log.recordFailure(300_000L));
+        assertEquals(ConnectionOutageLog.Action.SUPPRESS, log.recordFailure(300_001L));
+    }
+
+    @Test
+    @DisplayName("recovery reports once, and the next outage starts clean")
+    void recoveryResetsTheCycle() {
+        ConnectionOutageLog log = new ConnectionOutageLog(SUMMARY_INTERVAL_MS);
+        log.recordFailure(0L);
+        log.recordFailure(60_000L);
+
+        assertEquals(2, log.recordSuccess(), "recovery reports how many failures it ended");
+        assertEquals(0, log.recordSuccess(), "a healthy success must not log recovery again");
+        assertEquals(0, log.failureCount());
+
+        // A later outage is a new outage, so it earns its own trace.
+        assertEquals(ConnectionOutageLog.Action.FULL_TRACE, log.recordFailure(600_000L));
+    }
+
+    @Test
+    @DisplayName("outage duration is measured from the first failure and cleared on recovery")
+    void outageDurationTracksTheOutage() {
+        ConnectionOutageLog log = new ConnectionOutageLog(SUMMARY_INTERVAL_MS);
+        log.recordFailure(10_000L);
+        assertEquals(50_000L, log.outageDurationMs(60_000L));
+
+        log.recordSuccess();
+        assertEquals(0L, log.outageDurationMs(60_000L), "healthy provider reports no outage");
+    }
+
+    @Test
+    @DisplayName("durations render in operator-readable units")
+    void durationsRenderReadably() {
+        assertEquals("0s", ConnectionOutageLog.describeDuration(0L));
+        assertEquals("45s", ConnectionOutageLog.describeDuration(45_000L));
+        assertEquals("2m", ConnectionOutageLog.describeDuration(125_000L));
+        assertEquals("1h5m", ConnectionOutageLog.describeDuration(3_900_000L));
+        assertTrue(ConnectionOutageLog.describeDuration(59_999L).endsWith("s"));
+    }
+}

--- a/toolkitplugin/src/test/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBufferTest.java
+++ b/toolkitplugin/src/test/java/org/fourz/rvnkcore/service/chatrelay/ChatMessageBufferTest.java
@@ -1,0 +1,100 @@
+package org.fourz.rvnkcore.service.chatrelay;
+
+import org.fourz.rvnkcore.api.model.ChatMessageDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The tail buffer's read semantics (#2048).
+ *
+ * <p>The defect: a cursorless {@code since()} scanned head-first and returned the OLDEST
+ * {@code limit} entries, so a caller asking for "recent" chat read a frozen window at the
+ * start of the buffer forever, with every response well-formed. A cursorless read must
+ * serve the NEWEST slice; a cursored read must keep forward pagination after {@code since}.</p>
+ */
+class ChatMessageBufferTest {
+
+    private static ChatMessageDTO dto(String message) {
+        ChatMessageDTO d = new ChatMessageDTO(
+                java.util.UUID.randomUUID().toString(), "test", "global",
+                null, "tester", message, System.currentTimeMillis());
+        d.setRoom("GLOBAL");
+        return d;
+    }
+
+    private static ChatMessageBuffer filled(int n) {
+        ChatMessageBuffer buffer = new ChatMessageBuffer(500);
+        for (int i = 1; i <= n; i++) {
+            buffer.record(dto("m" + i));
+        }
+        return buffer;
+    }
+
+    private static List<Long> seqs(ChatMessageBuffer.Page page) {
+        return page.getMessages().stream().map(ChatMessageBuffer.Entry::getSeq)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void cursorlessSmallLimitReturnsTheNewestSlice() {
+        // The reproduced defect: 44 in the buffer, limit=5 returned seqs 1..5.
+        ChatMessageBuffer buffer = filled(44);
+        ChatMessageBuffer.Page page = buffer.since(null, 0, 5, null, null);
+        assertEquals(List.of(40L, 41L, 42L, 43L, 44L), seqs(page), "must be the newest 5, oldest-first");
+        assertEquals(44L, page.getSeq(), "cursor lands on the head so the next poll continues");
+    }
+
+    @Test
+    void cursorlessFullLimitStillReturnsEverything() {
+        ChatMessageBuffer buffer = filled(44);
+        ChatMessageBuffer.Page page = buffer.since(null, 0, 200, null, null);
+        assertEquals(44, page.getMessages().size());
+        assertEquals(1L, seqs(page).get(0));
+        assertEquals(44L, page.getSeq());
+    }
+
+    @Test
+    void cursoredReadKeepsForwardPagination() {
+        // Control: a cursored reader pages FORWARD - newest-first here would create gaps.
+        ChatMessageBuffer buffer = filled(44);
+        String boot = buffer.getBootId();
+        ChatMessageBuffer.Page page = buffer.since(boot, 10, 5, null, null);
+        assertEquals(List.of(11L, 12L, 13L, 14L, 15L), seqs(page), "oldest 5 AFTER the cursor");
+        assertFalse(page.isStale());
+        assertEquals(15L, page.getSeq());
+    }
+
+    @Test
+    void cursoredTailReturnsOnlyWhatIsNew() {
+        ChatMessageBuffer buffer = filled(44);
+        String boot = buffer.getBootId();
+        ChatMessageBuffer.Page page = buffer.since(boot, 40, 200, null, null);
+        assertEquals(List.of(41L, 42L, 43L, 44L), seqs(page));
+    }
+
+    @Test
+    void staleResyncServesTheNewestSlice() {
+        // A boot mismatch resyncs from the head, not from the fossil end of the buffer.
+        ChatMessageBuffer buffer = filled(44);
+        ChatMessageBuffer.Page page = buffer.since("not-this-boot", 30, 5, null, null);
+        assertTrue(page.isStale());
+        assertEquals(List.of(40L, 41L, 42L, 43L, 44L), seqs(page));
+        assertEquals(44L, page.getSeq());
+    }
+
+    @Test
+    void roomFilterAppliesBeforeTheNewestCut() {
+        ChatMessageBuffer buffer = new ChatMessageBuffer(500);
+        for (int i = 1; i <= 10; i++) {
+            ChatMessageDTO d = dto("m" + i);
+            d.setRoom(i % 2 == 0 ? "SERVER" : "GLOBAL");
+            buffer.record(d);
+        }
+        ChatMessageBuffer.Page page = buffer.since(null, 0, 3, "SERVER", null);
+        assertEquals(List.of(6L, 8L, 10L), seqs(page), "newest 3 MATCHING entries, not newest 3 overall");
+    }
+}


### PR DESCRIPTION
RVNKCore work since the last `dev` merge. **Merge this first** — RVNKLore, RVNKWorlds and RVNKQuests all build on routes added here.

## What lands

| Commit | Change |
|---|---|
| `07b3775` | `/v1/health` carries `pluginVersion` (#2054) — the fleet drift table needs it, because health `version` is the **server build**, not the plugin |
| `8d4c1b3` | `/lore/locations` routes + skew-guarded service defaults (#2053) |
| `4ceb7fa` | probe / column / heightmap / scatter routes for RVNKWorlds coordinate probes (#2051) |
| `a5ad90d` | cursorless `/v1/chat/recent` serves the **newest** limit, not the oldest (#2048) |
| `5414435` | `IQuestsApiService` + `QuestsController`, `/quests` under the auth blanket (#2042) |
| `d480f2a` | collapse repeated MySQL outage stack traces to one trace plus a paced summary (#2017) |
| `6fdf958` | make the fail-open ban check say why it failed (#1995) |

17 files changed, 830 insertions, 9 deletions.

## Two things worth a reviewer's eye

- **#2048 is a correctness fix, not a tidy-up.** `GET /v1/chat/recent?limit=N` returned the *oldest* N. Every existing consumer went through `tail.py`, which always sends a cursor and so landed on the right tail from the second poll — that is why nothing caught it for so long. A stateless caller polling with a bare limit read a frozen window forever while getting a healthy 200. Cursored reads keep forward pagination deliberately.
- **`/quests/*` needed its `AuthPathPatterns` entry.** A new controller mount ships **unauthenticated** without one. It was caught in review of #2042; check any future mount the same way.

## Verification

Deployed to RVNK Dev and live-verified through the whole #2037–#2056 chain. Dev ran `1.5.86-alpha` at the last read; a spawn probe against Dev returned `/v1/health` 200 with `pluginVersion: 1.5.86-alpha` and `/lore/types` 200 with 15 types.

Event runs `1.5.84-alpha` and production `1.5.78-alpha`. Neither tier is touched by this merge — staging is a separate, operator-gated step.
